### PR TITLE
fix: update bridge fee name

### DIFF
--- a/src/hooks/useReferrals.ts
+++ b/src/hooks/useReferrals.ts
@@ -12,7 +12,8 @@ export interface Referral {
   depositorAddr: string;
   referralAddress: string;
   depositDate: string;
-  realizedLpFeeUsd: number;
+  realizedLpFeeUsd?: number;
+  bridgeFeeUsd?: number;
   referralRate: number;
   acxRewards: string;
 }

--- a/src/views/Rewards/comp/RewardTable/createMyReferralsTableJSX.tsx
+++ b/src/views/Rewards/comp/RewardTable/createMyReferralsTableJSX.tsx
@@ -164,11 +164,14 @@ function formatMyReferralsRows(referrals: Referral[], account: string): IRow[] {
         {
           value: (
             <BridgeFeeCell>
-              {r.realizedLpFeeUsd.toLocaleString("en-US", {
-                style: "currency",
-                currency: "USD",
-                minimumFractionDigits: 4,
-              })}
+              {(r.realizedLpFeeUsd || r.bridgeFeeUsd || 0).toLocaleString(
+                "en-US",
+                {
+                  style: "currency",
+                  currency: "USD",
+                  minimumFractionDigits: 4,
+                }
+              )}
             </BridgeFeeCell>
           ),
         },


### PR DESCRIPTION
In the next deployed version of the rewards API, the `realizedLpFeeUsd` field will be replaced by `bridgeFeeUsd`. I added the new field name as fallback when the old field will stop coming from the API. After the new API will be deployed, I'll remove entirely the usage of `realizedLpFeeUsd` response field