### PR TITLE
fix(across-v2): take timestamp from hubpool

### DIFF
--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -80,16 +80,21 @@ export function useBridge() {
     if (!signer || status !== "ready" || !toAddress || !block || !fees) {
       return;
     }
-    return sendAcrossDeposit(signer, {
-      toAddress,
-      amount,
-      token,
-      fromChain,
-      toChain,
-      relayerFeePct: fees.relayerFee.pct,
-      timestamp: await hubPool.getCurrentTime(),
-      referrer,
-    });
+    try {
+      return sendAcrossDeposit(signer, {
+        toAddress,
+        amount,
+        token,
+        fromChain,
+        toChain,
+        relayerFeePct: fees.relayerFee.pct,
+        timestamp: await hubPool.getCurrentTime(),
+        referrer,
+      });
+    } catch (e) {
+      console.error("Something went wrong when depositing.")
+    }
+
   };
 
   const approve = async () => {

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -19,7 +19,9 @@ import {
   CHAINS,
   sendAcrossDeposit,
   sendAcrossApproval,
+  getHubPool,
 } from "utils";
+
 
 enum SendStatus {
   IDLE = "idle",
@@ -71,6 +73,7 @@ export function useBridge() {
   });
 
   const hasToApprove = !!allowance && amount.gt(allowance);
+  const hubPool = getHubPool(fromChain);
 
   const send = async () => {
     // NOTE: the `toAddress` check is redundant, as status won't be "ready" if `toAddress` is not set, but it's here to make TS happy. The same applies for `block` and `fees`.
@@ -84,7 +87,7 @@ export function useBridge() {
       fromChain,
       toChain,
       relayerFeePct: fees.relayerFee.pct,
-      timestamp: block.timestamp,
+      timestamp: await hubPool.getCurrentTime(),
       referrer,
     });
   };
@@ -125,11 +128,11 @@ type ComputeStatusArgs = {
   balance: ethers.BigNumber | undefined;
   fromChain: ChainId;
   fees:
-    | {
-        isLiquidityInsufficient: boolean;
-        isAmountTooLow: boolean;
-      }
-    | undefined;
+  | {
+    isLiquidityInsufficient: boolean;
+    isAmountTooLow: boolean;
+  }
+  | undefined;
 };
 /**
  * Computes the current send tab status.

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -47,7 +47,7 @@ function getHubPoolChainId(sendingChain: ChainId): ChainId {
 export function getHubPool(fromChain: ChainId, signer?: ethers.Signer): HubPool {
   const hubPoolChainId = getHubPoolChainId(fromChain);
   const maybeAddress = HUBPOOL_ADDRESSES[hubPoolChainId];
-  if (!isValidAddress(maybeAddress)) {
+  if (!isValidAddress(maybeAddress) || maybeAddress === ethers.constants.AddressZero) {
     throw new Error(
       `No HubPool supported on ${CHAINS[hubPoolChainId].name} with chainId: ${hubPoolChainId}`
     );

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -1,6 +1,6 @@
 import { clients, across, utils } from "@uma/sdk";
 import { ethers, BigNumber } from "ethers";
-import { SpokePool, SpokePool__factory } from "@across-protocol/contracts-v2";
+import { HubPool, HubPool__factory, SpokePool, SpokePool__factory } from "@across-protocol/contracts-v2";
 
 import {
   CHAINS,
@@ -11,9 +11,11 @@ import {
   Token,
   CHAINS_SELECTION,
   SPOKE_ADDRESSES,
+  HUBPOOL_ADDRESSES,
 } from "./constants";
 
 import { isValidString, parseEther, tagAddress } from "./format";
+import { isValidAddress } from "./address";
 
 export function getSpokePool(
   chainId: ChainId,
@@ -29,6 +31,28 @@ export function getSpokePool(
     maybeAddress,
     signer ?? PROVIDERS[chainId]()
   );
+}
+
+function getHubPoolChainId(sendingChain: ChainId): ChainId {
+  switch (sendingChain) {
+    case ChainId.ARBITRUM_RINKEBY:
+      return ChainId.RINKEBY;
+    case ChainId.KOVAN_OPTIMISM:
+      return ChainId.KOVAN;
+    default:
+      return ChainId.MAINNET
+  }
+}
+
+export function getHubPool(fromChain: ChainId, signer?: ethers.Signer): HubPool {
+  const hubPoolChainId = getHubPoolChainId(fromChain);
+  const maybeAddress = HUBPOOL_ADDRESSES[hubPoolChainId];
+  if (!isValidAddress(maybeAddress)) {
+    throw new Error(
+      `No HubPool supported on ${CHAINS[hubPoolChainId].name} with chainId: ${hubPoolChainId}`
+    );
+  }
+  return HubPool__factory.connect(maybeAddress, signer ?? PROVIDERS[hubPoolChainId]());
 }
 const { gasFeeCalculator } = across;
 
@@ -239,7 +263,7 @@ type AcrossDepositArgs = {
   amount: ethers.BigNumber;
   token: string;
   relayerFeePct: ethers.BigNumber;
-  timestamp: number;
+  timestamp: ethers.BigNumber;
   referrer?: string;
 };
 type AcrossApprovalArgs = {
@@ -250,7 +274,7 @@ type AcrossApprovalArgs = {
 /**
  * Makes a deposit on Across.
  * @param signer A valid signer, must be connected to a provider.
- * @param depositArgs - An object containing the {@link AcrossSendArgs arguments} to pass to the deposit function of the bridge contract.
+ * @param depositArgs - An object containing the {@link AcrossDepositArgs arguments} to pass to the deposit function of the bridge contract.
  * @returns The transaction response obtained after sending the transaction.
  */
 export async function sendAcrossDeposit(


### PR DESCRIPTION
This PR fixes a timestamp issue, `quoteTimestamps` were taken as the block timestamp of the sending chain, but now this is fixed and `getCurrentTime` on the `HubPool` is used.

Signed-off-by: Gamaranto <francesco@umaproject.org>