### PR TITLE
feat: add variable bridge time estimation to UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@uma/contracts-frontend": "^0.1.17",
     "@uma/contracts-node": "^0.1.17",
     "@uma/sdk": "^0.22.2",
+    "axios": "^0.27.2",
     "bnc-notify": "^1.9.1",
     "bnc-onboard": "^1.37.0",
     "downshift": "^6.1.7",

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -41,6 +41,7 @@ const SendAction: React.FC<Props> = ({ onDeposit }) => {
     txPending,
     fromChain,
     txHash,
+    limits,
   } = useSendAction(onDeposit);
   const showFees = amount.gt(0) && !!fees;
   const amountMinusFees = showFees ? receiveAmount(amount, fees) : undefined;
@@ -48,6 +49,10 @@ const SendAction: React.FC<Props> = ({ onDeposit }) => {
   const fromChainInfo = fromChain ? getChainInfo(fromChain) : undefined;
   const tokenInfo = tokenSymbol ? getToken(tokenSymbol) : undefined;
   const isWETH = tokenInfo?.symbol === "WETH";
+  const timeToRelay =
+    limits && toChain
+      ? getConfirmationDepositTime(amount, limits, toChain)
+      : undefined;
 
   return (
     <AccentSection>
@@ -64,7 +69,7 @@ const SendAction: React.FC<Props> = ({ onDeposit }) => {
             <InfoContainer>
               <Info>
                 {`Time to ${toChainInfo.name}`}
-                <div>{getConfirmationDepositTime()}</div>
+                <div>{timeToRelay || "loading"}</div>
               </Info>
               <Info>
                 <div>Destination Gas Fee</div>

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -42,6 +42,7 @@ const SendAction: React.FC<Props> = ({ onDeposit }) => {
     fromChain,
     txHash,
     limits,
+    limitsError,
   } = useSendAction(onDeposit);
   const showFees = amount.gt(0) && !!fees;
   const amountMinusFees = showFees ? receiveAmount(amount, fees) : undefined;
@@ -49,10 +50,12 @@ const SendAction: React.FC<Props> = ({ onDeposit }) => {
   const fromChainInfo = fromChain ? getChainInfo(fromChain) : undefined;
   const tokenInfo = tokenSymbol ? getToken(tokenSymbol) : undefined;
   const isWETH = tokenInfo?.symbol === "WETH";
-  const timeToRelay =
-    limits && toChain
-      ? getConfirmationDepositTime(amount, limits, toChain)
-      : undefined;
+  let timeToRelay = "loading";
+  if (limits && toChain) {
+    timeToRelay = getConfirmationDepositTime(amount, limits, toChain);
+  } else if (limitsError) {
+    timeToRelay = "estimation failed";
+  }
 
   return (
     <AccentSection>
@@ -69,7 +72,7 @@ const SendAction: React.FC<Props> = ({ onDeposit }) => {
             <InfoContainer>
               <Info>
                 {`Time to ${toChainInfo.name}`}
-                <div>{timeToRelay || "loading"}</div>
+                <div>{timeToRelay}</div>
               </Info>
               <Info>
                 <div>Destination Gas Fee</div>

--- a/src/components/SendAction/useSendAction.ts
+++ b/src/components/SendAction/useSendAction.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useSendForm, useBridgeFees, useBridge } from "hooks";
+import { useSendForm, useBridgeFees, useBridge, useBridgeLimits } from "hooks";
 import { onboard, confirmations } from "utils";
 import { Deposit } from "views/Confirmation";
 import { useConnection } from "state/hooks";
@@ -14,6 +14,11 @@ export default function useSendAction(
   const { fromChain, toChain, amount, tokenSymbol, toAddress, selectedRoute } =
     useSendForm();
   const { fees } = useBridgeFees(amount, toChain, tokenSymbol);
+  const { limits } = useBridgeLimits(
+    selectedRoute?.fromTokenAddress,
+    fromChain,
+    toChain
+  );
   const { status, hasToApprove, send, approve } = useBridge();
   const { account } = useConnection();
   const [txHash, setTxHash] = useState("");
@@ -102,5 +107,6 @@ export default function useSendAction(
     toggleInfoModal,
     txPending,
     txHash,
+    limits,
   };
 }

--- a/src/components/SendAction/useSendAction.ts
+++ b/src/components/SendAction/useSendAction.ts
@@ -14,7 +14,7 @@ export default function useSendAction(
   const { fromChain, toChain, amount, tokenSymbol, toAddress, selectedRoute } =
     useSendForm();
   const { fees } = useBridgeFees(amount, toChain, tokenSymbol);
-  const { limits } = useBridgeLimits(
+  const { limits, isError } = useBridgeLimits(
     selectedRoute?.fromTokenAddress,
     fromChain,
     toChain
@@ -108,5 +108,6 @@ export default function useSendAction(
     txPending,
     txHash,
     limits,
+    limitsError: isError,
   };
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,6 +2,7 @@ export * from "./useERC20";
 export * from "./useBalance";
 export * from "./useBlock";
 export * from "./useBridgeFees";
+export * from "./useBridgeLimits";
 export * from "./usePrevious";
 export * from "./useSendForm";
 export * from "./useBridge";

--- a/src/hooks/useBridgeFees.ts
+++ b/src/hooks/useBridgeFees.ts
@@ -5,7 +5,6 @@ import { useBlock } from "./useBlock";
 
 /**
  * This hook calculates the bridge fees for a given token and amount.
- * @remarks This hook **SHOULD NOT** be used to calculate the fees for a L1 to L2 transfer, as those use canonical bridges instead.
  * @param amount - The amount to check bridge fees for.
  * @param toChainId The chain Id of the receiving chain, its timestamp will be used to calculate the fees.
  * @param tokenSymbol - The token symbol to check bridge fees for.

--- a/src/hooks/useBridgeLimits.ts
+++ b/src/hooks/useBridgeLimits.ts
@@ -35,7 +35,6 @@ export function useBridgeLimits(
           `/api/limits?token=${token}&originChainId=${fromChainId}&destinationChainId=${toChainId}`
         )
       ).data;
-      console.log(response);
       return {
         minDeposit: BigNumber.from(response.minDeposit),
         maxDeposit: BigNumber.from(response.maxDeposit),

--- a/src/hooks/useBridgeLimits.ts
+++ b/src/hooks/useBridgeLimits.ts
@@ -46,6 +46,7 @@ export function useBridgeLimits(
       enabled: enabledQuery,
       // 5 mins.
       staleTime: 300000,
+      retry: 2,
     }
   );
   return {

--- a/src/hooks/useBridgeLimits.ts
+++ b/src/hooks/useBridgeLimits.ts
@@ -1,0 +1,56 @@
+import { useQuery } from "react-query";
+import { bridgeLimitsQueryKey, ChainId } from "utils";
+import axios from "axios";
+import { BigNumber } from "ethers";
+
+export interface BridgeLimits {
+  minDeposit: BigNumber;
+  maxDeposit: BigNumber;
+  maxDepositInstant: BigNumber;
+  maxDepositShortDelay: BigNumber;
+}
+
+/**
+ * This hook calculates the limit .
+ * @param token The token to get limits for.
+ * @param fromChainId The chain id from which the deposit transaction is sent.
+ * @param toChainId The chain id where the relay will be sent.
+ * @returns The limits datastructure returned from the serverless api.
+ */
+export function useBridgeLimits(
+  token?: string,
+  fromChainId?: ChainId,
+  toChainId?: ChainId
+) {
+  const enabledQuery =
+    token !== undefined && toChainId !== undefined && fromChainId !== undefined;
+  const queryKey = enabledQuery
+    ? bridgeLimitsQueryKey(token, fromChainId, toChainId)
+    : "DISABLED_BRIDGE_LIMITS_QUERY";
+  const { data: limits, ...delegated } = useQuery(
+    queryKey,
+    async (): Promise<BridgeLimits> => {
+      const response = (
+        await axios.get(
+          `/api/limits?token=${token}&originChainId=${fromChainId}&destinationChainId=${toChainId}`
+        )
+      ).data;
+      console.log(response);
+      return {
+        minDeposit: BigNumber.from(response.minDeposit),
+        maxDeposit: BigNumber.from(response.maxDeposit),
+        maxDepositInstant: BigNumber.from(response.maxDepositInstant),
+        maxDepositShortDelay: BigNumber.from(response.maxDepositShortDelay),
+      };
+    },
+    {
+      enabled: enabledQuery,
+      // 5 mins.
+      staleTime: 300000,
+    }
+  );
+  return {
+    limits,
+    ...delegated,
+  };
+}

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -159,13 +159,14 @@ export const getConfirmationDepositTime = (
     return "~1-4 minutes";
   } else if (amount.lte(limits.maxDepositShortDelay)) {
     // This is just a rough estimate of how long 2 bot runs (1-4 minutes allocated for each) + an arbitrum transfer of 3-10 minutes would take.
-    if (toChain === 42161) return "~5-15 minutes";
+    if (toChain === ChainId.ARBITRUM) return "~5-15 minutes";
 
     // Optimism transfers take about 10-20 minutes anecdotally. Boba is presumed to be similar.
-    if (toChain === 10 || toChain === 288) return "~12-25 minutes";
+    if (toChain === ChainId.OPTIMISM || toChain === ChainId.BOBA)
+      return "~12-25 minutes";
 
     // Polygon transfers take 20-30 minutes anecdotally.
-    if (toChain === 137) return "~20-35 minutes";
+    if (toChain === ChainId.POLYGON) return "~20-35 minutes";
 
     // Typical numbers for an arbitrary L2.
     return "~10-30 minutes";

--- a/src/utils/query-keys.ts
+++ b/src/utils/query-keys.ts
@@ -41,6 +41,15 @@ export function bridgeFeesQueryKey(
 ) {
   return ["bridgeFees", tokenSymbol, amount, chainId, blockNumber];
 }
+
+export function bridgeLimitsQueryKey(
+  token: string,
+  fromChainId: ChainId,
+  toChainId: ChainId
+) {
+  return ["bridgeLimits", token, fromChainId, toChainId];
+}
+
 /**
  * Generates query keys for react-query `useQuery` hook, used in the `useAllowance` hook.
  * @param chainId  The chain Id of the chain to execute the query on.

--- a/src/views/Confirmation/Confirmation.tsx
+++ b/src/views/Confirmation/Confirmation.tsx
@@ -45,7 +45,7 @@ type Props = {
   deposit?: Deposit;
 };
 const Confirmation: React.FC<Props> = ({ deposit, onClose }) => {
-  const { limits } = useBridgeLimits(
+  const { limits, isError } = useBridgeLimits(
     deposit?.tokenAddress,
     deposit?.fromChain,
     deposit?.toChain
@@ -61,18 +61,24 @@ const Confirmation: React.FC<Props> = ({ deposit, onClose }) => {
   const fromChainInfo = getChainInfo(deposit.fromChain);
   const toChainInfo = getChainInfo(deposit.toChain);
   const isWETH = fromTokenInfo?.symbol === "WETH";
-  const confirmationTime = limits
-    ? getConfirmationDepositTime(deposit.amount, limits, deposit.toChain)
-    : undefined;
+
+  let fundsArrivalText = "Loading time estimate";
+  if (limits) {
+    fundsArrivalText = `Your funds will arrive in ${getConfirmationDepositTime(
+      deposit.amount,
+      limits,
+      deposit.toChain
+    )}`;
+  } else if (isError) {
+    fundsArrivalText = "Time estimation failed";
+  }
 
   return (
     <Layout>
       <Wrapper>
         <Header>
           <Heading>Deposit succeeded</Heading>
-          <SubHeading>
-            Your funds will arrive in {confirmationTime || "loading"}
-          </SubHeading>
+          <SubHeading>{fundsArrivalText}</SubHeading>
           <SubHeading>
             To monitor progress, go to the
             <RouterLink to="/transactions">transactions page</RouterLink>

--- a/src/views/Confirmation/Confirmation.tsx
+++ b/src/views/Confirmation/Confirmation.tsx
@@ -28,6 +28,7 @@ import {
 } from "./Confirmation.styles";
 import { ethers } from "ethers";
 import { getConfirmationDepositTime } from "utils";
+import { useBridgeLimits } from "hooks";
 
 export type Deposit = {
   txHash: string;
@@ -44,6 +45,11 @@ type Props = {
   deposit?: Deposit;
 };
 const Confirmation: React.FC<Props> = ({ deposit, onClose }) => {
+  const { limits } = useBridgeLimits(
+    deposit?.tokenAddress,
+    deposit?.fromChain,
+    deposit?.toChain
+  );
   if (!deposit) return null;
   const config = getConfig();
   const amountMinusFees = receiveAmount(deposit.amount, deposit.fees);
@@ -55,6 +61,9 @@ const Confirmation: React.FC<Props> = ({ deposit, onClose }) => {
   const fromChainInfo = getChainInfo(deposit.fromChain);
   const toChainInfo = getChainInfo(deposit.toChain);
   const isWETH = fromTokenInfo?.symbol === "WETH";
+  const confirmationTime = limits
+    ? getConfirmationDepositTime(deposit.amount, limits, deposit.toChain)
+    : undefined;
 
   return (
     <Layout>
@@ -62,7 +71,7 @@ const Confirmation: React.FC<Props> = ({ deposit, onClose }) => {
         <Header>
           <Heading>Deposit succeeded</Heading>
           <SubHeading>
-            Your funds will arrive in {getConfirmationDepositTime()}
+            Your funds will arrive in {confirmationTime || "loading"}
           </SubHeading>
           <SubHeading>
             To monitor progress, go to the
@@ -156,7 +165,7 @@ const Confirmation: React.FC<Props> = ({ deposit, onClose }) => {
             <Info>
               <h3>Estimated time of arrival</h3>
               <div>
-                <div>{getConfirmationDepositTime()}</div>
+                <div>{confirmationTime || "loading"}</div>
               </div>
             </Info>
           </div>

--- a/src/views/Confirmation/Confirmation.tsx
+++ b/src/views/Confirmation/Confirmation.tsx
@@ -63,14 +63,17 @@ const Confirmation: React.FC<Props> = ({ deposit, onClose }) => {
   const isWETH = fromTokenInfo?.symbol === "WETH";
 
   let fundsArrivalText = "Loading time estimate";
+  let timeEstimate = "loading";
   if (limits) {
-    fundsArrivalText = `Your funds will arrive in ${getConfirmationDepositTime(
+    timeEstimate = getConfirmationDepositTime(
       deposit.amount,
       limits,
       deposit.toChain
-    )}`;
+    );
+    fundsArrivalText = `Your funds will arrive in ${timeEstimate}`;
   } else if (isError) {
     fundsArrivalText = "Time estimation failed";
+    timeEstimate = "estimation failed";
   }
 
   return (
@@ -171,7 +174,7 @@ const Confirmation: React.FC<Props> = ({ deposit, onClose }) => {
             <Info>
               <h3>Estimated time of arrival</h3>
               <div>
-                <div>{confirmationTime || "loading"}</div>
+                <div>{timeEstimate}</div>
               </div>
             </Info>
           </div>


### PR DESCRIPTION
**Overview**

This change allows us to provide users with a more accurate time estimate for their transfers. Instead of always seeing 1-3 minutes, users should see smaller numbers for smaller transfers and as their transfers get very large, the time estimate should tick up to something intermediate. The amount is different depending on the destination chain.

Instant transfers are estimated to take 1-4 minutes (not 1-3, since a typical bot run takes 2 minutes and a user could deposit on the back end of a run).

Transfers that could be funded by mainnet, but would require an L1->L2 transfer have the following estimates: 
- Optimism: 12-25 minutes.
- Polygon: 20-35 minutes.
- Boba: 12-25 (presuming that it's the same as Optimism).
- Arbitrum: 5-15 minutes.
- Default (not one of the above): 10-30 minutes. We should never hit this.

Anything larger than that will return an estimate of 2-4 hours.