### PR TITLE
fix(across-v2): make error banner work with new logic

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Switch, Route, useLocation } from "react-router-dom";
 import { Send, Pool, About, Transactions } from "views";
 import { Header, SuperHeader } from "components";
 import { useConnection } from "state/hooks";
-import { CHAINS, switchChain, WrongNetworkError } from "utils";
-import { useError, usePrevious } from "hooks";
+import { WrongNetworkError } from "utils";
+import { useError } from "hooks";
 import styled from "@emotion/styled";
 import Sidebar from "components/Sidebar";
 
@@ -14,16 +14,6 @@ function useRoutes() {
   const location = useLocation();
   const { error, removeError } = useError();
 
-  // reset wrong chain error on route change
-  const prevLocation = usePrevious(location);
-  useEffect(() => {
-    if (
-      error instanceof WrongNetworkError &&
-      prevLocation.pathname !== location.pathname
-    ) {
-      removeError();
-    }
-  }, [removeError, error, location.pathname, prevLocation.pathname]);
   return {
     openSidebar,
     setOpenSidebar,
@@ -35,25 +25,14 @@ function useRoutes() {
 }
 // Need this component for useLocation hook
 const Routes: React.FC = () => {
-  const { openSidebar, setOpenSidebar, error, removeError, provider } =
-    useRoutes();
-  const showError = provider && error instanceof WrongNetworkError;
+  const { openSidebar, setOpenSidebar, error, removeError } = useRoutes();
+
   return (
     <>
       {error && !(error instanceof WrongNetworkError) && (
         <SuperHeader>
           <div>{error.message}</div>
           <RemoveErrorSpan onClick={() => removeError()}>X</RemoveErrorSpan>
-        </SuperHeader>
-      )}
-      {showError && (
-        <SuperHeader>
-          <div>
-            You are on an incorrect network. Please{" "}
-            <button onClick={() => switchChain(provider, error.correctChainId)}>
-              switch to {CHAINS[error.correctChainId].name}
-            </button>
-          </div>
         </SuperHeader>
       )}
       <Header openSidebar={openSidebar} setOpenSidebar={setOpenSidebar} />

--- a/src/components/SendForm/SendForm.tsx
+++ b/src/components/SendForm/SendForm.tsx
@@ -6,22 +6,38 @@ import {
   AddressSelection,
   SendAction,
 } from "components";
-import { SendFormProvider } from "hooks";
+import { useSendForm } from "hooks";
 import type { Deposit } from "views/Confirmation";
+import SuperHeader from "components/SuperHeader";
+import { useConnection } from "state/hooks";
+import { CHAINS, switchChain } from "utils";
 
 type Props = {
   onDepositConfirmed: (deposit: Deposit) => void;
 };
 const SendForm: React.FC<Props> = ({ onDepositConfirmed }) => {
+  const { fromChain } = useSendForm();
+  const { chainId, provider } = useConnection();
+  const showError = !!chainId && provider && chainId !== fromChain;
   return (
-    <SendFormProvider>
+    <>
+      {showError && (
+        <SuperHeader>
+          <div>
+            You are on an incorrect network. Please{" "}
+            <button onClick={() => switchChain(provider, fromChain)}>
+              switch to {CHAINS[fromChain].name}
+            </button>
+          </div>
+        </SuperHeader>
+      )}
       <Layout>
         <ChainSelection />
         <CoinSelection />
         <AddressSelection />
         <SendAction onDeposit={onDepositConfirmed} />
       </Layout>
-    </SendFormProvider>
+    </>
   );
 };
 

--- a/src/components/SendForm/SendForm.tsx
+++ b/src/components/SendForm/SendForm.tsx
@@ -5,23 +5,21 @@ import {
   CoinSelection,
   AddressSelection,
   SendAction,
+  SuperHeader,
 } from "components";
-import { useSendForm } from "hooks";
 import type { Deposit } from "views/Confirmation";
-import SuperHeader from "components/SuperHeader";
-import { useConnection } from "state/hooks";
 import { CHAINS, switchChain } from "utils";
+import useSendFormComponent from "./useSendFormComponent";
 
 type Props = {
   onDepositConfirmed: (deposit: Deposit) => void;
 };
 const SendForm: React.FC<Props> = ({ onDepositConfirmed }) => {
-  const { fromChain } = useSendForm();
-  const { chainId, provider } = useConnection();
-  const showError = !!chainId && provider && chainId !== fromChain;
+  const { fromChain, provider, wrongNetwork } = useSendFormComponent();
+
   return (
     <>
-      {showError && (
+      {wrongNetwork && provider && (
         <SuperHeader>
           <div>
             You are on an incorrect network. Please{" "}

--- a/src/components/SendForm/useSendFormComponent.ts
+++ b/src/components/SendForm/useSendFormComponent.ts
@@ -1,0 +1,14 @@
+import { useSendForm } from "hooks";
+import { useConnection } from "state/hooks";
+
+export default function useSendFormComponent() {
+	const { fromChain } = useSendForm();
+	const { provider, chainId } = useConnection();
+	const wrongNetwork = !!chainId && provider && chainId !== fromChain;
+	return {
+		wrongNetwork,
+		fromChain,
+		provider,
+		chainId
+	}
+}

--- a/src/components/SuperHeader/SuperHeader.tsx
+++ b/src/components/SuperHeader/SuperHeader.tsx
@@ -1,6 +1,8 @@
 import styled from "@emotion/styled";
+import { useLayoutEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 
-const SuperHeader = styled.div`
+const Wrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -26,4 +28,30 @@ const SuperHeader = styled.div`
   }
 `;
 
+/**
+ * React component that renders its children in a super header on top of the page.
+ */
+const SuperHeader: React.FC = ({ children }) => {
+  const container = useRef(document.getElementById("super-header"));
+  // We create the "super-header" element and insert it into the DOM, if it does not exist already
+  useLayoutEffect(() => {
+    if (!container.current) {
+      // we know this to always be defined.
+      const root = document.getElementById("root") as HTMLDivElement;
+      const div = document.createElement("div");
+      div.id = "super-header";
+      root.insertBefore(div, root.firstChild);
+      container.current = div;
+    }
+    return () => {
+      if (container.current) {
+        container.current.remove();
+      }
+    };
+  }, []);
+  if (!container.current) {
+    return null;
+  }
+  return createPortal(<Wrapper>{children}</Wrapper>, container.current);
+};
 export default SuperHeader;

--- a/src/components/SuperHeader/SuperHeader.tsx
+++ b/src/components/SuperHeader/SuperHeader.tsx
@@ -43,11 +43,6 @@ const SuperHeader: React.FC = ({ children }) => {
       root.insertBefore(div, root.firstChild);
       container.current = div;
     }
-    return () => {
-      if (container.current) {
-        container.current.remove();
-      }
-    };
   }, []);
   if (!container.current) {
     return null;

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -17,6 +17,7 @@ import {
   getRoute,
   MAX_APPROVAL_AMOUNT,
   WrongNetworkError,
+  ChainId,
 } from "utils";
 
 
@@ -66,6 +67,7 @@ export function useBridge() {
     hasToSwitchChain,
     balance,
     fees,
+    fromChain
   });
 
   const hasToApprove = !!allowance && amount.gt(allowance);
@@ -123,6 +125,7 @@ type ComputeStatusArgs = {
   formStatus: FormStatus;
   hasToSwitchChain: boolean;
   balance: ethers.BigNumber | undefined;
+  fromChain: ChainId;
   fees:
   | {
     isLiquidityInsufficient: boolean;
@@ -143,12 +146,13 @@ function computeStatus({
   balance,
   fees,
   token,
+  fromChain
 }: ComputeStatusArgs): { status: SendStatus; error?: SendError } {
   if (formStatus !== FormStatus.VALID) {
     return { status: SendStatus.IDLE };
   }
   if (hasToSwitchChain) {
-    return { status: SendStatus.ERROR, error: new WrongNetworkError() };
+    return { status: SendStatus.ERROR, error: new WrongNetworkError(fromChain) };
   }
   if (balance) {
     const adjustedBalance =

--- a/src/hooks/useError.tsx
+++ b/src/hooks/useError.tsx
@@ -24,6 +24,7 @@ function useErrorManager() {
 }
 
 const ErrorContext = createContext<ErrorContextValue | undefined>(undefined);
+ErrorContext.displayName = "ErrorContext";
 export const ErrorProvider: React.FC = ({ children }) => {
   const value = useErrorManager();
   return (

--- a/src/hooks/useSendForm.tsx
+++ b/src/hooks/useSendForm.tsx
@@ -15,8 +15,9 @@ import {
   ParsingError,
   InsufficientBalanceError,
   ETH_ADDRESS,
+  WrongNetworkError,
 } from "utils";
-import { usePrevious } from "hooks";
+import { useError, usePrevious } from "hooks";
 import { useConnection } from "state/hooks";
 
 export enum FormStatus {
@@ -258,6 +259,14 @@ type SendFormManagerContext = FormState & {
 function useSendFormManager(): SendFormManagerContext {
   const [state, dispatch] = useReducer(formReducer, initialFormState);
   const { account: connectedAccount, chainId } = useConnection();
+  const { addError } = useError();
+
+  // Dispatch a global error if the user is connected but not to the fromChain
+  useEffect(() => {
+    if (chainId && chainId !== state.fromChain) {
+      addError(new WrongNetworkError(state.fromChain));
+    }
+  });
 
   // Keep the connected account and the toAddress in sync. If a user switches account, the toAddress should be updated to this new account.
   useEffect(() => {

--- a/src/hooks/useSendForm.tsx
+++ b/src/hooks/useSendForm.tsx
@@ -15,9 +15,8 @@ import {
   ParsingError,
   InsufficientBalanceError,
   ETH_ADDRESS,
-  WrongNetworkError,
 } from "utils";
-import { useError, usePrevious } from "hooks";
+import { usePrevious } from "hooks";
 import { useConnection } from "state/hooks";
 
 export enum FormStatus {
@@ -259,18 +258,6 @@ type SendFormManagerContext = FormState & {
 function useSendFormManager(): SendFormManagerContext {
   const [state, dispatch] = useReducer(formReducer, initialFormState);
   const { account: connectedAccount, chainId } = useConnection();
-  const { addError, removeError, error: globalError } = useError();
-
-  // Dispatch a global error if the user is connected but not to the fromChain
-  useEffect(() => {
-    const isWrongNetworkError = globalError instanceof WrongNetworkError;
-    if (!isWrongNetworkError && chainId && chainId !== state.fromChain) {
-      addError(new WrongNetworkError(state.fromChain));
-    }
-    if (isWrongNetworkError && chainId && chainId === state.fromChain) {
-      removeError();
-    }
-  }, [chainId, globalError, state.fromChain, addError, removeError]);
 
   // Keep the connected account and the toAddress in sync. If a user switches account, the toAddress should be updated to this new account.
   useEffect(() => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -619,7 +619,7 @@ export function getChainName(chainId: ChainId): string {
   }
 }
 
-export const DEFAULT_FROM_CHAIN_ID = ChainId.ARBITRUM;
+export const DEFAULT_FROM_CHAIN_ID = ChainId.OPTIMISM;
 export const DEFAULT_TO_CHAIN_ID = ChainId.MAINNET;
 
 /* Onboard config */

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -11,10 +11,12 @@ export class UnsupportedChainIdError extends Error {
 }
 
 export class WrongNetworkError extends Error {
-  public constructor() {
+  correctChainId: ChainId;
+  public constructor(correctChainId: ChainId) {
     super();
     this.name = this.constructor.name;
     this.message = `Connected to the wrong network.`;
+    this.correctChainId = correctChainId;
   }
 }
 

--- a/src/views/Pool.tsx
+++ b/src/views/Pool.tsx
@@ -55,13 +55,17 @@ const Pool: FC = () => {
   const wrongNetwork =
     provider &&
     (error instanceof UnsupportedChainIdError || chainId !== ChainId.MAINNET);
-  const { addError } = useError();
-  // if the user is connected but not to mainnet, dispatch a global error
+  const { addError, removeError, error: globalError } = useError();
+  // // if the user is connected but not to mainnet, dispatch a global error
   useEffect(() => {
-    if (chainId && chainId !== ChainId.MAINNET) {
+    const isWrongNetworkError = globalError instanceof WrongNetworkError;
+    if (!isWrongNetworkError && chainId && chainId !== ChainId.MAINNET) {
       addError(new WrongNetworkError(ChainId.MAINNET));
     }
-  });
+    if (isWrongNetworkError && chainId === ChainId.MAINNET) {
+      removeError();
+    }
+  }, [chainId, addError, removeError, globalError]);
   // Update pool info when token changes
   useEffect(() => {
     setLoadingPoolState(true);

--- a/src/views/Pool.tsx
+++ b/src/views/Pool.tsx
@@ -12,7 +12,8 @@ import {
   COLORS,
   QUERIES,
   max,
-  WrongNetworkError,
+  switchChain,
+  CHAINS,
 } from "utils";
 import { useAppSelector, useConnection, useBalance } from "state/hooks";
 import get from "lodash/get";
@@ -21,7 +22,7 @@ import styled from "@emotion/styled";
 import BouncingDotsLoader from "components/BouncingDotsLoader";
 
 import { BounceType } from "components/BouncingDotsLoader/BouncingDotsLoader";
-import { useError } from "hooks";
+import { SuperHeader } from "components";
 
 export type ShowSuccess = "deposit" | "withdraw";
 
@@ -55,17 +56,7 @@ const Pool: FC = () => {
   const wrongNetwork =
     provider &&
     (error instanceof UnsupportedChainIdError || chainId !== ChainId.MAINNET);
-  const { addError, removeError, error: globalError } = useError();
-  // // if the user is connected but not to mainnet, dispatch a global error
-  useEffect(() => {
-    const isWrongNetworkError = globalError instanceof WrongNetworkError;
-    if (!isWrongNetworkError && chainId && chainId !== ChainId.MAINNET) {
-      addError(new WrongNetworkError(ChainId.MAINNET));
-    }
-    if (isWrongNetworkError && chainId === ChainId.MAINNET) {
-      removeError();
-    }
-  }, [chainId, addError, removeError, globalError]);
+
   // Update pool info when token changes
   useEffect(() => {
     setLoadingPoolState(true);
@@ -92,6 +83,16 @@ const Pool: FC = () => {
 
   return (
     <Layout>
+      {wrongNetwork && (
+        <SuperHeader>
+          <div>
+            You are on an incorrect network. Please{" "}
+            <button onClick={() => switchChain(provider, ChainId.MAINNET)}>
+              switch to {CHAINS[ChainId.MAINNET].name}
+            </button>
+          </div>
+        </SuperHeader>
+      )}
       {!showSuccess ? (
         <Wrapper>
           <PoolSelection

--- a/src/views/Pool.tsx
+++ b/src/views/Pool.tsx
@@ -5,7 +5,6 @@ import PoolSelection from "components/PoolSelection";
 import PoolForm from "components/PoolForm";
 import DepositSuccess from "components/PoolForm/DepositSuccess";
 import {
-  DEFAULT_TO_CHAIN_ID,
   TOKENS_LIST,
   ChainId,
   Token,
@@ -13,6 +12,7 @@ import {
   COLORS,
   QUERIES,
   max,
+  WrongNetworkError,
 } from "utils";
 import { useAppSelector, useConnection, useBalance } from "state/hooks";
 import get from "lodash/get";
@@ -21,6 +21,7 @@ import styled from "@emotion/styled";
 import BouncingDotsLoader from "components/BouncingDotsLoader";
 
 import { BounceType } from "components/BouncingDotsLoader/BouncingDotsLoader";
+import { useError } from "hooks";
 
 export type ShowSuccess = "deposit" | "withdraw";
 
@@ -53,9 +54,14 @@ const Pool: FC = () => {
 
   const wrongNetwork =
     provider &&
-    (error instanceof UnsupportedChainIdError ||
-      chainId !== DEFAULT_TO_CHAIN_ID);
-
+    (error instanceof UnsupportedChainIdError || chainId !== ChainId.MAINNET);
+  const { addError } = useError();
+  // if the user is connected but not to mainnet, dispatch a global error
+  useEffect(() => {
+    if (chainId && chainId !== ChainId.MAINNET) {
+      addError(new WrongNetworkError(ChainId.MAINNET));
+    }
+  });
   // Update pool info when token changes
   useEffect(() => {
     setLoadingPoolState(true);

--- a/src/views/Send/Send.tsx
+++ b/src/views/Send/Send.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import SendForm from "components/SendForm";
 import Confirmation from "../Confirmation";
 import useSendTab from "./useSendTab";
+import { SendFormProvider } from "hooks";
 
 const SendTab: React.FC = () => {
   const {
@@ -16,7 +17,11 @@ const SendTab: React.FC = () => {
       <Confirmation deposit={deposit} onClose={onCloseConfirmationScreen} />
     );
   }
-  return <SendForm onDepositConfirmed={onDepositConfirmed} />;
+  return (
+    <SendFormProvider>
+      <SendForm onDepositConfirmed={onDepositConfirmed} />
+    </SendFormProvider>
+  );
 };
 
 export default SendTab;


### PR DESCRIPTION
This PR refactors the error banner at the top of the app to work with the new state management logic.
Note: 
I tried a different implementation with React Portals where you could render the `SuperHeader` banner inside the `Send` view (in the React tree) but render on top of the header in the real html tree. 
I think it had a nicer API:
```javascript
function SomeSendComp() {
   const {fromChain} = useSendForm();
   return (
     <>
      <SuperHeader>{logic to show errors}</SuperHeader>
      <OtherComp>...
      )
```

But it was really slow, so I abandoned that approach for this one, were we sync the banner with `useEffects` , I don't love this solution, so open to ideas on how to improve on this

Signed-off-by: Gamaranto <francesco@umaproject.org>