### PR TITLE
feat: add matomo events from v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 - REACT_APP_UPDATE_GAS_INTERVAL_MS: how frequently to update gas prices in MS, used for estimating adding liquidity when maxing eth. Default 30000 (30 sec).
 - REACT_APP_DISABLE_DEPOSITS: Displays a maintenance banner and disables the AddLiquidityForm in the Pool view.
 - REACT_APP_ENABLE_REACT_QUERY_DEV_TOOLS: Display React-Query dev tools if set to `true`.
+- REACT_APP_MATOMO_URL: Enable matomo by setting the matomo url, app will ignore events if not defined.
 
 ## Internal Contributions
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@across-protocol/contracts-v2": "^0.0.34",
     "@across-protocol/sdk-v2": "^0.0.6",
+    "@datapunt/matomo-tracker-js": "^0.5.1",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",
     "@eth-optimism/contracts": "^0.5.5",

--- a/public/index.html
+++ b/public/index.html
@@ -36,21 +36,6 @@
 
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo-small.png" />
     <title>Across - Bridge Layer 1 and Layer 2 assets</title>
-    <!-- Matomo -->
-    <script>
-      var _paq = window._paq = window._paq || [];
-      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-      _paq.push(['trackPageView']);
-      _paq.push(['enableLinkTracking']);
-      (function() {
-        var u="https://across.matomo.cloud/";
-        _paq.push(['setTrackerUrl', u+'matomo.php']);
-        _paq.push(['setSiteId', '1']);
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.async=true; g.src='//cdn.matomo.cloud/across.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-      })();
-    </script>
-<!-- End Matomo Code -->
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/AddressSelection/useAddressSelection.ts
+++ b/src/components/AddressSelection/useAddressSelection.ts
@@ -2,7 +2,7 @@ import { useSelect } from "downshift";
 import { useState, useEffect } from "react";
 import { useConnection } from "state/hooks";
 import { useSendForm } from "hooks";
-import { isValidAddress, getChainInfo } from "utils";
+import { isValidAddress, getChainInfo, trackEvent } from "utils";
 
 export default function useAddressSelection() {
   const { isConnected, account } = useConnection();
@@ -23,6 +23,12 @@ export default function useAddressSelection() {
     items: availableToChains.map((chain) => chain.chainId),
     onSelectedItemChange: ({ selectedItem }) => {
       if (selectedItem) {
+        // matomo tracking
+        trackEvent({
+          category: "send",
+          action: "setToChain",
+          name: selectedItem.toString(),
+        });
         setToChain(selectedItem);
       }
     },

--- a/src/components/ChainSelection/useChainSelection.ts
+++ b/src/components/ChainSelection/useChainSelection.ts
@@ -6,6 +6,7 @@ import {
   switchChain,
   onboard,
   getChainInfo,
+  trackEvent,
 } from "utils";
 
 export default function useChainSelection() {
@@ -37,6 +38,12 @@ export default function useChainSelection() {
     items: availableFromChains.map((chain) => chain.chainId),
     onSelectedItemChange: ({ selectedItem }) => {
       if (selectedItem) {
+        // Matomo track fromChain
+        trackEvent({
+          category: "send",
+          action: "setFromChain",
+          name: selectedItem.toString(),
+        });
         setFromChain(selectedItem);
       }
     },

--- a/src/components/CoinSelection/useCoinSelection.tsx
+++ b/src/components/CoinSelection/useCoinSelection.tsx
@@ -8,6 +8,7 @@ import {
   ParsingError,
   max,
   InsufficientBalanceError,
+  trackEvent,
   FEE_ESTIMATION,
 } from "utils";
 
@@ -39,6 +40,12 @@ export default function useCoinSelection() {
       if (selectedItem) {
         setInputAmount("");
         setTokenSymbol(selectedItem.symbol);
+        // Matomo track token selection
+        trackEvent({
+          category: "send",
+          action: "setAsset",
+          name: selectedItem.symbol,
+        });
       }
     },
   });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -441,6 +441,7 @@ export const infuraId = process.env.REACT_APP_PUBLIC_INFURA_ID;
 export const confirmations =
   Number(process.env.REACT_APP_PUBLIC_CONFIRMATIONS) || 1;
 export const onboardApiKey = process.env.REACT_APP_PUBLIC_ONBOARD_API_KEY;
+export const matomoUrl = process.env.REACT_APP_MATOMO_URL;
 
 export const MAX_APPROVAL_AMOUNT = ethers.constants.MaxUint256;
 export const FEE_ESTIMATION = ".004";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,3 +13,4 @@ export * from "./token";
 export * from "./query-keys";
 export * from "./ethers";
 export * from "./config";
+export * from "./matomo";

--- a/src/utils/matomo.ts
+++ b/src/utils/matomo.ts
@@ -1,0 +1,40 @@
+import assert from "assert";
+import { matomoUrl } from "utils";
+import MatomoTracker, { types } from "@datapunt/matomo-tracker-js";
+
+let tracker: MatomoTracker | undefined;
+
+export function trackerEnabled(): boolean {
+  return Boolean(matomoUrl);
+}
+export function getTracker(): MatomoTracker {
+  assert(trackerEnabled(), "Tracker is disabled, provide matomo url to enable");
+  assert(matomoUrl, "Matomo url is not defined");
+  if (tracker) return tracker;
+  tracker = new MatomoTracker({
+    urlBase: matomoUrl,
+    siteId: 1,
+    linkTracking: true,
+    trackerUrl: matomoUrl + "matomo.php",
+  });
+  // Load the event listeners
+  tracker.trackEvents();
+  // Track page views
+  tracker.trackPageView();
+  return tracker;
+}
+export function trackEvent(params: types.TrackEventParams) {
+  if (!trackerEnabled()) return;
+  const tracker = getTracker();
+  tracker.trackEvent(params);
+}
+export function trackPageView(params: types.TrackPageViewParams) {
+  if (!trackerEnabled()) return;
+  const tracker = getTracker();
+  tracker.trackPageView(params);
+}
+export function trackLink(params: types.TrackLinkParams) {
+  if (!trackerEnabled()) return;
+  const tracker = getTracker();
+  tracker.trackLink(params);
+}

--- a/src/utils/onboard.ts
+++ b/src/utils/onboard.ts
@@ -7,6 +7,7 @@ import {
   hubPoolChainId,
   ChainId,
   providerUrlsTable,
+  trackEvent,
 } from "utils";
 import { update, disconnect, error } from "state/connection";
 import { store } from "state";
@@ -110,11 +111,15 @@ export function OnboardEthers(config: Initialization, emit: Emit) {
   };
 }
 export const onboard = OnboardEthers(onboardBaseConfig(), (event, data) => {
+  if (event === "init") {
+    trackEvent({ category: "wallet", action: "connect", name: "null" });
+  }
   if (event === "update") {
     store.dispatch(update(data));
   }
   if (event === "disconnect") {
     store.dispatch(disconnect());
+    trackEvent({ category: "wallet", action: "disconnect", name: "null" });
   }
   if (event === "error") {
     store.dispatch(error(data));

--- a/src/views/Send/Send.tsx
+++ b/src/views/Send/Send.tsx
@@ -3,6 +3,7 @@ import SendForm from "components/SendForm";
 import Confirmation from "../Confirmation";
 import useSendTab from "./useSendTab";
 import { SendFormProvider } from "hooks";
+import { trackPageView } from "utils";
 
 const SendTab: React.FC = () => {
   const {
@@ -11,6 +12,14 @@ const SendTab: React.FC = () => {
     onCloseConfirmationScreen,
     onDepositConfirmed,
   } = useSendTab();
+
+  // Track page views of the Send tab
+  React.useEffect(() => {
+    trackPageView({
+      documentTitle: "Send",
+      href: "https://across.to",
+    });
+  }, []);
 
   if (showConfirmationScreen) {
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,6 +1205,11 @@
     react-qr-reader "^2.2.1"
     rxjs "^6.6.3"
 
+"@datapunt/matomo-tracker-js@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@datapunt/matomo-tracker-js/-/matomo-tracker-js-0.5.1.tgz#92a746ffa421f91b3a59fefce707d45ca22be96b"
+  integrity sha512-9/MW9vt/BA5Db7tO6LqCeQKtuvBNjyq51faF3AzUmPMlYsJCnASIxcut3VqJKiribhUoey7aYbPIYuj9x4DLPA==
+
 "@defi-wonderland/smock@^2.0.7":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@defi-wonderland/smock/-/smock-2.0.7.tgz#59d5fc93e175ad120c5dcdd8294e07525606c855"


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

This copies the functionality from this pr: https://github.com/across-protocol/frontend-v1/pull/179/files.  Adds matomo events, improves v1 slightly by allowing the url to be configured and matomo to be disabled if not provided. 