### PR TITLE
fix: reset tochain when fromchain selected

### DIFF
--- a/src/hooks/useSendForm.tsx
+++ b/src/hooks/useSendForm.tsx
@@ -179,7 +179,8 @@ function amountReducer(state: FormState, amount: ethers.BigNumber): FormState {
 function fromChainReducer(state: FormState, chainId: ChainId): FormState {
   const config = getConfig();
   let fromChain = chainId;
-  let toChain = state.toChain;
+  // reset toChain
+  let toChain = undefined;
   let tokenSymbol = state.tokenSymbol;
 
   let availableRoutes = config.filterRoutes({


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

To chain dropdown somtimes grays out routes that shoudl work.

This change resets the toChain selection when fromChain is selected, this resets the total routes that show up, enabling the to chain dropdown.