### PR TITLE
feat: Add pools route to export APYs

### DIFF
--- a/api/_utils.js
+++ b/api/_utils.js
@@ -59,13 +59,33 @@ const infuraProvider = (name) =>
 const bobaProvider = () =>
   new ethers.providers.StaticJsonRpcProvider("https://mainnet.boba.network");
 
+const makeHubPoolClientConfig = () => {
+  return {
+    chainId: 1,
+    hubPoolAddress: "0xc186fA914353c44b2E33eBE05f21846F1048bEda",
+    wethAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    configStoreAddress: "0x3B03509645713718B78951126E0A6de6f10043f5",
+  };
+};
+
+const getHubPoolClient = () => {
+  const hubPoolConfig = makeHubPoolClientConfig();
+  return new sdk.pool.Client(
+    hubPoolConfig,
+    {
+      provider: infuraProvider("mainnet"),
+    },
+    (_, __) => {} // Dummy function that does nothing and is needed to construct this client.
+  );
+};
+
 // Note: this address is used as the from address for simulated relay transactions on Optimism and Arbitrum since
 // gas estimates require a live estimate and not a pre-configured gas amount. This address should be pre-loaded with
 // a USDC approval for the _current_ spoke pools on Optimism (0xa420b2d1c0841415A695b81E5B867BCD07Dff8C9) and Arbitrum
 // (0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C). It also has a small amount of USDC ($0.10) used for estimations.
 // If this address lacks either of these, estimations will fail and relays to optimism and arbitrum will hang when
 // estimating gas. Defaults to 0x893d0d70ad97717052e3aa8903d9615804167759 so the app can technically run without this.
-export const dummyFromAddress =
+const dummyFromAddress =
   process.env.REACT_APP_DUMMY_FROM_ADDRESS ||
   "0x893d0d70ad97717052e3aa8903d9615804167759";
 
@@ -211,4 +231,6 @@ module.exports = {
   maxBN,
   minBN,
   isRouteEnabled,
+  getHubPoolClient,
+  dummyFromAddress,
 };

--- a/api/pools.js
+++ b/api/pools.js
@@ -19,12 +19,9 @@ const handler = async (request, response) => {
     // high volume. "max-age=0" instructs browsers not to cache, while s-maxage instructs Vercel edge caching
     // to cache the responses and invalidate when deployments update.
     response.setHeader("Cache-Control", "s-maxage=300");
-    response
-      .status(200)
-      .json({
-        estimatedApy: hubPoolClient.state.pools[token].estimatedApy,
-        projectedApr: hubPoolClient.state.pools[token].projectedApr,
-      });
+    response.status(200).json({
+      currentApy: hubPoolClient.state.pools[token].estimatedApy,
+    });
   } catch (error) {
     let status;
     if (error instanceof InputError) {

--- a/api/pools.js
+++ b/api/pools.js
@@ -1,0 +1,39 @@
+const ethers = require("ethers");
+
+const { InputError, isString, getHubPoolClient } = require("./_utils");
+
+const handler = async (request, response) => {
+  try {
+    const hubPoolClient = await getHubPoolClient();
+
+    let { token } = request.query;
+    if (!isString(token))
+      throw new InputError("Must provide token as query param");
+
+    token = ethers.utils.getAddress(token);
+
+    await hubPoolClient.updatePool(token);
+
+    // Instruct Vercel to cache limit data for this token for 5 minutes. Caching can be used to limit number of
+    // Vercel invocations and run time for this serverless function and trades off potential inaccuracy in times of
+    // high volume. "max-age=0" instructs browsers not to cache, while s-maxage instructs Vercel edge caching
+    // to cache the responses and invalidate when deployments update.
+    response.setHeader("Cache-Control", "s-maxage=300");
+    response
+      .status(200)
+      .json({
+        estimatedApy: hubPoolClient.state.pools[token].estimatedApy,
+        projectedApr: hubPoolClient.state.pools[token].projectedApr,
+      });
+  } catch (error) {
+    let status;
+    if (error instanceof InputError) {
+      status = 400;
+    } else {
+      status = 500;
+    }
+    response.status(status).send(error.message);
+  }
+};
+
+module.exports = handler;


### PR DESCRIPTION
## Motivation

In order to add Across yield to the [DefiLlama yield server](https://github.com/DefiLlama/yield-server), its convenient if the serverless API exports yield data.