### PR TITLE
Make slow relay delay longer due to bundle block delays

### DIFF
--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -182,7 +182,7 @@ export const getConfirmationDepositTime = (
   }
 
   // If the deposit size is above those, but is allowed by the app, we assume the pool will slow relay it.
-  return "~2-4 hours";
+  return "~3-7 hours";
 };
 
 type AcrossDepositArgs = {


### PR DESCRIPTION
Because bundles are usually delayed from proposing immediately after a previous one, we should extend the time that we estimate for slow relays.
