### PR TITLE
fix: parse decimals on tx history page 

### DIFF
--- a/src/views/Transactions/TransactionsTable/createTransactionTableJSX.tsx
+++ b/src/views/Transactions/TransactionsTable/createTransactionTableJSX.tsx
@@ -92,7 +92,7 @@ function formatTransactionRows(transactions: Transfer[]): IRow[] {
 
     const amount: ICell = {
       size: "xs",
-      value: ethers.utils.formatEther(tx.amount),
+      value: ethers.utils.formatUnits(tx.amount, token.decimals),
     };
 
     // TODO: change href to proper url when we get real TX data


### PR DESCRIPTION
Story details: https://app.shortcut.com/uma-project/story/5507