### PR TITLE
fix: prevent amount and asset from resetting when switching chains

### DIFF
--- a/src/components/CoinSelection/useCoinSelection.tsx
+++ b/src/components/CoinSelection/useCoinSelection.tsx
@@ -60,18 +60,18 @@ export default function useCoinSelection() {
   );
 
   useEffect(() => {
-    if (inputAmount === "" || inputAmount === "0") {
+    if (!selectedItem || inputAmount === "" || inputAmount === "0") {
       setAmount(ethers.constants.Zero);
-      return;
-    }
-    try {
-      const amount = parseUnits(inputAmount, selectedItem?.decimals);
-      setAmount(amount);
-    } catch (e) {
-      // if we have a parsing error, we have to set this to 0 otherwise we might get fee calculation issues
-      setAmount(BigNumber.from(0));
-      // this can throw an error if parseUnits fails for an input amount that has more decimals than token decimals
-      setFormError(new ParsingError());
+    } else {
+      try {
+        const amount = parseUnits(inputAmount, selectedItem.decimals);
+        setAmount(amount);
+      } catch (e) {
+        // if we have a parsing error, we have to set this to 0 otherwise we might get fee calculation issues
+        setAmount(BigNumber.from(0));
+        // this can throw an error if parseUnits fails for an input amount that has more decimals than token decimals
+        setFormError(new ParsingError());
+      }
     }
   }, [inputAmount, selectedItem, setAmount, setFormError, tokenSymbol]);
 

--- a/src/hooks/useSendForm.tsx
+++ b/src/hooks/useSendForm.tsx
@@ -190,7 +190,7 @@ function fromChainReducer(state: FormState, chainId: ChainId): FormState {
     fromTokenSymbol: tokenSymbol,
   });
   // if no valid routes found with user selection, de-prioritize the toChain to maintain token symbol.
-  if (!selectedRoutes.length) {
+  if (selectedRoutes.length === 0) {
     selectedRoutes = config.filterRoutes({
       fromChain,
       fromTokenSymbol: tokenSymbol,


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

Previously form inputs would reset when changing any of the selections.  Now this will not reset the amount, and attempt to keep the token selection and chain selection the same. This does not work in all cases, where its an invalid selection it will try to prioritize resetting the toChain and then the token.

Also the ordering of tokens was fixed, its now set by the constants file token array. 