### PR TITLE
feat: fetch tx history events in background 

### DIFF
--- a/src/state/transferHistory.ts
+++ b/src/state/transferHistory.ts
@@ -28,7 +28,7 @@ export function createTxHistoryClientConfig(params: Params): {
       lowerBoundBlockNumber: lowerBounds[chainId],
     };
   });
-  return { chains, pollingIntervalSeconds: 0 };
+  return { chains, pollingIntervalSeconds: 10 };
 }
 
 export default function getClient() {

--- a/src/state/transferHistory.ts
+++ b/src/state/transferHistory.ts
@@ -5,6 +5,7 @@ export enum TransfersHistoryEvent {
   TransfersUpdated = "TransfersUpdated",
 }
 const { TransfersHistoryClient } = transfersHistory;
+const POLLING_INTERVAL_SECONDS = 10;
 
 interface txHistoryConfig {
   chainId: number;
@@ -28,7 +29,7 @@ export function createTxHistoryClientConfig(params: Params): {
       lowerBoundBlockNumber: lowerBounds[chainId],
     };
   });
-  return { chains, pollingIntervalSeconds: 10 };
+  return { chains, pollingIntervalSeconds: POLLING_INTERVAL_SECONDS };
 }
 
 export default function getClient() {

--- a/src/views/Transactions/useTransactionsView.ts
+++ b/src/views/Transactions/useTransactionsView.ts
@@ -49,7 +49,7 @@ export default function useTransactionsView() {
           err
         );
       });
-      // start timer to stop fetching events after a certain time
+      // start timer that stops fetching events after a certain time
       const timeout = setTimeout(() => {
         txClient.stopFetchingTransfers(account);
         setTimer(undefined);
@@ -68,6 +68,8 @@ export default function useTransactionsView() {
 
   useEffect(() => {
     return () => {
+      // inside the cleanup function make sure that the old timer
+      // is cleared after setting up a new timer
       if (timer) {
         clearInterval(timer);
       }


### PR DESCRIPTION
Story details: https://app.shortcut.com/uma-project/story/5510

This PR enables the TX History tab to be updated automatically by fetching events in the background every 10 seconds for 5 minutes max

[Demo video](https://www.loom.com/share/91c998b2236c42a5976fd5dea713f9fa)