### PR TITLE
fix: decimal parsing of diffent tokens in transfer

### DIFF
--- a/src/views/Transactions/TransactionsTable/createMobileTransactionTableJSX.tsx
+++ b/src/views/Transactions/TransactionsTable/createMobileTransactionTableJSX.tsx
@@ -10,6 +10,7 @@ import {
   capitalizeFirstLetter,
   formatNumberTwoSigDigits,
   shortenString,
+  formatUnits,
 } from "utils/format";
 import { ICell, IRow } from "components/Table/Table";
 import { getChainInfo, ChainId } from "utils/constants";
@@ -134,7 +135,7 @@ function formatTransactionRows(
       </>
     );
 
-    const amount = ethers.utils.formatEther(tx.amount);
+    const amount = formatUnits(tx.amount, token.decimals).toString();
 
     const txHash = (
       <MobileTableLink

--- a/src/views/Transactions/TransactionsTable/createTransactionTableJSX.tsx
+++ b/src/views/Transactions/TransactionsTable/createTransactionTableJSX.tsx
@@ -1,11 +1,11 @@
 import { DateTime } from "luxon";
-import { ethers } from "ethers";
 import { TableLogo, TableLink, StyledPlus } from "./TransactionsTable.styles";
 import { getConfig, Token } from "utils/config";
 import {
   shortenTransactionHash,
   capitalizeFirstLetter,
   formatNumberTwoSigDigits,
+  formatUnits,
 } from "utils/format";
 import { ICell, IRow } from "components/Table/Table";
 import { getChainInfo } from "utils/constants";
@@ -114,7 +114,7 @@ function formatTransactionRows(
 
     const amount: ICell = {
       size: "xs",
-      value: ethers.utils.formatUnits(tx.amount, token.decimals),
+      value: formatUnits(tx.amount, token.decimals).toString(),
     };
 
     const txHash: ICell = {


### PR DESCRIPTION
parsing token amounts was not using decimal value of token on transfer history page