### PR TITLE
fix: display properly partial fill %

### DIFF
--- a/src/views/Transactions/TransactionsTable/createTransactionTableJSX.tsx
+++ b/src/views/Transactions/TransactionsTable/createTransactionTableJSX.tsx
@@ -67,7 +67,7 @@ function formatTransactionRows(
       value: capitalizeFirstLetter(tx.status),
     };
 
-    const fp = tx.filled.div(tx.amount).mul(100);
+    const fp = tx.filled.mul(100).div(tx.amount);
     const filled: ICell = {
       size: "xs",
       value: `${


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

Partial filled deposits were displayed as 0%. This quick PR fixes the math calculation