### PR TITLE
fix(across-v2): disable send until tx confirms

### DIFF
--- a/src/components/SendAction/useSendAction.ts
+++ b/src/components/SendAction/useSendAction.ts
@@ -39,9 +39,7 @@ export default function useSendAction(
       if (hasToApprove) {
         const tx = await approve();
         if (tx) {
-          tx.wait(CONFIRMATIONS).then(() => {
-            setTxPending(false);
-          });
+          tx.wait(CONFIRMATIONS).catch(console.error).finally(() => { setTxPending(false); });
         }
         return tx;
       } else {
@@ -62,9 +60,9 @@ export default function useSendAction(
                 from: account,
                 fees: feesUsed,
               });
-              setTxPending(false);
             })
-            .catch(console.error);
+            .catch(console.error)
+            .finally(() => { setTxPending(false); });
           // TODO: we should invalidate and refetch any queries of the transaction tab, so when a user switches to it, they see the new transaction immediately.
         }
         return tx;

--- a/src/components/SendAction/useSendAction.ts
+++ b/src/components/SendAction/useSendAction.ts
@@ -69,7 +69,8 @@ export default function useSendAction(
       }
     } catch (error) {
       console.error(error);
-      console.error(`Something went wrong sending the transaction`)
+      console.error(`Something went wrong sending the transaction`);
+      setTxPending(false);
     }
   };
 


### PR DESCRIPTION
Fixes https://app.shortcut.com/uma-project/story/5238/send-button-is-enabled-while-a-deposit-is-pending
Signed-off-by: Gamaranto <francesco@umaproject.org>