### PR TITLE
fix: allow query params to persist across tabs

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -41,14 +41,20 @@ const Header: React.FC<Props> = ({ openSidebar, setOpenSidebar }) => {
         <List>
           {LINKS.map(({ href, name }) => (
             <Item key={href} aria-selected={location.pathname === href}>
-              <Link to={href}>{name}</Link>
+              <Link
+                to={{
+                  pathname: href,
+                  search: location.search,
+                }}
+              >
+                {name}
+              </Link>
             </Item>
           ))}
         </List>
       </Navigation>
       <WalletWrapper>
         <Wallet setOpenSidebar={setOpenSidebar} />
-
         <MobileNavigation animate={openSidebar ? "open" : "closed"}>
           <MenuToggle toggle={toggleMenu} />
         </MobileNavigation>


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Makes it so query params stick around between tabs