### PR TITLE
feat: Add delimiter to referrer tag

### DIFF
--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -19,6 +19,7 @@ import {
   queriesTable,
   FLAT_RELAY_CAPITAL_FEE,
   relayerFeeCapitalCostConfig,
+  referrerDelimitterHex,
 } from "./constants";
 
 import { parseEther, tagAddress } from "./format";
@@ -237,7 +238,7 @@ export async function sendAcrossDeposit(
   // do not tag a referrer if data is not provided as a hex string.
   tx.data =
     referrer && ethers.utils.isAddress(referrer)
-      ? tagAddress(tx.data!, referrer)
+      ? tagAddress(tx.data!, referrer, referrerDelimitterHex)
       : tx.data;
 
   return signer.sendTransaction(tx);

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -19,7 +19,7 @@ import {
   queriesTable,
   FLAT_RELAY_CAPITAL_FEE,
   relayerFeeCapitalCostConfig,
-  referrerDelimitterHex,
+  referrerDelimiterHex,
 } from "./constants";
 
 import { parseEther, tagAddress } from "./format";
@@ -238,7 +238,7 @@ export async function sendAcrossDeposit(
   // do not tag a referrer if data is not provided as a hex string.
   tx.data =
     referrer && ethers.utils.isAddress(referrer)
-      ? tagAddress(tx.data!, referrer, referrerDelimitterHex)
+      ? tagAddress(tx.data!, referrer, referrerDelimiterHex)
       : tx.data;
 
   return signer.sendTransaction(tx);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -677,3 +677,5 @@ const getQueriesTable = () => {
 };
 
 export const queriesTable = getQueriesTable();
+
+export const referrerDelimitterHex = "0xaaaabbbbccccdddd";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -678,4 +678,4 @@ const getQueriesTable = () => {
 
 export const queriesTable = getQueriesTable();
 
-export const referrerDelimiterHex = "0xaaaabbbbccccdddd";
+export const referrerDelimiterHex = "0xdooddeaffeeddeadbeef";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -678,4 +678,4 @@ const getQueriesTable = () => {
 
 export const queriesTable = getQueriesTable();
 
-export const referrerDelimitterHex = "0xaaaabbbbccccdddd";
+export const referrerDelimiterHex = "0xaaaabbbbccccdddd";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -678,4 +678,4 @@ const getQueriesTable = () => {
 
 export const queriesTable = getQueriesTable();
 
-export const referrerDelimiterHex = "0xdooddeaffeeddeadbeef";
+export const referrerDelimiterHex = "0xdoodfeeddeadbeef";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -678,4 +678,4 @@ const getQueriesTable = () => {
 
 export const queriesTable = getQueriesTable();
 
-export const referrerDelimiterHex = "0xdoodfeeddeadbeef";
+export const referrerDelimiterHex = "0xd00dfeeddeadbeef";

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 import assert from "assert";
+import { referrerDelimitterHex } from "./constants";
 
 export function isValidString(s: string | null | undefined | ""): s is string {
   if (s != null && typeof s === "string" && s !== "") {
@@ -88,7 +89,7 @@ export function stringToHex(value: string) {
 // appends hex tag to data
 export function tagHex(dataHex: string, tagHex: string) {
   assert(ethers.utils.isHexString(dataHex), "Data must be valid hex string");
-  return ethers.utils.hexConcat([dataHex, tagHex]);
+  return ethers.utils.hexConcat([dataHex, referrerDelimitterHex, tagHex]);
 }
 
 // converts a string tag to hex and appends, currently not in use

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,6 +1,5 @@
 import { ethers } from "ethers";
 import assert from "assert";
-import { referrerDelimitterHex } from "./constants";
 
 export function isValidString(s: string | null | undefined | ""): s is string {
   if (s != null && typeof s === "string" && s !== "") {
@@ -105,10 +104,10 @@ export function tagString(dataHex: string, tagString: string) {
 export function tagAddress(
   dataHex: string,
   address: string,
-  delimitterHex: string = ""
+  delimiterHex: string = ""
 ) {
   assert(ethers.utils.isAddress(address), "Data must be a valid address");
-  return tagHex(dataHex, address, delimitterHex);
+  return tagHex(dataHex, address, delimiterHex);
 }
 
 export function capitalizeFirstLetter(str: string) {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -87,9 +87,13 @@ export function stringToHex(value: string) {
 }
 
 // appends hex tag to data
-export function tagHex(dataHex: string, tagHex: string) {
+export function tagHex(
+  dataHex: string,
+  tagHex: string,
+  delimitterHex: string = ""
+) {
   assert(ethers.utils.isHexString(dataHex), "Data must be valid hex string");
-  return ethers.utils.hexConcat([dataHex, referrerDelimitterHex, tagHex]);
+  return ethers.utils.hexConcat([dataHex, delimitterHex, tagHex]);
 }
 
 // converts a string tag to hex and appends, currently not in use
@@ -98,9 +102,13 @@ export function tagString(dataHex: string, tagString: string) {
 }
 
 // tags only an address
-export function tagAddress(dataHex: string, address: string) {
+export function tagAddress(
+  dataHex: string,
+  address: string,
+  delimitterHex: string = ""
+) {
   assert(ethers.utils.isAddress(address), "Data must be a valid address");
-  return tagHex(dataHex, address);
+  return tagHex(dataHex, address, delimitterHex);
 }
 
 export function capitalizeFirstLetter(str: string) {


### PR DESCRIPTION
To make it easier for clients to identify referred transactions, add a delimitter in front of referrer address. By adding in front, this allows referrer-identification logic to be backwards compatible

<!--
If you need QA on your PR include the following section in your code. This will alert the QA team
that they should be testing.  Engineers should use github emojis to :heart: :+1: if the QA comments are productive
or :-1: if the QA comments are hindering productivity. Its up to your own discretion to award emojis, but its encouraged
to do so since we can use this information to incentivise and reward QA testers.
-->
