### PR TITLE
feat: make navbar sticky

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,9 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+
+## Important CSS values
+
+### Z-index
+
+Navbar - 1000

--- a/src/components/Header/Header.styles.tsx
+++ b/src/components/Header/Header.styles.tsx
@@ -2,13 +2,23 @@ import styled from "@emotion/styled";
 import { Link as UnstyledLink } from "react-router-dom";
 import { motion } from "framer-motion";
 
-export const Wrapper = styled.header`
+interface IWrapper {
+  scrollPosition: number;
+}
+export const Wrapper = styled.header<IWrapper>`
   background-color: #2d2e33;
   height: 72px;
   padding: 0 24px;
   display: flex;
   align-items: center;
   color: #c5d5e0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+  border-bottom: ${({ scrollPosition }) => {
+    return scrollPosition > 0 ? "1px solid #4d4f56" : "none";
+  }};
 
   @media (max-width: 428px) {
     height: 64px;

--- a/src/components/Header/Header.styles.tsx
+++ b/src/components/Header/Header.styles.tsx
@@ -17,7 +17,7 @@ export const Wrapper = styled.header<IWrapper>`
   width: 100%;
   z-index: 1000;
   border-bottom: ${({ scrollPosition }) => {
-    return scrollPosition > 0 ? "1px solid #4d4f56" : "none";
+    return scrollPosition > 0 ? "1px solid #4d4f56" : "1px solid transparent";
   }};
 
   @media (max-width: 428px) {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -14,6 +14,7 @@ import {
 import MenuToggle from "./MenuToggle";
 import { enableMigration } from "utils";
 import { ReactComponent as Logo } from "assets/across-mobile-logo.svg";
+import useScrollPosition from "hooks/useScrollPosition";
 
 const LINKS = !enableMigration
   ? [
@@ -30,13 +31,14 @@ interface Props {
 }
 const Header: React.FC<Props> = ({ openSidebar, setOpenSidebar }) => {
   const location = useLocation();
+  const scrollPosition = useScrollPosition();
 
   const toggleMenu = () => {
     setOpenSidebar((prevValue) => !prevValue);
   };
 
   return (
-    <Wrapper>
+    <Wrapper scrollPosition={scrollPosition}>
       <UnstyledLink
         to={{ pathname: "/", search: location.search }}
         style={{ display: "flex" }}

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -127,7 +127,7 @@ const Wrapper = styled.div`
   display: grid;
   padding: 0 10px;
   grid-template-columns: 1fr min(var(--central-content), 100%) 1fr;
-  min-height: 92%;
+  min-height: 100%;
   height: fit-content;
   @media ${QUERIES.tabletAndUp} {
     padding: 0 30px;

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -139,6 +139,7 @@ const Main = styled.main`
   grid-column: 2;
   box-shadow: 0 0 120px hsla(${COLORS.primary[500]} / 0.25);
   clip-path: inset(0px -160px 0px -160px);
+  padding-top: 72px;
 `;
 
 const LinkText = styled.div`

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,3 +9,4 @@ export * from "./useBridge";
 export * from "./useQueryParams";
 export * from "./useError";
 export * from "./useWindowsSize";
+export * from "./useScrollPosition";

--- a/src/hooks/useScrollPosition.ts
+++ b/src/hooks/useScrollPosition.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from "react";
+
+const useScrollPosition = () => {
+  const [scrollPosition, setScrollPosition] = useState(0);
+
+  useEffect(() => {
+    const updatePosition = () => {
+      setScrollPosition(window.pageYOffset);
+    };
+    window.addEventListener("scroll", updatePosition);
+    updatePosition();
+    return () => window.removeEventListener("scroll", updatePosition);
+  }, []);
+
+  return scrollPosition;
+};
+
+export default useScrollPosition;

--- a/src/views/Rewards/Rewards.styles.tsx
+++ b/src/views/Rewards/Rewards.styles.tsx
@@ -8,6 +8,7 @@ export const Wrapper = styled.div`
   flex-direction: column;
   justify-content: space-between;
   min-height: calc(100% - 72px);
+  padding-top: 72px;
 
   @media (max-width: 428px) {
     min-height: calc(100% - 64px);

--- a/src/views/Rewards/comp/RewardReferral/RewardReferral.styles.tsx
+++ b/src/views/Rewards/comp/RewardReferral/RewardReferral.styles.tsx
@@ -108,7 +108,7 @@ export const ReferralUrl = styled.button`
   margin: 0 0 8px;
   width: 100%;
   display: flex;
-  justify-content: space-between;
+  justify-content: inherit;
   align-items: center;
   padding: ${18 / 16}rem ${18 / 16}rem;
   font-size: ${18 / 16}rem;

--- a/src/views/Rewards/comp/RewardReferral/RewardReferral.tsx
+++ b/src/views/Rewards/comp/RewardReferral/RewardReferral.tsx
@@ -75,13 +75,13 @@ const ReferralLinkComponent: React.FC<{
   const [showCheck, setShowCheck] = useState(false);
   const referralUrl = useMemo(() => {
     if (referrer) {
-      return `across.to?referrer=${referrer}`;
+      return `across.to?ref=${referrer}`;
     }
     return "";
   }, [referrer]);
   const displayedReferralUrl = useMemo(() => {
     if (referrer) {
-      return `across.to?referrer=${shortenAddress(referrer, "..", 3)}`;
+      return `across.to?ref=${shortenAddress(referrer, "..", 3)}`;
     }
     return "";
   }, [referrer]);

--- a/src/views/Rewards/useRewardsView.ts
+++ b/src/views/Rewards/useRewardsView.ts
@@ -3,6 +3,7 @@ import { useState, useMemo } from "react";
 import { useConnection } from "state/hooks";
 import { useReferrals } from "hooks/useReferrals";
 import { useReferralSummary } from "hooks/useReferralSummary";
+
 const DEFAULT_PAGE_SIZE = 10;
 
 export const useRewardsView = () => {

--- a/src/views/Transactions/Transactions.styles.tsx
+++ b/src/views/Transactions/Transactions.styles.tsx
@@ -3,6 +3,7 @@ import { PrimaryButton } from "components/Buttons";
 import { QUERIES } from "utils";
 
 export const Wrapper = styled.div`
+  padding-top: 72px;
   background-color: transparent;
 `;
 


### PR DESCRIPTION
Created useScrollPosition hook, when SP > 0 add a border to the navbar
<img width="1477" alt="Screen Shot 2022-07-27 at 2 36 10 PM" src="https://user-images.githubusercontent.com/12792146/181376898-8062babf-c919-4109-bbc2-5255f43f3cc1.png">

Needs QA
Overview

Acceptance Criteria

How To Report QA
Testers, use the following templates to pass the pull request or to report issues that require a resolution. Following these guidelines will help the developer respond more quickly to issues, but you are free to comment in any way as needed to help resolve issues.

Reporting QA Issues

Testers should use Github comments to report issues with the PR. Use screenshots if relevant, you can also check the [developer console](https://support.airtable.com/hc/en-us/articles/232313848-How-to-open-the-developer-console) to see if there are any logs which might be related. Use the following template when reporting a problem or issue with the PR. You submit multiple comments using this template if there are multiple issues.

**QA Issue**
1. Navbar stays stick when you can scroll down.
2. Border bottom is added.
3. Responsive.


**Repro Steps**
Be able to scroll viewport.
