### PR TITLE
improve: adds eth/weth routes for mainnet

### DIFF
--- a/src/data/routes_1_0x6Bb9910c5529Cb3b32c4f0e13E8bC38F903b2534.json
+++ b/src/data/routes_1_0x6Bb9910c5529Cb3b32c4f0e13E8bC38F903b2534.json
@@ -14,12 +14,48 @@
     },
     {
       "fromChain": 1,
+      "toChain": 10,
+      "fromTokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      "fromSpokeAddress": "0x931A43528779034ac9eb77df799d133557406176",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 1,
+      "toChain": 10,
+      "fromTokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      "fromSpokeAddress": "0x931A43528779034ac9eb77df799d133557406176",
+      "fromTokenSymbol": "ETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 1,
       "toChain": 137,
       "fromTokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
       "fromSpokeAddress": "0x931A43528779034ac9eb77df799d133557406176",
       "fromTokenSymbol": "USDC",
       "isNative": false,
       "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 1,
+      "toChain": 137,
+      "fromTokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      "fromSpokeAddress": "0x931A43528779034ac9eb77df799d133557406176",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 1,
+      "toChain": 137,
+      "fromTokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      "fromSpokeAddress": "0x931A43528779034ac9eb77df799d133557406176",
+      "fromTokenSymbol": "ETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
     },
     {
       "fromChain": 1,
@@ -32,6 +68,24 @@
     },
     {
       "fromChain": 1,
+      "toChain": 288,
+      "fromTokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      "fromSpokeAddress": "0x931A43528779034ac9eb77df799d133557406176",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 1,
+      "toChain": 288,
+      "fromTokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      "fromSpokeAddress": "0x931A43528779034ac9eb77df799d133557406176",
+      "fromTokenSymbol": "ETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 1,
       "toChain": 42161,
       "fromTokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
       "fromSpokeAddress": "0x931A43528779034ac9eb77df799d133557406176",
@@ -40,6 +94,24 @@
       "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     },
     {
+      "fromChain": 1,
+      "toChain": 42161,
+      "fromTokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      "fromSpokeAddress": "0x931A43528779034ac9eb77df799d133557406176",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 1,
+      "toChain": 42161,
+      "fromTokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      "fromSpokeAddress": "0x931A43528779034ac9eb77df799d133557406176",
+      "fromTokenSymbol": "ETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
       "fromChain": 10,
       "toChain": 1,
       "fromTokenAddress": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
@@ -50,12 +122,48 @@
     },
     {
       "fromChain": 10,
+      "toChain": 1,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 10,
+      "toChain": 1,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+      "fromTokenSymbol": "OETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 10,
       "toChain": 137,
       "fromTokenAddress": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
       "fromSpokeAddress": "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
       "fromTokenSymbol": "USDC",
       "isNative": false,
       "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 10,
+      "toChain": 137,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 10,
+      "toChain": 137,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+      "fromTokenSymbol": "OETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
     },
     {
       "fromChain": 10,
@@ -68,12 +176,57 @@
     },
     {
       "fromChain": 10,
+      "toChain": 288,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 10,
+      "toChain": 288,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+      "fromTokenSymbol": "OETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 10,
       "toChain": 42161,
       "fromTokenAddress": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
       "fromSpokeAddress": "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
       "fromTokenSymbol": "USDC",
       "isNative": false,
       "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 10,
+      "toChain": 42161,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 10,
+      "toChain": 42161,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+      "fromTokenSymbol": "OETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 137,
+      "toChain": 1,
+      "fromTokenAddress": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+      "fromSpokeAddress": "0xD3ddAcAe5aFb00F9B9cD36EF0Ed7115d7f0b584c",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
     },
     {
       "fromChain": 137,
@@ -83,6 +236,15 @@
       "fromTokenSymbol": "USDC",
       "isNative": false,
       "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 137,
+      "toChain": 10,
+      "fromTokenAddress": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+      "fromSpokeAddress": "0xD3ddAcAe5aFb00F9B9cD36EF0Ed7115d7f0b584c",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
     },
     {
       "fromChain": 137,
@@ -96,11 +258,29 @@
     {
       "fromChain": 137,
       "toChain": 288,
+      "fromTokenAddress": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+      "fromSpokeAddress": "0xD3ddAcAe5aFb00F9B9cD36EF0Ed7115d7f0b584c",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 137,
+      "toChain": 288,
       "fromTokenAddress": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
       "fromSpokeAddress": "0xD3ddAcAe5aFb00F9B9cD36EF0Ed7115d7f0b584c",
       "fromTokenSymbol": "USDC",
       "isNative": false,
       "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 137,
+      "toChain": 42161,
+      "fromTokenAddress": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+      "fromSpokeAddress": "0xD3ddAcAe5aFb00F9B9cD36EF0Ed7115d7f0b584c",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
     },
     {
       "fromChain": 137,
@@ -114,6 +294,24 @@
     {
       "fromChain": 288,
       "toChain": 1,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
+      "fromTokenSymbol": "ETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 288,
+      "toChain": 1,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
+      "fromTokenSymbol": "ETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 288,
+      "toChain": 1,
       "fromTokenAddress": "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
       "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
       "fromTokenSymbol": "USDC",
@@ -123,11 +321,47 @@
     {
       "fromChain": 288,
       "toChain": 10,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
+      "fromTokenSymbol": "ETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 288,
+      "toChain": 10,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
+      "fromTokenSymbol": "ETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 288,
+      "toChain": 10,
       "fromTokenAddress": "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
       "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
       "fromTokenSymbol": "USDC",
       "isNative": false,
       "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 288,
+      "toChain": 137,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
+      "fromTokenSymbol": "ETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 288,
+      "toChain": 137,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
+      "fromTokenSymbol": "ETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
     },
     {
       "fromChain": 288,
@@ -141,11 +375,47 @@
     {
       "fromChain": 288,
       "toChain": 42161,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
+      "fromTokenSymbol": "ETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 288,
+      "toChain": 42161,
+      "fromTokenAddress": "0x4200000000000000000000000000000000000006",
+      "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
+      "fromTokenSymbol": "ETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 288,
+      "toChain": 42161,
       "fromTokenAddress": "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
       "fromSpokeAddress": "0x7229405a2f0c550Ce35182EE1658302B65672443",
       "fromTokenSymbol": "USDC",
       "isNative": false,
       "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 42161,
+      "toChain": 1,
+      "fromTokenAddress": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "fromSpokeAddress": "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 42161,
+      "toChain": 1,
+      "fromTokenAddress": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "fromSpokeAddress": "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
+      "fromTokenSymbol": "AETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
     },
     {
       "fromChain": 42161,
@@ -159,6 +429,24 @@
     {
       "fromChain": 42161,
       "toChain": 10,
+      "fromTokenAddress": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "fromSpokeAddress": "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 42161,
+      "toChain": 10,
+      "fromTokenAddress": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "fromSpokeAddress": "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
+      "fromTokenSymbol": "AETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 42161,
+      "toChain": 10,
       "fromTokenAddress": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
       "fromSpokeAddress": "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
       "fromTokenSymbol": "USDC",
@@ -168,11 +456,47 @@
     {
       "fromChain": 42161,
       "toChain": 137,
+      "fromTokenAddress": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "fromSpokeAddress": "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 42161,
+      "toChain": 137,
+      "fromTokenAddress": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "fromSpokeAddress": "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
+      "fromTokenSymbol": "AETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 42161,
+      "toChain": 137,
       "fromTokenAddress": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
       "fromSpokeAddress": "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
       "fromTokenSymbol": "USDC",
       "isNative": false,
       "l1TokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    },
+    {
+      "fromChain": 42161,
+      "toChain": 288,
+      "fromTokenAddress": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "fromSpokeAddress": "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+    {
+      "fromChain": 42161,
+      "toChain": 288,
+      "fromTokenAddress": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "fromSpokeAddress": "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
+      "fromTokenSymbol": "AETH",
+      "isNative": true,
+      "l1TokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
     },
     {
       "fromChain": 42161,


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

You can now use the scripts here to generate routes:
https://github.com/across-protocol/helper-scripts. no docs yet but you can run with `yarn routes 1` where 1 represents the chain id of the hubpool you care about