### PR TITLE
fix: Do a check on overrided address if it's a contract code and show a warning.

### DIFF
--- a/src/components/AddressSelection/AddressSelection.styles.ts
+++ b/src/components/AddressSelection/AddressSelection.styles.ts
@@ -143,6 +143,15 @@ export const WarningBox = styled(ErrorBox)`
   margin-top: 20px;
 `;
 
+export const WarningButton = styled(PrimaryButton)`
+  display: block;
+  margin: 0 auto;
+  background-color: var(--color-gray);
+  color: var(--color-white);
+  margin-top: 12px;
+  margin-bottom: 16px;
+`;
+
 export const Item = motion(styled.li`
   padding: 15px 10px 10px;
   display: flex;

--- a/src/components/AddressSelection/AddressSelection.styles.ts
+++ b/src/components/AddressSelection/AddressSelection.styles.ts
@@ -141,15 +141,45 @@ export const Menu = styled.ul<MenuProps>`
 
 export const WarningBox = styled(ErrorBox)`
   margin-top: 20px;
-`;
+  div {
+    margin-top: 4px;
+    cursor: pointer;
+  }
 
-export const WarningButton = styled(PrimaryButton)`
-  display: block;
-  margin: 0 auto;
-  background-color: var(--color-gray);
-  color: var(--color-white);
-  margin-top: 12px;
-  margin-bottom: 16px;
+  input[type="checkbox"] {
+    display: none;
+    margin-left: 0;
+  }
+  input[type="checkbox"] + span {
+    display: inline-block;
+    position: relative;
+    width: 14px;
+    height: 14px;
+    margin: -1px 6px 0 0;
+    vertical-align: middle;
+    background: #f5f4f4 left top no-repeat;
+    border: 1px solid #ccc;
+    cursor: pointer;
+    > span {
+      display: none;
+    }
+  }
+  input[type="checkbox"]:checked + span {
+    background: #0073cd -19px top no-repeat;
+    span:first-of-type {
+      position: absolute;
+      display: block;
+      left: 4px;
+      top: 0px;
+      width: 5px;
+      height: 10px;
+      border: solid white;
+      border-width: 0 3px 3px 0;
+      -webkit-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      transform: rotate(45deg);
+    }
+  }
 `;
 
 export const Item = motion(styled.li`

--- a/src/components/AddressSelection/AddressSelection.styles.ts
+++ b/src/components/AddressSelection/AddressSelection.styles.ts
@@ -3,7 +3,7 @@ import { Section } from "../Section";
 import { PrimaryButton, BaseButton } from "../Buttons";
 import { ChevronDown } from "react-feather";
 import { motion } from "framer-motion";
-import { RoundBox as UnstyledBox } from "../Box";
+import { RoundBox as UnstyledBox, ErrorBox } from "../Box";
 
 export const LastSection = styled(Section)`
   border-bottom: none;
@@ -137,6 +137,10 @@ export const Menu = styled.ul<MenuProps>`
   width: 95%;
   margin: 0 auto;
   box-shadow: inset 0 8px 8% rgba(45, 46, 51, 0.2);
+`;
+
+export const WarningBox = styled(ErrorBox)`
+  margin-top: 20px;
 `;
 
 export const Item = motion(styled.li`

--- a/src/components/AddressSelection/AddressSelection.tsx
+++ b/src/components/AddressSelection/AddressSelection.tsx
@@ -24,6 +24,7 @@ import {
   RoundBox,
   ToggleChainName,
   Address,
+  WarningBox,
 } from "./AddressSelection.styles";
 import { AnimatePresence } from "framer-motion";
 import useAddressSelection from "./useAddressSelection";
@@ -47,6 +48,7 @@ const AddressSelection: React.FC = () => {
     availableToChains,
     selectedToChainInfo,
     fromChain,
+    showContractAddressWarning,
   } = useAddressSelection();
 
   return (
@@ -130,6 +132,13 @@ const AddressSelection: React.FC = () => {
                 Save Changes
               </SecondaryButton>
             </ButtonGroup>
+            {showContractAddressWarning && (
+              <WarningBox>
+                {`
+              Warning --- Address you inputted is a contract address. When sending ETH from L2 -> L1 WETH will arrive. Ensure the contract address will properly handle WETH or this may result in loss of funds.
+            `}
+              </WarningBox>
+            )}
           </Dialog>
         )}
       </LastSection>

--- a/src/components/AddressSelection/AddressSelection.tsx
+++ b/src/components/AddressSelection/AddressSelection.tsx
@@ -25,6 +25,7 @@ import {
   ToggleChainName,
   Address,
   WarningBox,
+  WarningButton,
 } from "./AddressSelection.styles";
 import { AnimatePresence } from "framer-motion";
 import useAddressSelection from "./useAddressSelection";
@@ -49,6 +50,7 @@ const AddressSelection: React.FC = () => {
     selectedToChainInfo,
     fromChain,
     showContractAddressWarning,
+    overrideAddress,
   } = useAddressSelection();
 
   return (
@@ -137,6 +139,9 @@ const AddressSelection: React.FC = () => {
                 {`
               Warning --- Address you inputted is a contract address. When sending ETH from L2 -> L1 WETH will arrive. Ensure the contract address will properly handle WETH or this may result in loss of funds.
             `}
+                <WarningButton onClick={overrideAddress}>
+                  Save Contract Address
+                </WarningButton>
               </WarningBox>
             )}
           </Dialog>

--- a/src/components/AddressSelection/AddressSelection.tsx
+++ b/src/components/AddressSelection/AddressSelection.tsx
@@ -25,7 +25,6 @@ import {
   ToggleChainName,
   Address,
   WarningBox,
-  WarningButton,
 } from "./AddressSelection.styles";
 import { AnimatePresence } from "framer-motion";
 import useAddressSelection from "./useAddressSelection";
@@ -52,6 +51,8 @@ const AddressSelection: React.FC = () => {
     fromChain,
     showContractAddressWarning,
     overrideAddress,
+    checked,
+    setChecked,
   } = useAddressSelection();
 
   return (
@@ -131,16 +132,34 @@ const AddressSelection: React.FC = () => {
             </InputWrapper>
             <ButtonGroup>
               <CancelButton onClick={toggle}>Cancel</CancelButton>
-              <SecondaryButton onClick={handleSubmit} disabled={!isValid}>
-                Save Changes
-              </SecondaryButton>
+              {!showContractAddressWarning ? (
+                <SecondaryButton onClick={handleSubmit} disabled={!isValid}>
+                  Save Changes
+                </SecondaryButton>
+              ) : (
+                <SecondaryButton onClick={overrideAddress} disabled={!checked}>
+                  Override Address
+                </SecondaryButton>
+              )}
             </ButtonGroup>
             {showContractAddressWarning && (
               <WarningBox>
                 {warningMessage}
-                <WarningButton onClick={overrideAddress}>
-                  Save Contract Address
-                </WarningButton>
+                <div onClick={() => setChecked((pv) => !pv)}>
+                  <input
+                    checked={checked}
+                    type="checkbox"
+                    onChange={(event) => {
+                      console.log("clicked?");
+                      setChecked(event.target.checked);
+                    }}
+                  />
+                  <span>
+                    <span />
+                    <span />
+                  </span>
+                  I understand the risks
+                </div>
               </WarningBox>
             )}
           </Dialog>

--- a/src/components/AddressSelection/AddressSelection.tsx
+++ b/src/components/AddressSelection/AddressSelection.tsx
@@ -30,6 +30,7 @@ import {
 import { AnimatePresence } from "framer-motion";
 import useAddressSelection from "./useAddressSelection";
 
+const warningMessage = `Warning --- Address you inputted is a contract address. When sending ETH across chains WETH will arrive. Ensure the contract address will properly handle WETH or send to a different EOA and convert your WETH to ETH and send to the contract address, or this may result in loss of funds.`;
 const AddressSelection: React.FC = () => {
   const {
     getItemProps,
@@ -136,9 +137,7 @@ const AddressSelection: React.FC = () => {
             </ButtonGroup>
             {showContractAddressWarning && (
               <WarningBox>
-                {`
-              Warning --- Address you inputted is a contract address. When sending ETH from L2 -> L1 WETH will arrive. Ensure the contract address will properly handle WETH or this may result in loss of funds.
-            `}
+                {warningMessage}
                 <WarningButton onClick={overrideAddress}>
                   Save Contract Address
                 </WarningButton>

--- a/src/components/AddressSelection/AddressSelection.tsx
+++ b/src/components/AddressSelection/AddressSelection.tsx
@@ -150,7 +150,6 @@ const AddressSelection: React.FC = () => {
                     checked={checked}
                     type="checkbox"
                     onChange={(event) => {
-                      console.log("clicked?");
                       setChecked(event.target.checked);
                     }}
                   />

--- a/src/components/AddressSelection/AddressSelection.tsx
+++ b/src/components/AddressSelection/AddressSelection.tsx
@@ -29,7 +29,7 @@ import {
 import { AnimatePresence } from "framer-motion";
 import useAddressSelection from "./useAddressSelection";
 
-const warningMessage = `Warning --- Address you inputted is a contract address. When sending ETH across chains WETH will arrive. Ensure the contract address will properly handle WETH or send to a different EOA and convert your WETH to ETH and send to the contract address, or this may result in loss of funds.`;
+const warningMessage = `Warning --- You've inputted a contract address. When bridging ETH to a contract address, ETH will be wrapped into WETH. Ensure the contract address can receive WETH. If you are not sure whether it can, then you should send to a non-contract address to be safe and receive ETH to prevent any chance of a loss of funds.`;
 const AddressSelection: React.FC = () => {
   const {
     getItemProps,

--- a/src/components/AddressSelection/useAddressSelection.ts
+++ b/src/components/AddressSelection/useAddressSelection.ts
@@ -2,7 +2,13 @@ import { useSelect } from "downshift";
 import { useState, useEffect } from "react";
 import { useConnection } from "state/hooks";
 import { useSendForm } from "hooks";
-import { isValidAddress, getChainInfo, trackEvent } from "utils";
+import {
+  isValidAddress,
+  getChainInfo,
+  trackEvent,
+  ChainId,
+  getCode,
+} from "utils";
 
 export default function useAddressSelection() {
   const { isConnected, account } = useConnection();
@@ -16,6 +22,8 @@ export default function useAddressSelection() {
   } = useSendForm();
   const [address, setAddress] = useState("");
   const [open, setOpen] = useState(false);
+  const [showContractAddressWarning, setShowContractAddressWarning] =
+    useState(false);
 
   const selectedToChainInfo = toChain ? getChainInfo(toChain) : undefined;
 
@@ -37,10 +45,20 @@ export default function useAddressSelection() {
 
   // keep the address in sync with the form address
   useEffect(() => {
+    setShowContractAddressWarning(false);
     if (toAddress) {
       setAddress(toAddress);
+      if (toChain === ChainId.MAINNET) {
+        getCode(toAddress)
+          .then((res) => {
+            console.log("res", res);
+          })
+          .catch((err) => {
+            console.log("err in getCode call", err);
+          });
+      }
     }
-  }, [toAddress]);
+  }, [toAddress, toChain]);
   // modal is closing, reset address to the current toAddress
   const toggle = () => {
     if (!isConnected) return;

--- a/src/components/AddressSelection/useAddressSelection.ts
+++ b/src/components/AddressSelection/useAddressSelection.ts
@@ -69,7 +69,7 @@ export default function useAddressSelection() {
   const isValid = !address || isValidAddress(address);
   const handleSubmit = () => {
     setShowContractAddressWarning(false);
-    console.log("tokenSymbol", tokenSymbol);
+
     if (isValid) {
       if (address) {
         if (address && toChain) {

--- a/src/components/AddressSelection/useAddressSelection.ts
+++ b/src/components/AddressSelection/useAddressSelection.ts
@@ -77,6 +77,11 @@ export default function useAddressSelection() {
   };
   const isValid = !address || isValidAddress(address);
   const handleSubmit = () => {
+    // Override save func is they click it twice.
+    if (showContractAddressWarning && address) {
+      setToAddress(address);
+    }
+
     setShowContractAddressWarning(false);
     if (isValid) {
       if (address) {

--- a/src/components/AddressSelection/useAddressSelection.ts
+++ b/src/components/AddressSelection/useAddressSelection.ts
@@ -23,6 +23,7 @@ export default function useAddressSelection() {
   } = useSendForm();
   const [address, setAddress] = useState("");
   const [open, setOpen] = useState(false);
+  const [checked, setChecked] = useState(false);
   const [showContractAddressWarning, setShowContractAddressWarning] =
     useState(false);
 
@@ -121,5 +122,7 @@ export default function useAddressSelection() {
     selectedToChainInfo,
     showContractAddressWarning,
     overrideAddress,
+    checked,
+    setChecked,
   };
 }

--- a/src/components/AddressSelection/useAddressSelection.ts
+++ b/src/components/AddressSelection/useAddressSelection.ts
@@ -77,11 +77,6 @@ export default function useAddressSelection() {
   };
   const isValid = !address || isValidAddress(address);
   const handleSubmit = () => {
-    // Override save func is they click it twice.
-    if (showContractAddressWarning && address) {
-      setToAddress(address);
-    }
-
     setShowContractAddressWarning(false);
     if (isValid) {
       if (address) {
@@ -108,6 +103,12 @@ export default function useAddressSelection() {
     }
   };
 
+  const overrideAddress = () => {
+    setToAddress(address);
+    toggle();
+    setShowContractAddressWarning(false);
+  };
+
   return {
     ...downshiftState,
     handleSubmit,
@@ -124,5 +125,6 @@ export default function useAddressSelection() {
     availableToChains,
     selectedToChainInfo,
     showContractAddressWarning,
+    overrideAddress,
   };
 }

--- a/src/components/AddressSelection/useAddressSelection.ts
+++ b/src/components/AddressSelection/useAddressSelection.ts
@@ -62,10 +62,16 @@ export default function useAddressSelection() {
   };
   const clearInput = () => {
     setAddress("");
+    setShowContractAddressWarning(false);
+    setChecked(false);
   };
 
   const handleAddressChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
     setAddress(evt.target.value);
+    if (showContractAddressWarning) {
+      setShowContractAddressWarning(false);
+      setChecked(false);
+    }
   };
   const isValid = !address || isValidAddress(address);
   const handleSubmit = () => {
@@ -99,6 +105,7 @@ export default function useAddressSelection() {
     setToAddress(address);
     toggle();
     setShowContractAddressWarning(false);
+    setChecked(false);
   };
 
   return {

--- a/src/components/AddressSelection/useAddressSelection.ts
+++ b/src/components/AddressSelection/useAddressSelection.ts
@@ -71,27 +71,25 @@ export default function useAddressSelection() {
     setShowContractAddressWarning(false);
 
     if (isValid) {
-      if (address) {
-        if (address && toChain) {
-          // Check to see if the toAddress they are inputting is a Contract on Mainnet
-          // If so, warn user because we send WETH and this could cause loss of funds.
-          if (tokenSymbol === "ETH" || tokenSymbol === "WETH") {
-            getCode(address, toChain)
-              .then((addr) => {
-                if (addr !== noContractCode) {
-                  setShowContractAddressWarning(true);
-                } else {
-                  setToAddress(address);
-                  toggle();
-                }
-              })
-              .catch((err) => {
-                console.log("err in getCode call", err);
-              });
-          } else {
-            setToAddress(address);
-            toggle();
-          }
+      if (address && toChain) {
+        // Check to see if the toAddress they are inputting is a Contract on Mainnet
+        // If so, warn user because we send WETH and this could cause loss of funds.
+        if (tokenSymbol === "ETH" || tokenSymbol === "WETH") {
+          getCode(address, toChain)
+            .then((addr) => {
+              if (addr !== noContractCode) {
+                setShowContractAddressWarning(true);
+              } else {
+                setToAddress(address);
+                toggle();
+              }
+            })
+            .catch((err) => {
+              console.log("err in getCode call", err);
+            });
+        } else {
+          setToAddress(address);
+          toggle();
         }
       } else if (account) {
         setToAddress(account);

--- a/src/components/AddressSelection/useAddressSelection.ts
+++ b/src/components/AddressSelection/useAddressSelection.ts
@@ -19,8 +19,8 @@ export default function useAddressSelection() {
     setToAddress,
     availableToChains,
     toAddress,
-    tokenSymbol,
   } = useSendForm();
+
   const [address, setAddress] = useState("");
   const [open, setOpen] = useState(false);
   const [checked, setChecked] = useState(false);
@@ -75,23 +75,19 @@ export default function useAddressSelection() {
       if (address && toChain) {
         // Check to see if the toAddress they are inputting is a Contract on Mainnet
         // If so, warn user because we send WETH and this could cause loss of funds.
-        if (tokenSymbol === "ETH" || tokenSymbol === "WETH") {
-          getCode(address, toChain)
-            .then((addr) => {
-              if (addr !== noContractCode) {
-                setShowContractAddressWarning(true);
-              } else {
-                setToAddress(address);
-                toggle();
-              }
-            })
-            .catch((err) => {
-              console.log("err in getCode call", err);
-            });
-        } else {
-          setToAddress(address);
-          toggle();
-        }
+        // Note: Removed check for WETH and ETH because they can change tokens outside of this modal.
+        getCode(address, toChain)
+          .then((addr) => {
+            if (addr !== noContractCode) {
+              setShowContractAddressWarning(true);
+            } else {
+              setToAddress(address);
+              toggle();
+            }
+          })
+          .catch((err) => {
+            console.log("err in getCode call", err);
+          });
       } else if (account) {
         setToAddress(account);
         toggle();

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -9,7 +9,7 @@ export function getAddress(address: string) {
 }
 
 const defaultProvider = ethers.getDefaultProvider();
-
+export const noContractCode = "0x";
 export async function getCode(address: string) {
   return await defaultProvider.getCode(address);
 }

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -7,3 +7,9 @@ export function isValidAddress(address: string) {
 export function getAddress(address: string) {
   return ethers.utils.getAddress(address);
 }
+
+const defaultProvider = ethers.getDefaultProvider();
+
+export async function getCode(address: string) {
+  return await defaultProvider.getCode(address);
+}

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,5 +1,5 @@
+import { ChainId, getProvider } from "utils";
 import { ethers } from "ethers";
-
 export function isValidAddress(address: string) {
   return ethers.utils.isAddress(address);
 }
@@ -8,8 +8,8 @@ export function getAddress(address: string) {
   return ethers.utils.getAddress(address);
 }
 
-const defaultProvider = ethers.getDefaultProvider();
 export const noContractCode = "0x";
-export async function getCode(address: string) {
-  return await defaultProvider.getCode(address);
+export async function getCode(address: string, chainId: ChainId) {
+  const provider = getProvider(chainId);
+  return await provider.getCode(address);
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -430,7 +430,6 @@ export const ArbitrumProviderUrl =
   process.env.REACT_APP_CHAIN_42161_PROVIDER_URL ||
   `https://arbitrum-mainnet.infura.io/v3/${infuraId}`;
 
-console.log(ArbitrumProviderUrl);
 export const PolygonProviderUrl =
   process.env.REACT_APP_CHAIN_137_PROVIDER_URL ||
   `https://polygon-mainnet.infura.io/v3/${infuraId}`;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -429,6 +429,8 @@ export const AddressZero = ethers.constants.AddressZero;
 export const ArbitrumProviderUrl =
   process.env.REACT_APP_CHAIN_42161_PROVIDER_URL ||
   `https://arbitrum-mainnet.infura.io/v3/${infuraId}`;
+
+console.log(ArbitrumProviderUrl);
 export const PolygonProviderUrl =
   process.env.REACT_APP_CHAIN_137_PROVIDER_URL ||
   `https://polygon-mainnet.infura.io/v3/${infuraId}`;


### PR DESCRIPTION
Story details: https://app.shortcut.com/uma-project/story/5675/warn-user-that-if-they-re-setting-deposit-recipient-to-a-smart-contract-that-they-will-receive-weth-therefore-tell-them-not

Do getCode(address) call to check if the address inputted is a Contract. If so, show a warning.

To test: Set bridge currency to ETH or WETH, adjust address manually to a known contract address on the toChain, then try to save the address.
<img width="631" alt="Screen Shot 2022-06-03 at 1 29 39 PM" src="https://user-images.githubusercontent.com/12792146/171947699-3442cd48-db60-486a-b649-08265502e46e.png">

