### PR TITLE
feat(across-v2): add query params for bridge tab

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -48,7 +48,7 @@ const Routes: React.FC = () => {
         <Route exact path="/transactions" component={Transactions} />
         <Route exact path="/pool" component={Pool} />
         <Route exact path="/about" component={About} />
-        <Route exact path="/" component={Send} />
+        <Route path="/" component={Send} />
       </Switch>
     </>
   );

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -243,7 +243,7 @@ export function filterTokensByDestinationChain(
  * @param chainB  the destination chain, that is, where tokens will be sent.
  * @returns Returns `true` if it is possible to bridge from chain A to chain B, `false` otherwise.
  */
-function canBridge(chainA: ChainId, chainB: ChainId): boolean {
+export function canBridge(chainA: ChainId, chainB: ChainId): boolean {
   // can't bridge to itself
   if (chainA === chainB) {
     return false;


### PR DESCRIPTION
Allows to pre-populate the send tab with the from and to chain from query params:
Example: `http://localhost:3000/bridge?from=288&to=1` would render a send tab from boba to mainnet

Signed-off-by: Gamaranto <francesco@umaproject.org>