### PR TITLE
fix: stop showing bad cache balance values

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 - REACT_APP_CHAIN_42161_PROVIDER_URL: custom provider for Arbitrum node
 - REACT_APP_MIGRATION_POOL_V2_WARNING: Warns user to check liquidity on V1 on Pool tab when set to `true`.
 - REACT_APP_DEBUG: set to 1 (or any value) to enable debug logs. Leave undefined to disable logs.
+- REACT_APP_DEFAULT_BLOCK_POLLING_INTERVAL_S: How quickly to poll blocks on chain, default 30 seconds if not supplied.
 
 ## Internal Contributions
 

--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -10,7 +10,6 @@ import {
   ChainId,
   getConfig,
 } from "utils";
-import { usePrevious } from "hooks";
 import { BigNumber } from "ethers";
 
 export function useNativeBalance(
@@ -162,14 +161,6 @@ export function useBalancesBySymbols(
         "DISABLED_BALANCES_QUERY",
         { chainIdToQuery, tokenSymbols, accountToQuery, blockNumberToQuery },
       ];
-  const prevAccount = usePrevious(accountToQuery);
-  const prevChain = usePrevious(chainIdToQuery);
-  const prevTokens = usePrevious(tokenSymbols);
-  // Keep the previous data only when blockNumberToQuery changes.
-  const keepPreviousData =
-    prevAccount === accountToQuery &&
-    prevChain === chainIdToQuery &&
-    JSON.stringify(prevTokens) === JSON.stringify(tokenSymbols);
   const { data: balances, ...delegated } = useQuery(
     queryKey,
     async () => {
@@ -184,9 +175,6 @@ export function useBalancesBySymbols(
       enabled: enabledQuery,
       // We already re-fetch when the block change, so we don't need to re-fetch.
       staleTime: Infinity,
-      // Old balances can be garbage collected immediately
-      cacheTime: 0,
-      keepPreviousData,
     }
   );
   return {

--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -1,14 +1,14 @@
-import { useQuery } from "react-query";
+import { useQuery, useQueries } from "react-query";
 import { useConnection } from "state/hooks";
 import { useBlock } from "./useBlock";
+import { usePrevious } from "hooks";
 import {
   getBalance,
   getNativeBalance,
-  getBalancesBySymbols,
   balanceQueryKey,
-  balancesQueryKey,
   ChainId,
   getConfig,
+  ConfigClient,
 } from "utils";
 import { BigNumber } from "ethers";
 
@@ -35,12 +35,10 @@ export function useNativeBalance(
       )
     : [
         "DISABLED_BALANCE_QUERY",
-        {
-          chainIdToQuery,
-          tokenSymbolToQuery,
-          accountToQuery,
-          blockNumberToQuery,
-        },
+        chainIdToQuery,
+        tokenSymbolToQuery,
+        accountToQuery,
+        blockNumberToQuery,
       ];
   const { data: balance, ...delegated } = useQuery(
     queryKey,
@@ -59,6 +57,50 @@ export function useNativeBalance(
     ...delegated,
   };
 }
+
+// Shared logic for querying by symbol using parameters which might not be available.
+const QueryBalanceBySymbol =
+  (params: {
+    accountToQuery?: string;
+    chainIdToQuery?: ChainId;
+    tokenSymbolToQuery?: string;
+    blockNumberToQuery?: number;
+    config: ConfigClient;
+  }) =>
+  async () => {
+    const {
+      accountToQuery,
+      chainIdToQuery,
+      tokenSymbolToQuery,
+      blockNumberToQuery,
+      config,
+    } = params;
+    if (
+      !chainIdToQuery ||
+      !tokenSymbolToQuery ||
+      !blockNumberToQuery ||
+      !accountToQuery
+    )
+      return BigNumber.from(0);
+    const tokenInfo = config.getTokenInfoBySymbol(
+      chainIdToQuery,
+      tokenSymbolToQuery
+    );
+    if (tokenInfo.isNative) {
+      return getNativeBalance(
+        chainIdToQuery,
+        accountToQuery,
+        blockNumberToQuery
+      );
+    } else {
+      return getBalance(
+        chainIdToQuery,
+        accountToQuery,
+        tokenInfo.address,
+        blockNumberToQuery
+      );
+    }
+  };
 /**
  * @param token - The token to fetch the balance of.
  * @param chainId - The chain Id of the chain to execute the query on. If not specified, defaults to the chainId the user is connected to or undefined.
@@ -90,33 +132,21 @@ export function useBalanceBySymbol(
       )
     : [
         "DISABLED_BALANCE_QUERY",
-        {
-          chainIdToQuery,
-          tokenSymbolToQuery,
-          accountToQuery,
-          blockNumberToQuery,
-        },
+        chainIdToQuery,
+        tokenSymbolToQuery,
+        accountToQuery,
+        blockNumberToQuery,
       ];
   const config = getConfig();
   const { data: balance, ...delegated } = useQuery(
     queryKey,
-    async () => {
-      if (!chainIdToQuery || !tokenSymbolToQuery) return BigNumber.from(0);
-      const tokenInfo = config.getTokenInfoBySymbol(
-        chainIdToQuery,
-        tokenSymbolToQuery
-      );
-      if (tokenInfo.isNative) {
-        return getNativeBalance(chainId, accountToQuery!, blockNumberToQuery);
-      } else {
-        return getBalance(
-          chainId,
-          accountToQuery!,
-          tokenInfo.address,
-          blockNumberToQuery
-        );
-      }
-    },
+    QueryBalanceBySymbol({
+      config,
+      chainIdToQuery,
+      tokenSymbolToQuery,
+      blockNumberToQuery,
+      accountToQuery,
+    }),
     {
       enabled: enabledQuery,
       // We already re-fetch when the block number changes, so we don't need to re-fetch.
@@ -142,43 +172,54 @@ export function useBalancesBySymbols(
   account?: string,
   blockNumber?: number
 ) {
+  const config = getConfig();
   const { account: connectedAccount } = useConnection();
   const chainIdToQuery = chainId;
   const accountToQuery = account ?? connectedAccount;
   const { block: latestBlock } = useBlock(chainId);
   const blockNumberToQuery = blockNumber ?? latestBlock?.number;
-  // To fetch balances, we need a list of tokens, an account to get balances of, and a specified chainId.
-  const enabledQuery =
-    !!chainIdToQuery && !!accountToQuery && !!blockNumberToQuery;
-  const queryKey = enabledQuery
-    ? balancesQueryKey(
-        tokenSymbols,
-        accountToQuery,
-        blockNumberToQuery,
-        chainIdToQuery
-      )
-    : [
-        "DISABLED_BALANCES_QUERY",
-        { chainIdToQuery, tokenSymbols, accountToQuery, blockNumberToQuery },
-      ];
-  const { data: balances, ...delegated } = useQuery(
-    queryKey,
-    async () => {
-      return getBalancesBySymbols(
-        chainId!,
-        tokenSymbols,
-        accountToQuery!,
-        blockNumberToQuery
-      );
-    },
-    {
-      enabled: enabledQuery,
-      // We already re-fetch when the block change, so we don't need to re-fetch.
+  const prevAccount = usePrevious(accountToQuery);
+  const prevChain = usePrevious(chainIdToQuery);
+  const prevTokens = usePrevious(tokenSymbols);
+  // Keep the previous data only when blockNumberToQuery changes.
+  const keepPreviousData =
+    prevAccount === accountToQuery &&
+    prevChain === chainIdToQuery &&
+    JSON.stringify(prevTokens) === JSON.stringify(tokenSymbols);
+  const enabled = !!chainIdToQuery && !!accountToQuery && !!blockNumberToQuery;
+  // we use useQueries instead of useQuery so we can share cache values with the singular balance query
+  const queries = tokenSymbols.map((tokenSymbolToQuery) => {
+    const queryKey = enabled
+      ? balanceQueryKey(
+          accountToQuery,
+          blockNumberToQuery,
+          chainIdToQuery,
+          tokenSymbolToQuery
+        )
+      : [
+          "DISABLED_BALANCE_QUERY",
+          chainIdToQuery,
+          tokenSymbolToQuery,
+          accountToQuery,
+          blockNumberToQuery,
+        ];
+    const queryFn = QueryBalanceBySymbol({
+      config,
+      chainIdToQuery,
+      tokenSymbolToQuery,
+      blockNumberToQuery,
+      accountToQuery,
+    });
+    return {
+      queryKey,
+      queryFn,
       staleTime: Infinity,
-    }
-  );
+      keepPreviousData,
+      enabled,
+    };
+  });
+  const result = useQueries(queries);
   return {
-    balances,
-    ...delegated,
+    balances: result.map((result) => result.data),
   };
 }

--- a/src/hooks/useBlock.ts
+++ b/src/hooks/useBlock.ts
@@ -18,7 +18,7 @@ export function useBlock(chainId?: ChainId) {
   const { data: block, ...delegated } = useQuery(
     queryKey,
     async () => {
-      return await getBlock(chainId!);
+      return getBlock(chainId!);
     },
     {
       // refetch based on the chain polling interval

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -119,9 +119,8 @@ export type ChainInfo = {
 
 export type ChainInfoList = ChainInfo[];
 export type ChainInfoTable = Record<number, ChainInfo>;
-export const defaultBlockPollingInterval = Number(
-  process.env.REACT_APP_DEFAULT_BLOCK_POLLING_INTERVAL || 30 * 1000
-);
+export const defaultBlockPollingInterval =
+  Number(process.env.REACT_APP_DEFAULT_BLOCK_POLLING_INTERVAL_S || 30) * 1000;
 
 const defaultConstructExplorerLink =
   (explorerUrl: string) => (txHash: string) =>

--- a/src/utils/query-keys.ts
+++ b/src/utils/query-keys.ts
@@ -41,7 +41,7 @@ export function balancesQueryKey(
   blockNumber: number,
   chainId?: ChainId
 ) {
-  return ["balances", chainId, tokenSymbols, account, blockNumber];
+  return ["balances", chainId, tokenSymbols.join(","), account, blockNumber];
 }
 /**
  * @param tokenSymbol  The token symbol to check bridge fees for.

--- a/src/utils/query-keys.ts
+++ b/src/utils/query-keys.ts
@@ -20,29 +20,13 @@ export function latestBlockQueryKey(chainId: ChainId) {
  */
 export function balanceQueryKey(
   account: string,
-  blockNumber: number,
+  blockNumber?: number,
   chainId?: ChainId,
   token?: string
 ) {
   return ["balance", chainId, token, account, blockNumber];
 }
 
-/**
- * Generates query keys for react-query `useQuery` hook, used in the `useBalances` hook.
- * @param chainId  The chain Id of the chain to execute the query on.
- * @param tokens  The tokens to fetch the balance of.
- * @param account  The account to query the balances of.
- * @param blockNumber  The block number to execute the query on.
- * @returns An array of query keys for react-query `useQuery` hook.
- */
-export function balancesQueryKey(
-  tokenSymbols: string[],
-  account: string,
-  blockNumber: number,
-  chainId?: ChainId
-) {
-  return ["balances", chainId, tokenSymbols.join(","), account, blockNumber];
-}
 /**
  * @param tokenSymbol  The token symbol to check bridge fees for.
  * @param amount  The amount to check bridge fees for.

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -29,34 +29,6 @@ export function getBalance(
   return contract.balanceOf(account, { blockTag: blockNumber });
 }
 
-// TODO: switch to a multicall implementation
-/**
- *
- * @param chainId The chain Id of the chain to query
- * @param tokens An array of tokens to fetch the balances of.
- * @param account The account to query the balances of.
- * @param blockNumber The block number to execute the query.
- * @returns A Promise that resolves to an array of balances of the account
- */
-export function getBalancesBySymbols(
-  chainId: ChainId,
-  tokenSymbols: string[],
-  account: string,
-  blockNumber?: number
-): Promise<ethers.BigNumber[]> {
-  const config = getConfig();
-  return Promise.all(
-    tokenSymbols.map((tokenSymbol) => {
-      const tokenInfo = config.getTokenInfoBySymbol(chainId, tokenSymbol);
-      if (tokenInfo.isNative) {
-        return getNativeBalance(chainId, account, blockNumber);
-      } else {
-        return getBalance(chainId, account, tokenInfo.address, blockNumber);
-      }
-    })
-  );
-}
-
 /**
  *
  * @param chainId  The chain Id of the chain to query


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>


The issue was that a bad balance would flash for a second when switching from chain. 

I dont know exactly what this code did but with it in, it would flash an incorrect balance for a second. With this code the balance goes blank once selecting a new from chain, resolving the issue. 