### PR TITLE
fix: fix checksum address issue in routes computation

### DIFF
--- a/api/_utils.js
+++ b/api/_utils.js
@@ -379,7 +379,7 @@ const isRouteEnabled = (fromChainId, toChainId, fromToken) => {
     ({ fromTokenAddress, fromChain, toChain }) =>
       fromChainId === fromChain &&
       toChainId === toChain &&
-      fromToken === fromTokenAddress
+      fromToken.toLowerCase() === fromTokenAddress.toLowerCase()
   );
   return enabled;
 };

--- a/src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json
+++ b/src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json
@@ -546,7 +546,7 @@
     {
       "fromChain": 137,
       "toChain": 1,
-      "fromTokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+      "fromTokenAddress": "0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3",
       "fromSpokeAddress": "0x69B5c72837769eF1e7C164Abc6515DcFf217F920",
       "fromTokenSymbol": "BAL",
       "isNative": false,
@@ -600,7 +600,7 @@
     {
       "fromChain": 137,
       "toChain": 10,
-      "fromTokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+      "fromTokenAddress": "0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3",
       "fromSpokeAddress": "0x69B5c72837769eF1e7C164Abc6515DcFf217F920",
       "fromTokenSymbol": "BAL",
       "isNative": false,
@@ -699,7 +699,7 @@
     {
       "fromChain": 137,
       "toChain": 42161,
-      "fromTokenAddress": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+      "fromTokenAddress": "0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3",
       "fromSpokeAddress": "0x69B5c72837769eF1e7C164Abc6515DcFf217F920",
       "fromTokenSymbol": "BAL",
       "isNative": false,
@@ -988,7 +988,7 @@
     {
       "fromChain": 42161,
       "toChain": 1,
-      "fromTokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+      "fromTokenAddress": "0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8",
       "fromSpokeAddress": "0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C",
       "fromTokenSymbol": "BAL",
       "isNative": false,
@@ -1051,7 +1051,7 @@
     {
       "fromChain": 42161,
       "toChain": 10,
-      "fromTokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+      "fromTokenAddress": "0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8",
       "fromSpokeAddress": "0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C",
       "fromTokenSymbol": "BAL",
       "isNative": false,
@@ -1114,7 +1114,7 @@
     {
       "fromChain": 42161,
       "toChain": 137,
-      "fromTokenAddress": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+      "fromTokenAddress": "0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8",
       "fromSpokeAddress": "0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C",
       "fromTokenSymbol": "BAL",
       "isNative": false,


### PR DESCRIPTION
This fixes a bug in the routes computation where some of the added addresses were not in the checksum format.

Changes:
- Updates those addresses to the correct checksum format.
- Changes the failing comparison to use .toLowerCase before comparing to ensure that non-checksummed addresses would work (i.e. this will prevent this sort of thing in the future).

In general, we should _always_ use checksummed addresses, but a resilient comparison function will mean that mistakes in the input format will not cause bugs like this.
