### PR TITLE
feat: add mainnet routes

### DIFF
--- a/src/components/Wallet/Wallet.tsx
+++ b/src/components/Wallet/Wallet.tsx
@@ -1,7 +1,7 @@
 import { onboard } from "utils";
 import { FC } from "react";
 import { useConnection } from "state/hooks";
-import { useBalanceBySymbol } from "hooks";
+import { useNativeBalance } from "hooks";
 
 import { getChainInfo, shortenAddress, formatEther, getConfig } from "utils";
 
@@ -25,7 +25,7 @@ const Wallet: FC<Props> = ({ setOpenSidebar }) => {
   const nativeToken = chainId ? config.getNativeTokenInfo(chainId) : undefined;
   const chain = chainId ? getChainInfo(chainId) : undefined;
 
-  const { balance } = useBalanceBySymbol(nativeToken?.symbol, chainId, account);
+  const { balance } = useNativeBalance(nativeToken?.symbol, chainId, account);
 
   if (account && !isConnected && !chainId) {
     return (

--- a/src/data/routes_1_0x6Bb9910c5529Cb3b32c4f0e13E8bC38F903b2534.json
+++ b/src/data/routes_1_0x6Bb9910c5529Cb3b32c4f0e13E8bC38F903b2534.json
@@ -1,0 +1,186 @@
+{
+  "hubPoolChain": 1,
+  "hubPoolAddress": "0x6Bb9910c5529Cb3b32c4f0e13E8bC38F903b2534",
+  "routes": [
+    {
+      "fromChain": 1,
+      "toChain": 10,
+      "fromTokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "fromSpokeAddress": "0x931A43528779034ac9eb77df799d133557406176",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 1,
+      "toChain": 137,
+      "fromTokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "fromSpokeAddress": "0x931A43528779034ac9eb77df799d133557406176",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 1,
+      "toChain": 288,
+      "fromTokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "fromSpokeAddress": "0x931A43528779034ac9eb77df799d133557406176",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 1,
+      "toChain": 42161,
+      "fromTokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "fromSpokeAddress": "0x931A43528779034ac9eb77df799d133557406176",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 10,
+      "toChain": 1,
+      "fromTokenAddress": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+      "fromSpokeAddress": "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 10,
+      "toChain": 137,
+      "fromTokenAddress": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+      "fromSpokeAddress": "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 10,
+      "toChain": 288,
+      "fromTokenAddress": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+      "fromSpokeAddress": "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 10,
+      "toChain": 42161,
+      "fromTokenAddress": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+      "fromSpokeAddress": "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 137,
+      "toChain": 1,
+      "fromTokenAddress": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+      "fromSpokeAddress": "0xD3ddAcAe5aFb00F9B9cD36EF0Ed7115d7f0b584c",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 137,
+      "toChain": 10,
+      "fromTokenAddress": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+      "fromSpokeAddress": "0xD3ddAcAe5aFb00F9B9cD36EF0Ed7115d7f0b584c",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 137,
+      "toChain": 288,
+      "fromTokenAddress": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+      "fromSpokeAddress": "0xD3ddAcAe5aFb00F9B9cD36EF0Ed7115d7f0b584c",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 137,
+      "toChain": 42161,
+      "fromTokenAddress": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+      "fromSpokeAddress": "0xD3ddAcAe5aFb00F9B9cD36EF0Ed7115d7f0b584c",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 288,
+      "toChain": 1,
+      "fromTokenAddress": "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
+      "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 288,
+      "toChain": 10,
+      "fromTokenAddress": "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
+      "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 288,
+      "toChain": 137,
+      "fromTokenAddress": "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
+      "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 288,
+      "toChain": 42161,
+      "fromTokenAddress": "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
+      "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 42161,
+      "toChain": 1,
+      "fromTokenAddress": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "fromSpokeAddress": "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 42161,
+      "toChain": 10,
+      "fromTokenAddress": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "fromSpokeAddress": "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 42161,
+      "toChain": 137,
+      "fromTokenAddress": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "fromSpokeAddress": "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 42161,
+      "toChain": 288,
+      "fromTokenAddress": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "fromSpokeAddress": "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    }
+  ]
+}

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -51,7 +51,7 @@ export function useBridge() {
   const spokePool = fromChain ? config.getSpokePool(fromChain) : undefined;
   const { allowance } = useAllowance(
     tokenSymbol,
-    chainId,
+    fromChain,
     account,
     spokePool?.address,
     block?.number

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -11,6 +11,7 @@ import * as superstruct from "superstruct";
 
 // all routes should be pre imported to be able to switch based on chain id
 import KovanRoutes from "data/routes_42_0xD449Af45a032Df413b497A709EeD3E8C112EbcE3.json";
+import MainnetRoutes from "data/routes_1_0x6Bb9910c5529Cb3b32c4f0e13E8bC38F903b2534.json";
 
 /* Chains and Tokens section */
 export enum ChainId {
@@ -89,7 +90,7 @@ export const COLORS = {
 
 // Update once addresses are known
 export const RATEMODEL_ADDRESSES: Record<ChainId, string> = {
-  [ChainId.MAINNET]: ethers.constants.AddressZero,
+  [ChainId.MAINNET]: getAddress("0xd18fFeb5fdd1F2e122251eA7Bf357D8Af0B60B50"),
   [ChainId.ARBITRUM]: ethers.constants.AddressZero,
   [ChainId.OPTIMISM]: ethers.constants.AddressZero,
   [ChainId.BOBA]: ethers.constants.AddressZero,
@@ -495,6 +496,10 @@ export function getRoutes(chainId: ChainId): RouteConfig {
   if (chainId === ChainId.KOVAN) {
     superstruct.assert(KovanRoutes, RouteConfig);
     return KovanRoutes;
+  }
+  if (chainId === ChainId.MAINNET) {
+    superstruct.assert(MainnetRoutes, RouteConfig);
+    return MainnetRoutes;
   }
   throw new Error("No routes defined for chainId: " + chainId);
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -90,7 +90,7 @@ export const COLORS = {
 
 // Update once addresses are known
 export const RATEMODEL_ADDRESSES: Record<ChainId, string> = {
-  [ChainId.MAINNET]: getAddress("0xd18fFeb5fdd1F2e122251eA7Bf357D8Af0B60B50"),
+  [ChainId.MAINNET]: getAddress("0x3B03509645713718B78951126E0A6de6f10043f5"),
   [ChainId.ARBITRUM]: ethers.constants.AddressZero,
   [ChainId.OPTIMISM]: ethers.constants.AddressZero,
   [ChainId.BOBA]: ethers.constants.AddressZero,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -90,7 +90,7 @@ export const COLORS = {
 
 // Update once addresses are known
 export const RATEMODEL_ADDRESSES: Record<ChainId, string> = {
-  [ChainId.MAINNET]: getAddress("0x3B03509645713718B78951126E0A6de6f10043f5"),
+  [ChainId.MAINNET]: getAddress("0xd18fFeb5fdd1F2e122251eA7Bf357D8Af0B60B50"),
   [ChainId.ARBITRUM]: ethers.constants.AddressZero,
   [ChainId.OPTIMISM]: ethers.constants.AddressZero,
   [ChainId.BOBA]: ethers.constants.AddressZero,

--- a/src/views/Pool.tsx
+++ b/src/views/Pool.tsx
@@ -35,7 +35,7 @@ const Pool: FC = () => {
   const config = getConfig();
   const tokenList = config.getTokenList(chainId);
   const chainInfo = getChainInfo(chainId);
-  const [token, setToken] = useState(tokenList[2]);
+  const [token, setToken] = useState(tokenList[0]);
   const [showSuccess, setShowSuccess] = useState<ShowSuccess | undefined>();
   const [depositUrl, setDepositUrl] = useState("");
   const [loadingPoolState, setLoadingPoolState] = useState(false);


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

This adds configuration for mainnet, fixes some bugs that came up with this. To test this view the mainnet deployment (frontend-v2 preview).

Hubpool addresses is based on v1 hubpool, which probably isnt right but currently theres no v2 deployment.
weth address is an env for the pool tab, but i think we could probably update that to deduce from on chain data.

edit: hub pool has been updated with the config store address