### PR TITLE
fix(across-v2): keep past data in balance queries

### DIFF
--- a/src/components/CoinSelection/useCoinSelection.tsx
+++ b/src/components/CoinSelection/useCoinSelection.tsx
@@ -5,7 +5,6 @@ import React, { useMemo, useEffect, useCallback } from "react";
 import { useConnection } from "state/hooks";
 import { useBalance, useBalances, useBridgeFees, useSendForm } from "hooks";
 import {
-  TOKENS_LIST,
   ParsingError,
   filterTokensByDestinationChain,
   max,
@@ -34,7 +33,7 @@ export default function useCoinSelection() {
   );
 
   const { balances } = useBalances(
-    TOKENS_LIST[fromChain].map((t) => t.address),
+    tokenList.map((t) => t.address),
     fromChain,
     account
   );

--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -8,6 +8,7 @@ import {
   balancesQueryKey,
   ChainId,
 } from "utils";
+import { usePrevious } from "hooks";
 
 /**
  * @param token - The token to fetch the balance of.
@@ -96,6 +97,11 @@ export function useBalances(
       "DISABLED_BALANCES_QUERY",
       { chainIdToQuery, tokens, accountToQuery, blockNumberToQuery },
     ];
+  const prevAccount = usePrevious(accountToQuery);
+  const prevChain = usePrevious(chainIdToQuery);
+  const prevTokens = usePrevious(tokens);
+  // Keep the previous data only when blockNumberToQuery changes.
+  const keepPreviousData = prevAccount === accountToQuery && prevChain === chainIdToQuery && JSON.stringify(prevTokens) === JSON.stringify(tokens);
   const { data: balances, ...delegated } = useQuery(
     queryKey,
     async () => {
@@ -113,7 +119,7 @@ export function useBalances(
       staleTime: Infinity,
       // Old balances can be garbage collected immediately
       cacheTime: 0,
-      keepPreviousData: true,
+      keepPreviousData,
     }
   );
   return {

--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -34,9 +34,9 @@ export function useBalance(
   const queryKey = enabledQuery
     ? balanceQueryKey(chainIdToQuery, token, accountToQuery, blockNumberToQuery)
     : [
-        "DISABLED_BALANCE_QUERY",
-        { chainIdToQuery, token, accountToQuery, blockNumberToQuery },
-      ];
+      "DISABLED_BALANCE_QUERY",
+      { chainIdToQuery, token, accountToQuery, blockNumberToQuery },
+    ];
   const { data: balance, ...delegated } = useQuery(
     queryKey,
     async () => {
@@ -87,15 +87,15 @@ export function useBalances(
     !!blockNumberToQuery;
   const queryKey = enabledQuery
     ? balancesQueryKey(
-        chainIdToQuery,
-        tokens,
-        accountToQuery,
-        blockNumberToQuery
-      )
+      chainIdToQuery,
+      tokens,
+      accountToQuery,
+      blockNumberToQuery
+    )
     : [
-        "DISABLED_BALANCES_QUERY",
-        { chainIdToQuery, tokens, accountToQuery, blockNumberToQuery },
-      ];
+      "DISABLED_BALANCES_QUERY",
+      { chainIdToQuery, tokens, accountToQuery, blockNumberToQuery },
+    ];
   const { data: balances, ...delegated } = useQuery(
     queryKey,
     async () => {
@@ -111,6 +111,9 @@ export function useBalances(
       enabled: enabledQuery,
       // We already re-fetch when the block change, so we don't need to re-fetch.
       staleTime: Infinity,
+      // Old balances can be garbage collected immediately
+      cacheTime: 0,
+      keepPreviousData: true,
     }
   );
   return {


### PR DESCRIPTION
Fixes https://app.shortcut.com/uma-project/story/5204/incorrect-wallet-balances-showing-on-v2 by keeping the old query data until the new one arrives.

**Why the bug happened**
There was actually no bug, by default, react query will throw out the old data when the keys for a query change, since we use the block number as the query key, each time that changes, we consider it as a new query and we throw out old data. This has the effect of making the `balances` undefined until we get the fresh data.
Now, react-query will keep the previous balances until the fresh data arrives, and consequently, the UI will always show balances

Signed-off-by: Gamaranto <francesco@umaproject.org>