### PR TITLE
fix: copy url is more proper link to fix youtube encoding

### DIFF
--- a/src/views/Rewards/comp/RewardReferral/RewardReferral.tsx
+++ b/src/views/Rewards/comp/RewardReferral/RewardReferral.tsx
@@ -75,7 +75,7 @@ const ReferralLinkComponent: React.FC<{
   const [showCheck, setShowCheck] = useState(false);
   const referralUrl = useMemo(() => {
     if (referrer) {
-      return `across.to?ref=${referrer}`;
+      return `https://across.to/?ref=${referrer}`;
     }
     return "";
   }, [referrer]);


### PR DESCRIPTION
Youtube has strict encoding to create a link on its platform. Adhere to that standard, which should work in other places just fine.