### PR TITLE
fix: fix cut modals

### DIFF
--- a/src/components/Dialog/Dialog.styles.tsx
+++ b/src/components/Dialog/Dialog.styles.tsx
@@ -2,23 +2,49 @@ import styled from "@emotion/styled";
 import { DialogContent, DialogOverlay } from "@reach/dialog";
 import { COLORS, QUERIES } from "utils";
 
+export const Overlay = styled(DialogOverlay)`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: hsla(${COLORS.gray[500]} / 0.9);
+  display: flex;
+  padding: 20px;
+`;
+
+export const Content = styled.div`
+  padding: 10px 25px;
+  width: 100%;
+  overflow: auto;
+
+  ::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background-color: var(--color-primary);
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: var(--color-gray-300);
+    border-radius: 5px;
+    box-shadow: inset 0 0 0 1px var(--color-primary);
+  }
+`;
+
 export const Wrapper = styled(DialogContent)`
   position: relative;
-  padding: 20px 25px;
+  display: flex;
+  margin: auto;
+  padding: 10px 0;
   background-color: var(--color-primary);
   color: var(--color-gray);
   outline: none;
   border-radius: 12px;
   max-width: 440px;
-  width: min(440px, calc(100% - 20px));
-  top: 25%;
-  overflow: auto;
-  min-height: 30vh;
-  max-height: 80vh;
-  @media ${QUERIES.tabletAndUp} {
-    top: 30%;
-    min-height: 20vh;
-  }
+  max-height: 100%;
+  min-width: min(440px, calc(100% - 20px));
 `;
 
 export const CloseButton = styled.button`
@@ -31,16 +57,4 @@ export const CloseButton = styled.button`
   border: none;
   outline: none;
   cursor: pointer;
-`;
-
-export const Overlay = styled(DialogOverlay)`
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: hsla(${COLORS.gray[500]} / 0.9);
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
 `;

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { X } from "react-feather";
-import { Overlay, Wrapper, CloseButton } from "./Dialog.styles";
+import { Overlay, Wrapper, CloseButton, Content } from "./Dialog.styles";
 
 type Props = {
   isOpen: boolean;
@@ -13,7 +13,7 @@ const Dialog: React.FC<Props> = ({ isOpen, onClose, children }) => (
       <CloseButton onClick={onClose}>
         <X />
       </CloseButton>
-      <div>{children}</div>
+      <Content>{children}</Content>
     </Wrapper>
   </Overlay>
 );


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

<!--
If you need QA on your PR include the following section in your code. This will alert the QA team
that they should be testing.  Engineers should use github emojis to :heart: :+1: if the QA comments are productive
or :-1: if the QA comments are hindering productivity. Its up to your own discretion to award emojis, but its encouraged
to do so since we can use this information to incentivise and reward QA testers.
-->

## Needs QA

**Overview**

<!--
Give context around the change, anything that would help the testers understand the issue, feature and the changes made.
Don't expect them to look at the code, but anything you think they should know before testing. Screenshots are
useful here to illustrate changes or new parts of the app.

Example:
This PR adds ability to speed up your transfers through the transfer tab. <screenshot of speedup button>
This change only affects the transfer tab, so do not expect changes in the app elsewhere.
-->

This PR fixes the modals being cut and overflowing on some particular screen dimensions. I also improved the styling of the scroll bar

![bug](https://user-images.githubusercontent.com/89395931/174799698-097367a2-305c-49cf-9b67-9f48c6b72ac7.png)


**Acceptance Criteria**
<!--
Acceptance criteria should be composed of 2 parts, the first part is how to test, if its not obvious, the second part
is what they should be expect to be observing as the correct behavior.

It may not always be obvious how to test your changes, the more direction you can give the better, such as directing
the tester to particular parts of the app need testing, or specific actions to be taken using specific browsers or devices. 

The second part is to Describe what the tester should be testing and what the expected behavior is. Enumerate them so that testers
can respond to the numbers directly if there are issues.

Example:
Use the generated kovan link and first send a transaction between any chains, then go to transfer tab.
You should see your active transfer, and the new speedup button.

1. See that you can send a transfer and then speed it up.  
2. See that transfer shows a speedup transaction hash after speeding it up.
3. See that there were no regressions with the transfer table.
-->

1. In case the height of the modal is higher than the screen's height, the the modal should be contained inside the window and the content should be scrollable. 

Screenshot taken on an iPhone landscape

<img width="856" alt="Screenshot 2022-06-21 at 15 28 01" src="https://user-images.githubusercontent.com/89395931/174800154-06f770bc-1710-40ac-80b7-f44377f08e27.png">


<!-- If requesting QA DO NOT remove the following section, this is meant to direct QA Testers responses to your PR -->
### How To Report QA
Testers, use the following templates to pass the pull request or to report issues that require a resolution.
Following these guidelines will help the developer respond more quickly to issues, but you are free to comment
in any way as needed to help resolve issues.

**Reporting QA Issues**

Testers should use Github comments to report issues with the PR. Use screenshots if relevant, you can also
check the [developer console](https://support.airtable.com/hc/en-us/articles/232313848-How-to-open-the-developer-console)
to see if there are any logs which might be related. Use the following template when reporting a problem or issue with the PR.
You submit multiple comments using this template if there are multiple issues.

```
**QA Issue**

<!--
Describe the problem with you ran into, if it has to do with one of the acceptance criteria, then add it here.
Add any screenshots of the app or console logs if you think it would be useful.
-->

**Repro Steps**

<!--
If this issue was seen after taking particular steps, then note how to do it here.

Example:
1. Go to bridge tab and send a tx between any chains.
2. go to pool tab before going to transaction tab.
3. see that my pending transaction is missing.
-->

**Testing Environment**

<!--
Optionally include anything about your testing environment, ie phone, tablet, chrome or safari, if you used
metamask or a different wallet, etc. This will let other testers know if there are configurations they could
test differently from yours.

Example:
Used Metamask and the latest version of Safari on a Macbook. 
-->


```

**Reporting QA Regression**

A regression is something that was working, but now is no longer working due to the new code changes. The breakage
may seem completely unrelated to the pull request, which is why they can go unnoticed during testing.
If you find a regression, or arent sure, report it anyway as an issue and the engineer can decide how to resolve it. 


**Reporting QA Passed**

If you tested and did not find any issues, you will need to signal to the developer that this passed your QA.
Do this by adding comments in the pr. You should communicate to both the developers and other testers what you did during testing. Use the following
template to signal that QA passed your testing.

```
**QA Pass**

<!--
Describe what you tested, if you tested beyond what was originally specified, or any other parts of the app.
This will help others decide how to do their testing, and let the engineer know the testing coverage of the app.

Example:
Tested sending eth and weth between optimism and arbitrum on kovan and back again. Both cases I was able to see my 
transaction and speed it up. No issues with the UI but I wasnt sure if the transaction actually was faster. Also
tested adding and removing liquidity from the pool tab which worked as expected. 

-->

**Testing Environment**

<!--
Optionally include anything unique about your testing environment, ie phone, tablet, chrome or safari, if you used
Metamask or a different wallet, etc. This will let other testers know if there are configurations they could
test differently from yours.

Example:
Used Metamask and the latest version of Safari on a Macbook. 
-->

```
