### PR TITLE
fix: change formatting style for numbers

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -51,15 +51,23 @@ export function shortenTransactionHash(hash: string): string {
   return `${hash.substring(0, 5)}...`;
 }
 
+// for number less than 1, this will ensure at least 1 digit is shown ( not rounded to 0)
 export const smallNumberFormatter = (num: number) =>
   new Intl.NumberFormat("en-US", {
     minimumSignificantDigits: 1,
     maximumSignificantDigits: 3,
   }).format(num);
 
+// for numbers 1 or greater, this will ensure we never round down and lose values > 1, while minimizing decimals to max of 3
 export const largeNumberFormatter = (num: number) =>
   new Intl.NumberFormat("en-US", {
     maximumFractionDigits: 3,
+  }).format(num);
+
+// for numbers 1000 or greater, this will remove any fractional component to make it a bit cleaner
+export const veryLargeNumberFormatter = (num: number) =>
+  new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 0,
   }).format(num);
 
 export function formatUnits(
@@ -67,7 +75,10 @@ export function formatUnits(
   decimals: number
 ): string {
   const value = Number(ethers.utils.formatUnits(wei, decimals));
-  if (value > 1) {
+  if (value >= 1000) {
+    return veryLargeNumberFormatter(value);
+  }
+  if (value >= 1) {
     return largeNumberFormatter(value);
   }
   return smallNumberFormatter(value);

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -51,18 +51,26 @@ export function shortenTransactionHash(hash: string): string {
   return `${hash.substring(0, 5)}...`;
 }
 
-// this actually will round up in some cases
-export const numberFormatter = (num: number) =>
+export const smallNumberFormatter = (num: number) =>
   new Intl.NumberFormat("en-US", {
     minimumSignificantDigits: 1,
-    maximumSignificantDigits: 4,
+    maximumSignificantDigits: 3,
+  }).format(num);
+
+export const largeNumberFormatter = (num: number) =>
+  new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 3,
   }).format(num);
 
 export function formatUnits(
   wei: ethers.BigNumberish,
   decimals: number
 ): string {
-  return numberFormatter(Number(ethers.utils.formatUnits(wei, decimals)));
+  const value = Number(ethers.utils.formatUnits(wei, decimals));
+  if (value > 1) {
+    return largeNumberFormatter(value);
+  }
+  return smallNumberFormatter(value);
 }
 
 export function formatEther(wei: ethers.BigNumberish): string {


### PR DESCRIPTION
this pr is updated with a new strategy proposed by korpi:
if number is less than 1, minimum use significant digits
if greater than one use maximum fraction digits
for numbers 1000 or greater, we drop any fractional values
This seems to work well for big and small values

I think with this technique we dont need any tool tips since we both minimize what we show and show necessary decimals when numbers are really small 

new behavior
![image](https://user-images.githubusercontent.com/4429761/180464231-8fbe24c0-2305-49b2-a748-e87ebc35cacc.png)
![image](https://user-images.githubusercontent.com/4429761/180464304-a105ac37-afb9-467e-9409-721d07859e7e.png)


old behavior
![image](https://user-images.githubusercontent.com/4429761/180454589-b0d5ddc6-aebe-4173-a802-2366c204a63b.png)
![image](https://user-images.githubusercontent.com/4429761/180454683-e29ae9e0-44f9-4a3b-91a5-1b9b9012d65c.png)
