### PR TITLE
fix: refetch all pool balances on token changes

### DIFF
--- a/src/views/Pool.tsx
+++ b/src/views/Pool.tsx
@@ -96,14 +96,9 @@ const Pool: FC = () => {
       })
       .finally(() => {
         setLoadingPoolState(false);
-        // lazily load other pools
-        const otherPools = tokenList.filter((x) => x.address !== address);
-        otherPools.forEach((x) => {
-          poolClient.updatePool(x.address);
-        });
+        refetchBalance();
       });
-    // eslint-disable-next-line
-  }, [token, setLoadingPoolState, poolClient]);
+  }, [token, setLoadingPoolState, poolClient, refetchBalance]);
 
   useEffect(() => {
     if (isConnected && connection.account && token.address) {

--- a/src/views/Pool.tsx
+++ b/src/views/Pool.tsx
@@ -97,7 +97,12 @@ const Pool: FC = () => {
       .finally(() => {
         setLoadingPoolState(false);
       });
-  }, [token, setLoadingPoolState, poolClient]);
+    // lazily load other pools
+    const otherPools = tokenList.filter((x) => x.address !== address);
+    otherPools.forEach((x) => {
+      poolClient.updatePool(x.address);
+    });
+  }, [token, setLoadingPoolState, poolClient, tokenList]);
 
   useEffect(() => {
     if (isConnected && connection.account && token.address) {

--- a/src/views/Pool.tsx
+++ b/src/views/Pool.tsx
@@ -96,13 +96,14 @@ const Pool: FC = () => {
       })
       .finally(() => {
         setLoadingPoolState(false);
+        // lazily load other pools
+        const otherPools = tokenList.filter((x) => x.address !== address);
+        otherPools.forEach((x) => {
+          poolClient.updatePool(x.address);
+        });
       });
-    // lazily load other pools
-    const otherPools = tokenList.filter((x) => x.address !== address);
-    otherPools.forEach((x) => {
-      poolClient.updatePool(x.address);
-    });
-  }, [token, setLoadingPoolState, poolClient, tokenList]);
+    // eslint-disable-next-line
+  }, [token, setLoadingPoolState, poolClient]);
 
   useEffect(() => {
     if (isConnected && connection.account && token.address) {


### PR DESCRIPTION
Update all pools on change instead of the singular one.