### PR TITLE
improve(api): Set Cache-Control header to reduce Serverless Invocations

### DIFF
--- a/api/limits.js
+++ b/api/limits.js
@@ -149,6 +149,11 @@ const handler = async (request, response) => {
       ).toString(),
     };
 
+    // Instruct Vercel to cache limit data for this token for 5 minutes. Caching can be used to limit number of
+    // Vercel invocations and run time for this serverless function and trades off potential inaccuracy in times of 
+    // high volume. "max-age=0" instructs browsers not to cache, while s-maxage instructs Vercel edge caching
+    // to cache the responses and invalidate when deployments update.
+    response.setHeader("Cache-Control", 's-maxage=300')
     response.status(200).json(responseJson);
   } catch (error) {
     let status;


### PR DESCRIPTION
<!--
If you need QA on your PR include the following section in your code. This will alert the QA team
that they should be testing.  Engineers should use github emojis to :heart: :+1: if the QA comments are productive
or :-1: if the QA comments are hindering productivity. Its up to your own discretion to award emojis, but its encouraged
to do so since we can use this information to incentivise and reward QA testers.
-->

Currentl Vercel serverless invocations 
![Screen Shot 2022-07-15 at 13 45 11](https://user-images.githubusercontent.com/9457025/179281570-981edd2a-b93d-4e4a-9177-91da2caef393.png)

Theoretically this # can be reduced by caching responses. Caching the /suggested-fees responses doesn't make sense since the `amount` request parameter will usually be different, but we should be able to cache /limits which does seem like the more requested route.

Idea to cache came from this document which I found by looking up "vercel serverless functions 429"
https://vercel.com/support/articles/what-should-i-do-if-i-receive-a-429-error-on-vercel