### PR TITLE
improve: format numbers to show more sig digits

### DIFF
--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { formatUnits, receiveAmount, getChainInfo, getToken } from "utils";
+import {
+  formatUnits,
+  receiveAmount,
+  getChainInfo,
+  getToken,
+  getConfirmationDepositTime,
+} from "utils";
 import { PrimaryButton } from "../Buttons";
 import {
   Wrapper,
@@ -42,6 +48,13 @@ const SendAction: React.FC<Props> = ({ onDeposit }) => {
   const tokenInfo = tokenSymbol ? getToken(tokenSymbol) : undefined;
   const isWETH = tokenInfo?.symbol === "WETH";
 
+  console.log({
+    amount: amount?.toString(),
+    lpFee: fees?.lpFee?.total?.toString(),
+    relayerFee: fees?.relayerFee?.total?.toString(),
+    amountMinusFees: amountMinusFees?.toString(),
+  });
+
   return (
     <AccentSection>
       <Wrapper>
@@ -57,7 +70,7 @@ const SendAction: React.FC<Props> = ({ onDeposit }) => {
             <InfoContainer>
               <Info>
                 {`Time to ${toChainInfo.name}`}
-                <div>~1-3 minutes</div>
+                <div>{getConfirmationDepositTime()}</div>
               </Info>
               <Info>
                 <div>Ethereum Network Gas</div>

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -48,13 +48,6 @@ const SendAction: React.FC<Props> = ({ onDeposit }) => {
   const tokenInfo = tokenSymbol ? getToken(tokenSymbol) : undefined;
   const isWETH = tokenInfo?.symbol === "WETH";
 
-  console.log({
-    amount: amount?.toString(),
-    lpFee: fees?.lpFee?.total?.toString(),
-    relayerFee: fees?.relayerFee?.total?.toString(),
-    amountMinusFees: amountMinusFees?.toString(),
-  });
-
   return (
     <AccentSection>
       <Wrapper>

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -135,7 +135,7 @@ export async function getBridgeFees({
 }
 
 export const getConfirmationDepositTime = () => {
-  return "~2 minutes";
+  return "~1-3 minutes";
 };
 
 type AcrossDepositArgs = {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -52,9 +52,11 @@ export function shortenTransactionHash(hash: string): string {
 }
 
 // this actually will round up in some cases
-export const numberFormatter = new Intl.NumberFormat("en-US", {
-  minimumFractionDigits: 4,
-}).format;
+export const numberFormatter = (num: number) =>
+  new Intl.NumberFormat("en-US", {
+    minimumSignificantDigits: 1,
+    maximumSignificantDigits: 4,
+  }).format(num);
 
 export function formatUnits(
   wei: ethers.BigNumberish,


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

now shows the significant digits
![image](https://user-images.githubusercontent.com/4429761/168360640-52d4cafa-2a2f-4d6d-8575-1359796271e1.png)

previously
![image](https://user-images.githubusercontent.com/4429761/168356448-c10f47a1-a287-4374-83f4-0f6bda7d5310.png)
