### PR TITLE
fix: do not lose existing account on chain change

### DIFF
--- a/src/state/connection.ts
+++ b/src/state/connection.ts
@@ -37,7 +37,7 @@ const connectionSlice = createSlice({
   reducers: {
     update: (state, action: PayloadAction<Update>) => {
       const { account, chainId, provider, signer } = action.payload;
-      state.account = account ? getAddress(account) : undefined;
+      state.account = account ? getAddress(account) : state.account;
       state.provider = provider ?? state.provider;
       // theres a potential problem with this: if onboard says a signer is undefined, we default them back
       // to the previous signer. This means we get out of sync with onboard and could have serious consequences.

--- a/src/utils/onboard.ts
+++ b/src/utils/onboard.ts
@@ -8,6 +8,7 @@ import {
   ChainId,
   providerUrlsTable,
   trackEvent,
+  debug,
 } from "utils";
 import { update, disconnect, error } from "state/connection";
 import { store } from "state";
@@ -116,6 +117,7 @@ export function OnboardEthers(config: Initialization, emit: Emit) {
   };
 }
 export const onboard = OnboardEthers(onboardBaseConfig(), (event, data) => {
+  if (debug) console.log("onboard event", event, data);
   if (event === "init") {
     trackEvent({ category: "wallet", action: "connect", name: "null" });
   }


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

I removed this line previously, but i guess it needs to be in there because chain changes do not include account update. 