### PR TITLE
feature: allow ref to be used; add catch for when both exist.

### DIFF
--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -1,5 +1,4 @@
 import { ethers } from "ethers";
-import { useQueryParams } from "./useQueryParams";
 import { FormStatus, useSendForm } from "./useSendForm";
 import { useBalanceBySymbol } from "./useBalance";
 import { useBridgeFees } from "./useBridgeFees";
@@ -21,6 +20,7 @@ import {
   trackEvent,
   formatUnits,
 } from "utils";
+import useReferrer from "./useReferrer";
 
 enum SendStatus {
   IDLE = "idle",
@@ -36,11 +36,7 @@ type SendError =
 
 export function useBridge() {
   const config = getConfig();
-  const { referrer, ref: refParam } = useQueryParams();
-  // If ref and referrer params exist, prefer referrer param.
-  // Not likely to happen but should have a catch if we get a bad link.
-  // TODO? Test which of these is a good value?
-  let r = referrer || refParam;
+  const referrer = useReferrer();
 
   const { chainId, account, signer } = useConnection();
   const {
@@ -109,7 +105,7 @@ export function useBridge() {
         isNative: selectedRoute.isNative,
         relayerFeePct: fees.relayerFee.pct,
         timestamp: await hubPool.getCurrentTime(),
-        referrer: r,
+        referrer,
       });
       // matomo track bridge
       trackEvent({

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -37,12 +37,11 @@ type SendError =
 export function useBridge() {
   const config = getConfig();
   const { referrer, ref: refParam } = useQueryParams();
-  let r: string | undefined = undefined;
   // If ref and referrer params exist, prefer referrer param.
   // Not likely to happen but should have a catch if we get a bad link.
   // TODO? Test which of these is a good value?
-  if (refParam) r = refParam;
-  if (referrer) r = referrer;
+  let r = referrer || refParam;
+
   const { chainId, account, signer } = useConnection();
   const {
     amount,

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -36,7 +36,13 @@ type SendError =
 
 export function useBridge() {
   const config = getConfig();
-  const { referrer } = useQueryParams();
+  const { referrer, ref: refParam } = useQueryParams();
+  let r: string | undefined = undefined;
+  // If ref and referrer params exist, prefer referrer param.
+  // Not likely to happen but should have a catch if we get a bad link.
+  // TODO? Test which of these is a good value?
+  if (refParam) r = refParam;
+  if (referrer) r = referrer;
   const { chainId, account, signer } = useConnection();
   const {
     amount,
@@ -104,7 +110,7 @@ export function useBridge() {
         isNative: selectedRoute.isNative,
         relayerFeePct: fees.relayerFee.pct,
         timestamp: await hubPool.getCurrentTime(),
-        referrer,
+        referrer: r,
       });
       // matomo track bridge
       trackEvent({

--- a/src/hooks/useReferrer.ts
+++ b/src/hooks/useReferrer.ts
@@ -1,0 +1,10 @@
+import { useQueryParams } from "./useQueryParams";
+
+export default function useReferrer() {
+  const { referrer, ref: refParam } = useQueryParams();
+  // If ref and referrer params exist, prefer referrer param.
+  // Not likely to happen but should have a catch if we get a bad link.
+  // TODO? Test which of these is a good value?
+  let r = referrer || refParam;
+  return r;
+}

--- a/src/hooks/useReferrer.ts
+++ b/src/hooks/useReferrer.ts
@@ -5,6 +5,5 @@ export default function useReferrer() {
   // If ref and referrer params exist, prefer referrer param.
   // Not likely to happen but should have a catch if we get a bad link.
   // TODO? Test which of these is a good value?
-  let r = referrer || refParam;
-  return r;
+  return referrer || refParam;
 }


### PR DESCRIPTION
ref is an allowable queryParam for referrer.

Note: If for some reason both exist I have defaulted to referrer. If anyone has thoughts on this, let me know.