### PR TITLE
fix: add balance to coin selection

### DIFF
--- a/src/components/AddressSelection/AddressSelection.styles.ts
+++ b/src/components/AddressSelection/AddressSelection.styles.ts
@@ -193,6 +193,5 @@ export const InputGroup = styled.div`
 `;
 
 export const ToggleChainName = styled.div`
-  width: 85px;
   text-align: left;
 `;

--- a/src/components/CoinSelection/CoinSelection.styles.ts
+++ b/src/components/CoinSelection/CoinSelection.styles.ts
@@ -161,4 +161,4 @@ export const BalanceLabel = styled.span`
   line-height: ${16 / 16}rem;
   font-weight: 400;
   text-align: right;
-`
+`;

--- a/src/components/CoinSelection/CoinSelection.styles.ts
+++ b/src/components/CoinSelection/CoinSelection.styles.ts
@@ -151,3 +151,13 @@ export const Input = styled.input`
 export const ErrorBox = motion(styled(UnstyledErrorBox)`
   margin-top: 10px;
 `);
+
+export const BalanceLabel = styled.span`
+  display: block;
+  margin: 10px 0 0;
+  height: ${16 / 16}rem;
+  font-size: ${12 / 16}rem;
+  line-height: ${16 / 16}rem;
+  font-weight: 400;
+  text-align: right;
+`

--- a/src/components/CoinSelection/CoinSelection.styles.ts
+++ b/src/components/CoinSelection/CoinSelection.styles.ts
@@ -154,7 +154,7 @@ export const ErrorBox = motion(styled(UnstyledErrorBox)`
 
 export const BalanceLabel = styled.span`
   display: block;
-  margin: 10px 0 0;
+  margin: 10px 25px 0 0;
   height: ${16 / 16}rem;
   font-size: ${12 / 16}rem;
   line-height: ${16 / 16}rem;

--- a/src/components/CoinSelection/CoinSelection.styles.ts
+++ b/src/components/CoinSelection/CoinSelection.styles.ts
@@ -150,6 +150,7 @@ export const Input = styled.input`
 
 export const ErrorBox = motion(styled(UnstyledErrorBox)`
   margin-top: 10px;
+  display: none;
 `);
 
 export const BalanceLabel = styled.span`

--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -97,8 +97,19 @@ const CoinSelection = () => {
                 ))}
             </Menu>
           </InputGroup>
-          <BalanceLabel>{balance && selectedItem && `Balance ${formatUnits(balance, selectedItem.decimals)} ${selectedItem.symbol}`}</BalanceLabel>
-          <ErrorBox animate={{ opacity: showError ? 1 : 0, display: showError ? "block" : "none" }}>
+          <BalanceLabel>
+            {balance &&
+              selectedItem &&
+              `Balance ${formatUnits(balance, selectedItem.decimals)} ${
+                selectedItem.symbol
+              }`}
+          </BalanceLabel>
+          <ErrorBox
+            animate={{
+              opacity: showError ? 1 : 0,
+              display: showError ? "block" : "none",
+            }}
+          >
             {showError && errorMsg}
           </ErrorBox>
         </Wrapper>

--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -98,7 +98,7 @@ const CoinSelection = () => {
             </Menu>
           </InputGroup>
           <BalanceLabel>{balance && selectedItem && `Balance ${formatUnits(balance, selectedItem.decimals)} ${selectedItem.symbol}`}</BalanceLabel>
-          <ErrorBox animate={{ opacity: showError ? 1 : 0 }}>
+          <ErrorBox animate={{ opacity: showError ? 1 : 0, display: showError ? "block" : "none" }}>
             {showError && errorMsg}
           </ErrorBox>
         </Wrapper>

--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -14,6 +14,7 @@ import {
   MaxButton,
   Input,
   ErrorBox,
+  BalanceLabel,
 } from "./CoinSelection.styles";
 import useCoinSelection from "./useCoinSelection";
 import { AnimatePresence } from "framer-motion";
@@ -35,6 +36,7 @@ const CoinSelection = () => {
     error,
     showError,
     balances,
+    balance,
   } = useCoinSelection();
   return (
     <AnimatePresence>
@@ -95,7 +97,7 @@ const CoinSelection = () => {
                 ))}
             </Menu>
           </InputGroup>
-
+          <BalanceLabel>{balance && selectedItem && `Balance ${formatUnits(balance, selectedItem.decimals)} ${selectedItem.symbol}`}</BalanceLabel>
           <ErrorBox animate={{ opacity: showError ? 1 : 0 }}>
             {showError && errorMsg}
           </ErrorBox>


### PR DESCRIPTION
Story details: https://app.shortcut.com/uma-project/story/3405

1. The main feature added in this PR is showing the balance of the current selected token
<img width="498" alt="Screenshot 2022-04-06 at 13 02 39" src="https://user-images.githubusercontent.com/89395931/161950855-d835e788-8e9c-44d4-be3b-3432a8ddb6e0.png">

But I also fixed some small issues I found:

2. Destination chain name was shown on multiple lines
<img width="500" alt="Screenshot 2022-04-06 at 12 41 12" src="https://user-images.githubusercontent.com/89395931/161951039-8c2226ff-2e9b-4e93-aef0-56b3499658dd.png">

3. Error box was occupying space if the form didn't have any error
<img width="506" alt="Screenshot 2022-04-06 at 13 05 41" src="https://user-images.githubusercontent.com/89395931/161951542-3729b95e-4601-4484-b676-1820aa48bd63.png">
