### PR TITLE
chore: bump sdk-v2 to 0.1.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@across-protocol/contracts-v2": "^0.0.34",
-    "@across-protocol/sdk-v2": "^0.1.18",
+    "@across-protocol/sdk-v2": "^0.1.19",
     "@datapunt/matomo-tracker-js": "^0.5.1",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@^0.1.18":
-  version "0.1.18"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.1.18.tgz#c7f886a95031e59d4dbdb7d81a2946b7e976bb08"
-  integrity sha512-HgSOElsTymvpRrmOPbjEO144ywdrYKFrY6fodAelAxA2uF8QwUQLDbEhXG7lipRpIjjzBoH4fA+U5iCjk7XJdw==
+"@across-protocol/sdk-v2@^0.1.19":
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.1.19.tgz#2b6c1349dd99633b870a3d41751d24929cc4ba00"
+  integrity sha512-6/Lm1Szx+bhF8a13N1GZwnvLkJtI9OFFcTCjxLNzPnk987/qQtAsxeHp2kTE4LQDq1zbrkJRqeqL3F/d4Pu96w==
   dependencies:
     "@across-protocol/contracts-v2" "^0.0.50"
     "@eth-optimism/sdk" "^1.1.4"


### PR DESCRIPTION
Desired feature from this sdk version is an improved coingecko client that reduces the amount of requests sent to the Pro API: https://github.com/across-protocol/sdk-v2/commit/ca0de27d29e84b4a6ea42bb4a325ada2c0c63121