### PR TITLE
fix: clear account if wallet locks

### DIFF
--- a/src/state/connection.ts
+++ b/src/state/connection.ts
@@ -37,7 +37,7 @@ const connectionSlice = createSlice({
   reducers: {
     update: (state, action: PayloadAction<Update>) => {
       const { account, chainId, provider, signer } = action.payload;
-      state.account = account ? getAddress(account) : state.account;
+      state.account = account ? getAddress(account) : undefined;
       state.provider = provider ?? state.provider;
       // theres a potential problem with this: if onboard says a signer is undefined, we default them back
       // to the previous signer. This means we get out of sync with onboard and could have serious consequences.

--- a/src/utils/onboard.ts
+++ b/src/utils/onboard.ts
@@ -49,6 +49,11 @@ export function OnboardEthers(config: Initialization, emit: Emit) {
     subscriptions: {
       address: (address: string) => {
         emit("update", { account: address });
+        if (!address) {
+          // if we dont call reset here when account is undefined, we wont be able to reconnect
+          // this can happen if user locks their wallet.
+          reset();
+        }
       },
       network: (chainIdInHex) => {
         if (chainIdInHex == null) {


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

We dont disconnect the wallet if someone locks their wallet. Was not able to reproduce issue in card.