### PR TITLE
fix: fix pagination issues

### DIFF
--- a/src/hooks/useReferralSummary.ts
+++ b/src/hooks/useReferralSummary.ts
@@ -29,17 +29,19 @@ const defaultReferralsSummary: ReferralsSummary = {
   activeRefereesCount: 0,
 };
 
-export function useReferralSummary(account: string) {
+export function useReferralSummary(account?: string) {
+  const enabledQuery = account !== undefined;
+
   const { data: summary, ...other } = useQuery(
     queryKey,
     async () => {
-      return getReferrals(account!);
+      return getReferralSummary(account!);
     },
     {
       // refetch based on the chain polling interval
       // disable this temporary
       // refetchInterval: 60000,
-      enabled: !!account,
+      enabled: enabledQuery,
     }
   );
 
@@ -53,7 +55,7 @@ export function useReferralSummary(account: string) {
  * @param account Address of logged in user.
  * @returns A promise resolving to the referral summary of the user
  */
-async function getReferrals(account: string) {
+async function getReferralSummary(account: string) {
   return axios.get<ReferralsSummary>(
     `${rewardsApiUrl}/referrals/summary?address=${account}`
   );

--- a/src/utils/query-keys.ts
+++ b/src/utils/query-keys.ts
@@ -68,3 +68,27 @@ export function allowanceQueryKey(
 ) {
   return ["allowance", chainId, tokenSymbol, owner, spender, blockNumber];
 }
+
+/**
+ * Generates query keys for react-query `useQuery` hook, used in the `useReferrals` hook.
+ * @param account  The address that referrals are being queried for.
+ * @param limit The limit on the number of results that are returned (page size).
+ * @param offset The number of elements to omit before returning results.
+ * @returns An array of query keys for react-query `useQuery` hook.
+ */
+export function referralsQueryKey(
+  account: string,
+  limit: number,
+  offset: number
+) {
+  return ["referrals", account, limit, offset];
+}
+
+/**
+ * Generates query keys for react-query `useQuery` hook, used in the `useReferralSummary` hook.
+ * @param account  The address that referral summary is being queried for.
+ * @returns An array of query keys for react-query `useQuery` hook.
+ */
+export function referralSummaryQueryKey(account: string) {
+  return ["referralSummary", account];
+}

--- a/src/views/Rewards/Rewards.tsx
+++ b/src/views/Rewards/Rewards.tsx
@@ -20,6 +20,7 @@ const Rewards = () => {
     pageSize,
     setPageSize,
     pageSizes,
+    totalReferralCount,
   } = useRewardsView();
 
   return (
@@ -41,6 +42,7 @@ const Rewards = () => {
           pageSize={pageSize}
           setPageSize={setPageSize}
           pageSizes={pageSizes}
+          totalReferralCount={totalReferralCount}
         />
       </Content>
       <Footer />

--- a/src/views/Rewards/comp/RewardTablePagination/RewardTablePagination.tsx
+++ b/src/views/Rewards/comp/RewardTablePagination/RewardTablePagination.tsx
@@ -86,6 +86,7 @@ export const Pagination = ({
   pageSize,
   pageSizes,
 }: Props) => {
+  const pageSelectorEnabled = lastPage !== 0;
   return (
     <Wrapper>
       <PageSizeSelect
@@ -93,45 +94,52 @@ export const Pagination = ({
         pageSizes={pageSizes}
         onPageSizeChange={onPageSizeChange}
       />
-      <PaginationElements>
-        {!hideStart && (
-          <>
-            <ElementWrapper onClick={() => onPageChange(0)}> 1 </ElementWrapper>
-            &nbsp; ... &nbsp;
-          </>
-        )}
-        {pageList.map((page, index) => {
-          return (
-            <ElementWrapper
-              active={index === activeIndex}
-              key={page}
-              onClick={() => onPageChange(page)}
+      {pageSelectorEnabled && (
+        <>
+          <PaginationElements>
+            {!hideStart && (
+              <>
+                <ElementWrapper onClick={() => onPageChange(0)}>
+                  {" "}
+                  1{" "}
+                </ElementWrapper>
+                &nbsp; ... &nbsp;
+              </>
+            )}
+            {pageList.map((page, index) => {
+              return (
+                <ElementWrapper
+                  active={index === activeIndex}
+                  key={page}
+                  onClick={() => onPageChange(page)}
+                >
+                  {page + 1}
+                </ElementWrapper>
+              );
+            })}
+            {!hideEnd && (
+              <>
+                <PagesPlaceholder>...</PagesPlaceholder>
+                <ElementWrapper onClick={() => onPageChange(lastPage)}>
+                  {lastPage + 1}
+                </ElementWrapper>
+              </>
+            )}
+            <NextElement
+              disabled={disableBack}
+              onClick={() => onPageChange(currentPage - 1)}
             >
-              {page + 1}
-            </ElementWrapper>
-          );
-        })}
-        {!hideEnd && (
-          <>
-            <PagesPlaceholder>...</PagesPlaceholder>
-            <ElementWrapper onClick={() => onPageChange(lastPage)}>
-              {lastPage + 1}
-            </ElementWrapper>
-          </>
-        )}
-        <NextElement
-          disabled={disableBack}
-          onClick={() => onPageChange(currentPage - 1)}
-        >
-          <ArrowIcon />
-        </NextElement>
-        <NextElement
-          disabled={disableForward}
-          onClick={() => onPageChange(currentPage + 1)}
-        >
-          <ArrowIcon />
-        </NextElement>
-      </PaginationElements>
+              <ArrowIcon />
+            </NextElement>
+            <NextElement
+              disabled={disableForward}
+              onClick={() => onPageChange(currentPage + 1)}
+            >
+              <ArrowIcon />
+            </NextElement>
+          </PaginationElements>
+        </>
+      )}
     </Wrapper>
   );
 };

--- a/src/views/Rewards/comp/RewardTableWithOverlay/RewardTableWithOverlay.tsx
+++ b/src/views/Rewards/comp/RewardTableWithOverlay/RewardTableWithOverlay.tsx
@@ -16,6 +16,7 @@ const RewardTableWithOverlay: React.FC<{
   pageSize: number;
   setPageSize: (value: number) => void;
   pageSizes: number[];
+  totalReferralCount: number;
 }> = ({
   isConnected,
   referrals,
@@ -25,21 +26,18 @@ const RewardTableWithOverlay: React.FC<{
   pageSize,
   setPageSize,
   pageSizes,
+  totalReferralCount,
 }) => {
   const rows = createMyReferralsTableJSX(referrals, isConnected, account);
-  const elementCount = rows.length;
 
   const paginateState = paginate({
-    elementCount,
+    elementCount: totalReferralCount,
     currentPage,
     maxNavigationCount: 5,
     elementsPerPage: pageSize,
   });
 
-  const paginatedRows = rows.slice(
-    paginateState.startIndex,
-    paginateState.endIndex
-  );
+  const paginatedRows = rows;
 
   return (
     <Wrapper>
@@ -50,17 +48,15 @@ const RewardTableWithOverlay: React.FC<{
         rows={paginatedRows}
         headers={headers}
       />
-      {paginateState.totalPages > 1 ? (
-        <div>
-          <Pagination
-            onPageSizeChange={setPageSize}
-            pageSize={pageSize}
-            pageSizes={pageSizes}
-            onPageChange={setCurrentPage}
-            {...paginateState}
-          />
-        </div>
-      ) : null}
+      <div>
+        <Pagination
+          onPageSizeChange={setPageSize}
+          pageSize={pageSize}
+          pageSizes={pageSizes}
+          onPageChange={setCurrentPage}
+          {...paginateState}
+        />
+      </div>
     </Wrapper>
   );
 };

--- a/src/views/Rewards/useRewardsView.ts
+++ b/src/views/Rewards/useRewardsView.ts
@@ -7,13 +7,29 @@ const DEFAULT_PAGE_SIZE = 10;
 
 export const useRewardsView = () => {
   const { isConnected, account } = useConnection();
-  const { referrals } = useReferrals(account || "");
   const [currentPage, setCurrentPage] = useState(0);
-  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [pageSize, setPageSizeState] = useState(DEFAULT_PAGE_SIZE);
+
+  // Note: we need to reset the page to 0 whenever we change the size to avoid going off the end.
+  const setPageSize = (newPageSize: number) => {
+    // Reset current page to 0 when resetting the page size.
+    setCurrentPage(0);
+    setPageSizeState(newPageSize);
+  };
+
   const pageSizes = useMemo(() => [10, 25, 50], []);
-  const { summary, isLoading: isReferalSummaryLoading } = useReferralSummary(
-    account || ""
+  const { referrals, pagination } = useReferrals(
+    account,
+    pageSize,
+    pageSize * currentPage
   );
+  const { summary, isLoading: isReferalSummaryLoading } =
+    useReferralSummary(account);
+
+  console.log("pageSize", pageSize);
+  console.log("total count", summary);
+  console.log("current page", currentPage);
+  console.log("refs", referrals);
 
   return {
     referralsSummary: summary,
@@ -26,5 +42,6 @@ export const useRewardsView = () => {
     pageSize,
     setPageSize,
     pageSizes,
+    totalReferralCount: pagination.total,
   };
 };

--- a/src/views/Rewards/useRewardsView.ts
+++ b/src/views/Rewards/useRewardsView.ts
@@ -26,11 +26,6 @@ export const useRewardsView = () => {
   const { summary, isLoading: isReferalSummaryLoading } =
     useReferralSummary(account);
 
-  console.log("pageSize", pageSize);
-  console.log("total count", summary);
-  console.log("current page", currentPage);
-  console.log("refs", referrals);
-
   return {
     referralsSummary: summary,
     isReferalSummaryLoading,


### PR DESCRIPTION
This fixes a few issues:
1. There was a hardcoded pagination limit of 30, so users couldn't see more than 30 referrals.
2. The elements per page selector disappeared once a user selected a page size that contained more than their total number of elements. So they couldn't reverse the action. This change allows the user to _always_ select a page size even if they don't need it.

To accomplish this, I had to change the way we query a bit. We lazily load each page of the referrals. In the future, we may _not_ want to do this to reduce the total number of queries, but it seemed like the simplest approach for now.

In the code, this also fixes some issues with the way the hooks were built. We were previously using a constant reactQuery key. This was dangerous because we were using account in the query, so theoretically the user could switch accounts and see stale data from the previous account from the cache.
