### PR TITLE
fix: max bridge with weth

### DIFF
--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -67,7 +67,7 @@ export function useBridge() {
     fromChain && chainId && chainId !== fromChain
   );
   let { status, error } = computeStatus({
-    tokenAddress: tokenInfo?.address,
+    tokenSymbol: tokenInfo?.symbol,
     amount,
     formStatus,
     hasToSwitchChain,
@@ -157,7 +157,7 @@ type Fees = {
   isAmountTooLow: boolean;
 };
 type ComputeStatusArgs = {
-  tokenAddress?: string;
+  tokenSymbol?: string;
   amount: ethers.BigNumber;
   formStatus: FormStatus;
   hasToSwitchChain: boolean;
@@ -177,11 +177,11 @@ function computeStatus({
   amount,
   balance,
   fees,
-  tokenAddress,
+  tokenSymbol,
   fromChain,
 }: ComputeStatusArgs): { status: SendStatus; error?: SendError } {
   const config = getConfig();
-  if (!tokenAddress) {
+  if (!tokenSymbol) {
     return { status: SendStatus.IDLE };
   }
   if (!fromChain) {
@@ -196,9 +196,9 @@ function computeStatus({
       error: new WrongNetworkError(fromChain),
     };
   }
-  const { isNative, decimals } = config.getTokenInfoByAddress(
+  const { isNative, decimals } = config.getTokenInfoBySymbol(
     fromChain,
-    tokenAddress
+    tokenSymbol
   );
   if (balance) {
     const adjustedBalance = isNative
@@ -215,7 +215,7 @@ function computeStatus({
     if (fees.isLiquidityInsufficient) {
       return {
         status: SendStatus.ERROR,
-        error: new InsufficientLiquidityError(tokenAddress),
+        error: new InsufficientLiquidityError(tokenSymbol),
       };
     }
     if (fees.isAmountTooLow) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -155,6 +155,7 @@ export class ConfigClient {
         };
       });
   }
+  // this has a chance to mix up eth/weth which can be a problem. prefer token by symbol.
   getTokenInfoByAddress(chainId: number, address: string): Token {
     const tokens = this.getTokenList(chainId);
     const token = tokens.find((token) => token.address === address);


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

Finding token info by address actually was returning eth, so gas was being subtracted from max preventing it from sending.  the solution is to lookup token by symbol to find out if its native or not.