### PR TITLE
fix: hide pagination when not connected.

### DIFF
--- a/src/views/Rewards/comp/RewardTableWithOverlay/RewardTableWithOverlay.tsx
+++ b/src/views/Rewards/comp/RewardTableWithOverlay/RewardTableWithOverlay.tsx
@@ -48,15 +48,17 @@ const RewardTableWithOverlay: React.FC<{
         rows={paginatedRows}
         headers={headers}
       />
-      <div>
-        <Pagination
-          onPageSizeChange={setPageSize}
-          pageSize={pageSize}
-          pageSizes={pageSizes}
-          onPageChange={setCurrentPage}
-          {...paginateState}
-        />
-      </div>
+      {isConnected && (
+        <div>
+          <Pagination
+            onPageSizeChange={setPageSize}
+            pageSize={pageSize}
+            pageSizes={pageSizes}
+            onPageChange={setCurrentPage}
+            {...paginateState}
+          />
+        </div>
+      )}
     </Wrapper>
   );
 };


### PR DESCRIPTION
Add condition where pagination component only shows when connected, as it's not clickable anyway.

Signed-off-by: Tulun <jaykiraly@gmail.com>
