### PR TITLE
fix: fix dropdown menu cut

### DIFF
--- a/src/components/AddressSelection/AddressSelection.styles.ts
+++ b/src/components/AddressSelection/AddressSelection.styles.ts
@@ -8,6 +8,7 @@ import { RoundBox as UnstyledBox, ErrorBox } from "../Box";
 export const LastSection = styled(Section)`
   border-bottom: none;
 `;
+
 export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/components/AddressSelection/AddressSelection.styles.ts
+++ b/src/components/AddressSelection/AddressSelection.styles.ts
@@ -124,7 +124,7 @@ export const Menu = styled.ul<MenuProps>`
   right: 0;
   // HACK: we use this as padding, to prevent elements overflowing into the label when scrolling up
   border-top: 10px solid transparent;
-  transform: translateY(60px);
+  transform: translateY(80px);
   height: fit-content;
   max-height: 50vh;
   overflow-y: auto;

--- a/src/components/AddressSelection/AddressSelection.styles.ts
+++ b/src/components/AddressSelection/AddressSelection.styles.ts
@@ -44,6 +44,7 @@ export const Info = styled.div`
     line-height: 1;
   }
 `;
+
 export const Address = styled.div`
   font-size: ${14 / 16}rem;
   text-align: left;
@@ -80,6 +81,7 @@ export const InputWrapper = styled(RoundBox)`
     outline: var(--color-primary-dark) solid 1px;
   }
 `;
+
 export const Input = styled.input`
   width: 100%;
   border: none;
@@ -101,9 +103,11 @@ export const ClearButton = styled(BaseButton)`
   align-items: center;
   padding: 0;
 `;
+
 export const CancelButton = styled(PrimaryButton)`
   border: 1px solid var(--color-gray-300);
 `;
+
 export const ButtonGroup = styled.div`
   display: flex;
   gap: 20px;

--- a/src/components/SendAction/SendAction.styles.ts
+++ b/src/components/SendAction/SendAction.styles.ts
@@ -11,7 +11,7 @@ export const Wrapper = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: 40px 0 65px;
+  padding: 40px 0 150px;
 `;
 
 export const InfoHeadlineContainer = styled.div`

--- a/src/components/SendAction/SendAction.styles.ts
+++ b/src/components/SendAction/SendAction.styles.ts
@@ -11,7 +11,7 @@ export const Wrapper = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: 40px 0 150px;
+  padding: 40px 0 160px;
 `;
 
 export const InfoHeadlineContainer = styled.div`


### PR DESCRIPTION
Increased the padding below the Send button in order to accommodate  the full height of the menu dropdown

The issue that needs to be fixed:

<img width="420" alt="Screenshot 2022-07-01 at 14 33 09" src="https://user-images.githubusercontent.com/89395931/176886793-9d017285-a0a9-4cb0-9466-c681ecaeb75c.png">
