### PR TITLE
feat: add new relayer fee logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@across-protocol/contracts-v2": "^0.0.34",
-    "@across-protocol/sdk-v2": "^0.1.2",
+    "@across-protocol/sdk-v2": "^0.1.3",
     "@datapunt/matomo-tracker-js": "^0.5.1",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -66,11 +66,11 @@ const SendAction: React.FC<Props> = ({ onDeposit }) => {
                 <div>{getConfirmationDepositTime()}</div>
               </Info>
               <Info>
-                <div>Ethereum Network Gas</div>
+                <div>Destination Gas Fees</div>
                 <div>
                   {showFees
                     ? `${formatUnits(
-                        fees.relayerFee.total,
+                        fees.relayerGasFee.total,
                         tokenInfo.decimals
                       )} ${tokenInfo.symbol}`
                     : "loading"}
@@ -80,9 +80,10 @@ const SendAction: React.FC<Props> = ({ onDeposit }) => {
                 <div>Across Bridge Fee</div>
                 <div>
                   {fees
-                    ? `${formatUnits(fees.lpFee.total, tokenInfo.decimals)} ${
-                        tokenInfo.symbol
-                      }`
+                    ? `${formatUnits(
+                        fees.lpFee.total.add(fees.relayerCapitalFee.total),
+                        tokenInfo.decimals
+                      )} ${tokenInfo.symbol}`
                     : "loading"}
                 </div>
               </Info>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -8,6 +8,7 @@ import bobaLogo from "assets/boba-logo.svg";
 import polygonLogo from "assets/polygon-logo.svg";
 import { getAddress } from "./address";
 import * as superstruct from "superstruct";
+import { relayFeeCalculator } from "@across-protocol/sdk-v2";
 
 // all routes should be pre imported to be able to switch based on chain id
 import KovanRoutes from "data/routes_42_0x8d84F51710dfa9D409027B167371bBd79e0539e5.json";
@@ -536,3 +537,43 @@ export const routeConfig = getRoutes(hubPoolChainId);
 export const hubPoolAddress = routeConfig.hubPoolAddress;
 export const migrationPoolV2Warning =
   process.env.REACT_APP_MIGRATION_POOL_V2_WARNING;
+
+export const queriesTable: Record<
+  ChainId,
+  (provider: ethers.providers.Provider) => relayFeeCalculator.QueryInterface
+> = {
+  [ChainId.MAINNET]: (provider: ethers.providers.Provider) =>
+    new relayFeeCalculator.EthereumQueries(provider),
+  [ChainId.ARBITRUM]: (provider: ethers.providers.Provider) =>
+    new relayFeeCalculator.ArbitrumQueries(provider),
+  [ChainId.OPTIMISM]: (provider: ethers.providers.Provider) =>
+    new relayFeeCalculator.OptimismQueries(provider),
+  [ChainId.BOBA]: (provider: ethers.providers.Provider) =>
+    new relayFeeCalculator.BobaQueries(provider),
+  [ChainId.POLYGON]: (provider: ethers.providers.Provider) =>
+    new relayFeeCalculator.PolygonQueries(provider),
+  [ChainId.KOVAN]: (provider: ethers.providers.Provider) =>
+    new relayFeeCalculator.EthereumQueries(provider),
+  [ChainId.RINKEBY]: (provider: ethers.providers.Provider) =>
+    new relayFeeCalculator.EthereumQueries(provider),
+  [ChainId.GOERLI]: (provider: ethers.providers.Provider) =>
+    new relayFeeCalculator.EthereumQueries(provider),
+  [ChainId.MUMBAI]: (provider: ethers.providers.Provider) =>
+    new relayFeeCalculator.PolygonQueries(provider),
+  // Use hardcoded DAI address instead of USDC because DAI is enabled here.
+  [ChainId.KOVAN_OPTIMISM]: (provider: ethers.providers.Provider) =>
+    new relayFeeCalculator.OptimismQueries(
+      provider,
+      undefined,
+      "0x1954D4A36ac4fD8BEde42E59368565A92290E705",
+      "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
+    ),
+  // USe hardcoded WETH address instead of USDC because WETH is enabled here.
+  [ChainId.ARBITRUM_RINKEBY]: (provider: ethers.providers.Provider) =>
+    new relayFeeCalculator.ArbitrumQueries(
+      provider,
+      undefined,
+      "0x3BED21dAe767e4Df894B31b14aD32369cE4bad8b",
+      "0xB47e6A5f8b33b3F17603C83a0535A9dcD7E32681"
+    ),
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.1.2.tgz#32d162891cfdb3f6ca88e83be5975d68d46ad885"
-  integrity sha512-JesjfcnlPQZj1sbp1qZzAxEgBA7nTQBGGHgoIxq9lX3R8MpaLOFJqiLSu/2/JVqeHXD0mFf/k3qVGVi3ERjieA==
+"@across-protocol/sdk-v2@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.1.3.tgz#f5f14a8fa45c1fa4bc2e1b0c9f13f6f29f5968c1"
+  integrity sha512-5uD/LkSANe/v+IjUg+Dm25p50yNLGNBE3kHTmiKMsb4om7apk2j19ibo+qsRU/41B2WgZxgJMDoGQCt97LocJQ==
   dependencies:
     "@across-protocol/contracts-v2" "^0.0.50"
     "@eth-optimism/sdk" "^1.1.4"


### PR DESCRIPTION
This PR adds two features that come out of updates in the SDK:

1. It updates the way we get Query objects for computing gas costs on each chain (we now use chain-specific objects provided by the SDK).
2. It updates how we compute Network Gas Fees vs Bridge Fees. We group relayer capital costs and LP fees into bridge fees and put _only_ the relayer gas fees into gas fees.