### PR TITLE
fix: fix issue with remove liquidity when decimals are input

### DIFF
--- a/src/components/PoolForm/RemoveLiquidityForm.tsx
+++ b/src/components/PoolForm/RemoveLiquidityForm.tsx
@@ -348,6 +348,8 @@ const validateForm = (
         return setFormError("Transaction may fail due to insufficient gas.");
       }
     }
+    // make sure any previous errors are cleared, for instance when typing .7.
+    setFormError("");
   } catch (e) {
     return setFormError("Invalid number.");
   }


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

Errors were not being cleared when a valid number was detected in the remove liquidity form input. Now they are.