### PR TITLE
fix: add loading animation on deposit

### DIFF
--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -18,6 +18,7 @@ import {
 import InformationDialog from "components/InformationDialog";
 import useSendAction from "./useSendAction";
 import type { Deposit } from "views/Confirmation";
+import BouncingDotsLoader from "components/BouncingDotsLoader";
 
 type Props = {
   onDeposit: (deposit: Deposit) => void;
@@ -35,6 +36,7 @@ const SendAction: React.FC<Props> = ({ onDeposit }) => {
     isInfoModalOpen,
     toggleInfoModal,
     buttonMsg,
+    txPending,
   } = useSendAction(onDeposit);
   const showFees = amount.gt(0) && !!fees;
   const amountMinusFees = showFees ? receiveAmount(amount, fees) : undefined;
@@ -80,6 +82,7 @@ const SendAction: React.FC<Props> = ({ onDeposit }) => {
         </InfoWrapper>
         <PrimaryButton onClick={handleActionClick} disabled={buttonDisabled}>
           {buttonMsg}
+          {txPending && <BouncingDotsLoader />}
         </PrimaryButton>
       </Wrapper>
       <InformationDialog isOpen={isInfoModalOpen} onClose={toggleInfoModal} />

--- a/src/components/SendAction/useSendAction.ts
+++ b/src/components/SendAction/useSendAction.ts
@@ -67,17 +67,14 @@ export default function useSendAction(
             .catch(console.error);
           // TODO: we should invalidate and refetch any queries of the transaction tab, so when a user switches to it, they see the new transaction immediately.
         }
-
-        setTxPending(false);
         return tx;
       }
-    } catch (error) {
+    } finally {
       setTxPending(false);
-      throw error;
     }
   };
 
-  const buttonDisabled = status !== "ready";
+  const buttonDisabled = status !== "ready" || txPending;
 
   let buttonMsg: string = "Send";
   if (status === "ready") {


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

This PR adds an animation to the deposit button and also disables it while the deposit transaction is in pending state

<img width="396" alt="Screenshot 2022-04-06 at 13 27 29" src="https://user-images.githubusercontent.com/89395931/161955232-acd44e95-40e8-4e08-98d7-67e4e833bb94.png">
