### PR TITLE
feat(api): add coingecko route

### DIFF
--- a/api/_utils.js
+++ b/api/_utils.js
@@ -148,12 +148,7 @@ const queries = {
 
 const maxRelayFeePct = 0.25;
 
-const getRelayerFeeDetails = (l1Token, amount, destinationChainId) => {
-  const tokenSymbol = Object.entries(sdk.relayFeeCalculator.SymbolMapping).find(
-    ([_symbol, { address }]) => address.toLowerCase() === l1Token.toLowerCase()
-  )[0];
-  console.log(`INFO(getRelayerFeeDetails): Token symbol ${tokenSymbol}`);
-
+const getRelayerFeeCalculator = (destinationChainId) => {
   const relayerFeeCalculatorConfig = {
     feeLimitPercent: maxRelayFeePct * 100,
     capitalCostsPercent: 0.04,
@@ -163,10 +158,26 @@ const getRelayerFeeDetails = (l1Token, amount, destinationChainId) => {
   console.log(
     `INFO(getRelayerFeeDetails): relayer fee calculator config ${relayerFeeCalculatorConfig}`
   );
-  const relayFeeCalculator = new sdk.relayFeeCalculator.RelayFeeCalculator(
+  return new sdk.relayFeeCalculator.RelayFeeCalculator(
     relayerFeeCalculatorConfig
   );
+};
+const getRelayerFeeDetails = (l1Token, amount, destinationChainId) => {
+  const tokenSymbol = Object.entries(sdk.relayFeeCalculator.SymbolMapping).find(
+    ([_symbol, { address }]) => address.toLowerCase() === l1Token.toLowerCase()
+  )[0];
+  console.log(`INFO(getRelayerFeeDetails): Token symbol ${tokenSymbol}`);
+  const relayFeeCalculator = getRelayerFeeCalculator(destinationChainId);
   return relayFeeCalculator.relayerFeeDetails(amount, tokenSymbol);
+};
+
+const getTokenPrice = (l1Token, destinationChainId) => {
+  const tokenSymbol = Object.entries(sdk.relayFeeCalculator.SymbolMapping).find(
+    ([_symbol, { address }]) => address.toLowerCase() === l1Token.toLowerCase()
+  )[0];
+  console.log(`INFO(getTokenPrice): Token symbol ${tokenSymbol}`);
+  const relayFeeCalculator = getRelayerFeeCalculator(destinationChainId);
+  return relayFeeCalculator.getTokenPrice(tokenSymbol);
 };
 
 const providerCache = {};
@@ -264,6 +275,7 @@ module.exports = {
   infuraProvider,
   bobaProvider,
   getRelayerFeeDetails,
+  getTokenPrice,
   maxRelayFeePct,
   getProvider,
   getBalance,

--- a/api/_utils.js
+++ b/api/_utils.js
@@ -162,19 +162,21 @@ const getRelayerFeeCalculator = (destinationChainId) => {
     relayerFeeCalculatorConfig
   );
 };
-const getRelayerFeeDetails = (l1Token, amount, destinationChainId) => {
-  const tokenSymbol = Object.entries(sdk.relayFeeCalculator.SymbolMapping).find(
-    ([_symbol, { address }]) => address.toLowerCase() === l1Token.toLowerCase()
+const getTokenSymbol = (tokenAddress) => {
+  return Object.entries(sdk.relayFeeCalculator.SymbolMapping).find(
+    ([_symbol, { address }]) =>
+      address.toLowerCase() === tokenAddress.toLowerCase()
   )[0];
+};
+const getRelayerFeeDetails = (l1Token, amount, destinationChainId) => {
+  const tokenSymbol = getTokenSymbol(l1Token);
   console.log(`INFO(getRelayerFeeDetails): Token symbol ${tokenSymbol}`);
   const relayFeeCalculator = getRelayerFeeCalculator(destinationChainId);
   return relayFeeCalculator.relayerFeeDetails(amount, tokenSymbol);
 };
 
 const getTokenPrice = (l1Token, destinationChainId) => {
-  const tokenSymbol = Object.entries(sdk.relayFeeCalculator.SymbolMapping).find(
-    ([_symbol, { address }]) => address.toLowerCase() === l1Token.toLowerCase()
-  )[0];
+  const tokenSymbol = getTokenSymbol(l1Token);
   console.log(`INFO(getTokenPrice): Token symbol ${tokenSymbol}`);
   const relayFeeCalculator = getRelayerFeeCalculator(destinationChainId);
   return relayFeeCalculator.getTokenPrice(tokenSymbol);

--- a/api/coingecko.js
+++ b/api/coingecko.js
@@ -3,7 +3,7 @@ const ethers = require("ethers");
 const { InputError, isString, getTokenPrice } = require("./_utils");
 
 const handler = async (request, response) => {
-  console.log(`INFO(pools): Handling request to /coingecko ${request}`);
+  console.log(`INFO(pools): Handling request to /coingecko`, request);
 
   try {
     let { l1Token } = request.query;
@@ -12,7 +12,7 @@ const handler = async (request, response) => {
 
     l1Token = ethers.utils.getAddress(l1Token);
 
-    const price = await getTokenPrice(l1Token);
+    const price = await getTokenPrice(l1Token, 1);
 
     // This tells our CDN the value is fresh for one second. If a request is repeated within the next second,
     // the previously cached value is still fresh. The header x-vercel-cache present in the response will show the

--- a/api/coingecko.js
+++ b/api/coingecko.js
@@ -14,14 +14,24 @@ const handler = async (request, response) => {
 
     const price = await getTokenPrice(l1Token, 1);
 
-    // This tells our CDN the value is fresh for one second. If a request is repeated within the next second,
+    // Two different explanations for how `stale-while-revalidate` works:
+
+    // https://vercel.com/docs/concepts/edge-network/caching#stale-while-revalidate
+    // This tells our CDN the value is fresh for 10 seconds. If a request is repeated within the next 10 seconds,
     // the previously cached value is still fresh. The header x-vercel-cache present in the response will show the
-    // value HIT. If the request is repeated between 1 and 60 seconds later, the cached value will be stale but
+    // value HIT. If the request is repeated between 1 and 20 seconds later, the cached value will be stale but
     // still render. In the background, a revalidation request will be made to populate the cache with a fresh value.
     // x-vercel-cache will have the value STALE until the cache is refreshed.
+
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+    // The response is fresh for 10s. After 10s it becomes stale, but the cache is allowed to reuse it
+    // for any requests that are made in the following 20s, provided that they revalidate the response in the background.
+    // Revalidation will make the cache be fresh again, so it appears to clients that it was always fresh during
+    // that period — effectively hiding the latency penalty of revalidation from them.
+    // If no request happened during that period, the cache became stale and the next request will revalidate normally.
     response.setHeader(
       "Cache-Control",
-      "s-maxage=1, stale-while-revalidate=59"
+      "s-maxage=10, stale-while-revalidate=20"
     );
     response.status(200).json({ price });
   } catch (error) {

--- a/api/coingecko.js
+++ b/api/coingecko.js
@@ -1,0 +1,40 @@
+const ethers = require("ethers");
+
+const { InputError, isString, getTokenPrice } = require("./_utils");
+
+const handler = async (request, response) => {
+  console.log(`INFO(pools): Handling request to /coingecko ${request}`);
+
+  try {
+    let { l1Token } = request.query;
+    if (!isString(l1Token))
+      throw new InputError("Must provide l1Token as query param");
+
+    l1Token = ethers.utils.getAddress(l1Token);
+
+    const price = await getTokenPrice(l1Token);
+
+    // This tells our CDN the value is fresh for one second. If a request is repeated within the next second,
+    // the previously cached value is still fresh. The header x-vercel-cache present in the response will show the
+    // value HIT. If the request is repeated between 1 and 60 seconds later, the cached value will be stale but
+    // still render. In the background, a revalidation request will be made to populate the cache with a fresh value.
+    // x-vercel-cache will have the value STALE until the cache is refreshed.
+    response.setHeader(
+      "Cache-Control",
+      "s-maxage=1, stale-while-revalidate=59"
+    );
+    response.status(200).json({ price });
+  } catch (error) {
+    console.log(`ERROR(coingecko): Error found: ${error}`);
+
+    let status;
+    if (error instanceof InputError) {
+      status = 400;
+    } else {
+      status = 500;
+    }
+    response.status(status).send(error.message);
+  }
+};
+
+module.exports = handler;

--- a/api/limits.js
+++ b/api/limits.js
@@ -18,7 +18,7 @@ const {
 } = require("./_utils");
 
 const handler = async (request, response) => {
-  console.log(`INFO(limits): Handling request to /limits ${request}`);
+  console.log(`INFO(limits): Handling request to /limits`, request);
 
   try {
     const {

--- a/api/limits.js
+++ b/api/limits.js
@@ -99,6 +99,8 @@ const handler = async (request, response) => {
       hubPool.interface.encodeFunctionData("pooledTokens", [l1Token]),
     ];
 
+    // TODO: Get token price first from /coingecko route, which we'll use as input to getRelayerFeeDetails
+
     console.log(
       `INFO(limits): Sending several requests to HubPool ${multicallInput} and fetching relayer balances`
     );

--- a/api/pools.js
+++ b/api/pools.js
@@ -3,7 +3,7 @@ const ethers = require("ethers");
 const { InputError, isString, getHubPoolClient } = require("./_utils");
 
 const handler = async (request, response) => {
-  console.log(`INFO(pools): Handling request to /pools ${request}`);
+  console.log(`INFO(pools): Handling request to /pools`, request);
 
   try {
     const hubPoolClient = await getHubPoolClient();

--- a/api/suggested-fees.js
+++ b/api/suggested-fees.js
@@ -17,7 +17,8 @@ const {
 
 const handler = async (request, response) => {
   console.log(
-    `INFO(suggested-fees): Handling request to /suggested-fees ${request}`
+    `INFO(suggested-fees): Handling request to /suggested-fees`,
+    request
   );
   try {
     const provider = infuraProvider("mainnet");

--- a/test/api/main.test.js
+++ b/test/api/main.test.js
@@ -1,24 +1,30 @@
 const limitsHandler = require("../../api/limits");
 const feesHandler = require("../../api/suggested-fees");
+const poolsHandler = require("../../api/pools");
+const coingeckoHandler = require("../../api/coingecko");
 
 // Public infura key published in @umaprotocol/packages/common/ProviderUtils
 process.env.REACT_APP_PUBLIC_INFURA_ID = "e34138b2db5b496ab5cc52319d2f0299";
 
 // Create mocked response object:
-const response = {};
-response.status = jest.fn().mockReturnValue(response);
-response.send = jest.fn();
+let response;
+const getMockedResponse = () => {
+  const response = {};
+  response.status = jest.fn().mockReturnValue(response);
+  response.send = jest.fn();
+  return response;
+};
 
 // Query params must be strings or server should return 400. In these tests we purposefully trigger 400 errors because
 // we want to test that the handler is importing all files and building correctly. We don't attempt to trigger 200
 // successful responses because its difficult to replicate the production server.
 const request = {
-  query: {
-    token: "0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    destinationChainId: 1,
-  },
+  query: {},
 };
 
+beforeEach(() => {
+  response = getMockedResponse();
+});
 test("limits has no load-time errors", async () => {
   await limitsHandler(request, response);
   expect(response.status).toHaveBeenCalledWith(400);
@@ -31,5 +37,19 @@ test("suggested-fees has no load-time errors", async () => {
   expect(response.status).toHaveBeenCalledWith(400);
   expect(response.send).toHaveBeenCalledWith(
     "Must provide amount, token, and destinationChainId as query params"
+  );
+});
+test("pools has no load-time errors", async () => {
+  await poolsHandler(request, response);
+  expect(response.status).toHaveBeenCalledWith(400);
+  expect(response.send).toHaveBeenCalledWith(
+    "Must provide token as query param"
+  );
+});
+test("coingecko has no load-time errors", async () => {
+  await coingeckoHandler(request, response);
+  expect(response.status).toHaveBeenCalledWith(400);
+  expect(response.send).toHaveBeenCalledWith(
+    "Must provide l1Token as query param"
   );
 });


### PR DESCRIPTION
Adds route that can cache coingecko pro API responses via Vercel edge caching. We'll be able to call this route internally from /limits and /suggested-fees to reduce coingecko pro API hits