### PR TITLE
fix: revert destination address by passing empty value

### DIFF
--- a/src/components/AddressSelection/AddressSelection.styles.ts
+++ b/src/components/AddressSelection/AddressSelection.styles.ts
@@ -92,6 +92,8 @@ export const InputError = styled.div`
 `;
 
 export const ClearButton = styled(BaseButton)`
+  display: flex;
+  align-items: center;
   padding: 0;
 `;
 export const CancelButton = styled(PrimaryButton)`

--- a/src/components/AddressSelection/AddressSelection.tsx
+++ b/src/components/AddressSelection/AddressSelection.tsx
@@ -116,10 +116,7 @@ const AddressSelection: React.FC = () => {
           </InputWrapper>
           <ButtonGroup>
             <CancelButton onClick={toggle}>Cancel</CancelButton>
-            <SecondaryButton
-              onClick={handleSubmit}
-              disabled={!isValid || !address}
-            >
+            <SecondaryButton onClick={handleSubmit} disabled={!isValid}>
               Save Changes
             </SecondaryButton>
           </ButtonGroup>

--- a/src/components/AddressSelection/useAddressSelection.ts
+++ b/src/components/AddressSelection/useAddressSelection.ts
@@ -5,7 +5,7 @@ import { useSendForm } from "hooks";
 import { CHAINS_SELECTION, isValidAddress } from "utils";
 
 export default function useAddressSelection() {
-  const { isConnected } = useConnection();
+  const { isConnected, account } = useConnection();
   const { toChain, toAddress, fromChain, setToChain, setToAddress } =
     useSendForm();
   const [address, setAddress] = useState("");
@@ -43,8 +43,12 @@ export default function useAddressSelection() {
   };
   const isValid = !address || isValidAddress(address);
   const handleSubmit = () => {
-    if (isValid && address) {
-      setToAddress(address);
+    if (isValid) {
+      if (address) {
+        setToAddress(address);
+      } else if (account) {
+        setToAddress(account);
+      }
       toggle();
     }
   };


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org

Quick PR that allows the user to revert the destination address to the connected wallet  by allowing to pass an empty value

<img width="347" alt="Screenshot 2022-04-13 at 04 19 46" src="https://user-images.githubusercontent.com/89395931/163080201-aaed5835-4876-43af-b508-c1c1571eaf58.png">
