### PR TITLE
feat: speed up modal

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -10,3 +10,4 @@ export * from "./useQueryParams";
 export * from "./useError";
 export * from "./useWindowsSize";
 export * from "./useScrollPosition";
+export * from "./useNotify";

--- a/src/hooks/useNotify.ts
+++ b/src/hooks/useNotify.ts
@@ -1,0 +1,77 @@
+import { useEffect, useState, useCallback } from "react";
+import { ContractTransaction } from "ethers";
+
+import { useConnection } from "state/hooks";
+import { supportedNotifyChainIds } from "utils/constants";
+import { getChainInfo } from "utils";
+
+type TxStatus = "idle" | "pending" | "success" | "error";
+
+export function useNotify() {
+  const [chainId, setChainId] = useState<number | undefined>();
+  const [txResponse, setTxResponse] = useState<
+    ContractTransaction | undefined
+  >();
+  const [txStatus, setTxStatus] = useState<TxStatus>("idle");
+  const [txErrorMsg, setTxErrorMsg] = useState<string | undefined>();
+
+  const { notify, setNotifyConfig } = useConnection();
+
+  const cleanup = useCallback(() => {
+    if (txResponse) {
+      notify.unsubscribe(txResponse.hash);
+      setChainId(undefined);
+      setTxResponse(undefined);
+      setNotifyConfig({
+        networkId: 1,
+      });
+    }
+  }, [txResponse, notify, setNotifyConfig]);
+
+  useEffect(() => {
+    if (txResponse && chainId) {
+      setTxStatus("pending");
+
+      if (supportedNotifyChainIds.includes(chainId)) {
+        const { emitter } = notify.hash(txResponse.hash);
+        setNotifyConfig({
+          networkId: chainId,
+        });
+
+        emitter.on("txSent", () => {
+          return {
+            link: getChainInfo(chainId).constructExplorerLink(txResponse.hash),
+          };
+        });
+        emitter.on("txConfirmed", () => {
+          setTxStatus("success");
+          cleanup();
+        });
+        emitter.on("txFailed", () => {
+          setTxStatus("error");
+          setTxErrorMsg("Tx failed");
+          cleanup();
+        });
+      } else {
+        // TODO: We could still trigger notifications for chains that are not supported by Notify.
+        // See https://docs.blocknative.com/notify#notification
+        txResponse
+          .wait()
+          .then(() => {
+            setTxStatus("success");
+          })
+          .catch((error) => {
+            setTxStatus("error");
+            setTxErrorMsg(error.message);
+          });
+      }
+    }
+  }, [txResponse, cleanup, setNotifyConfig, chainId, notify]);
+
+  return {
+    setChainId,
+    setTxResponse,
+    txStatus,
+    txErrorMsg,
+  };
+}

--- a/src/hooks/useOnboard.tsx
+++ b/src/hooks/useOnboard.tsx
@@ -20,7 +20,7 @@ import { Account } from "@web3-onboard/core/dist/types";
 import { useConnectWallet, useSetChain } from "@web3-onboard/react";
 import { Chain } from "@web3-onboard/common";
 import { ethers } from "ethers";
-import Notify, { API as NotifyAPI, InitOptions } from "bnc-notify";
+import Notify, { API as NotifyAPI, ConfigOptions } from "bnc-notify";
 
 export type SetChainOptions = {
   chainId: string;
@@ -40,22 +40,17 @@ type OnboardContextValue = {
   signer: ethers.providers.JsonRpcSigner | undefined;
   provider: ethers.providers.Web3Provider | null;
   notify: NotifyAPI;
-  createNotify: (opts?: InitOptions) => NotifyAPI;
+  setNotifyConfig: (opts: ConfigOptions) => void;
   account: Account | null;
   chainId: ChainId;
   error?: Error;
 };
 
-function createNotify(opts?: InitOptions) {
-  return Notify({
-    dappId: process.env.REACT_APP_PUBLIC_ONBOARD_API_KEY, // [String] The API key created by step one above
-    networkId: 1,
-    desktopPosition: "topRight",
-    ...opts,
-  });
-}
-
-const defaultNotify = createNotify();
+const notify = Notify({
+  dappId: process.env.REACT_APP_PUBLIC_ONBOARD_API_KEY,
+  networkId: 1,
+  desktopPosition: "topRight",
+});
 
 function useOnboardManager() {
   const [onboard, setOnboard] = useState<OnboardAPI | null>(null);
@@ -118,8 +113,8 @@ function useOnboardManager() {
     isConnected: !!connectedChain,
     signer,
     provider,
-    notify: defaultNotify,
-    createNotify,
+    notify,
+    setNotifyConfig: (config: ConfigOptions) => notify.config(config),
     account,
     chainId: (Number(wallet?.chains[0].id) as ChainId) || 0,
     error,

--- a/src/hooks/useOnboard.tsx
+++ b/src/hooks/useOnboard.tsx
@@ -20,7 +20,7 @@ import { Account } from "@web3-onboard/core/dist/types";
 import { useConnectWallet, useSetChain } from "@web3-onboard/react";
 import { Chain } from "@web3-onboard/common";
 import { ethers } from "ethers";
-import Notify, { API as NotifyAPI } from "bnc-notify";
+import Notify, { API as NotifyAPI, InitOptions } from "bnc-notify";
 
 export type SetChainOptions = {
   chainId: string;
@@ -40,16 +40,22 @@ type OnboardContextValue = {
   signer: ethers.providers.JsonRpcSigner | undefined;
   provider: ethers.providers.Web3Provider | null;
   notify: NotifyAPI;
+  createNotify: (opts?: InitOptions) => NotifyAPI;
   account: Account | null;
   chainId: ChainId;
   error?: Error;
 };
 
-const notify = Notify({
-  dappId: process.env.REACT_APP_PUBLIC_ONBOARD_API_KEY, // [String] The API key created by step one above
-  networkId: 1,
-  desktopPosition: "topRight",
-});
+function createNotify(opts?: InitOptions) {
+  return Notify({
+    dappId: process.env.REACT_APP_PUBLIC_ONBOARD_API_KEY, // [String] The API key created by step one above
+    networkId: 1,
+    desktopPosition: "topRight",
+    ...opts,
+  });
+}
+
+const defaultNotify = createNotify();
 
 function useOnboardManager() {
   const [onboard, setOnboard] = useState<OnboardAPI | null>(null);
@@ -112,7 +118,8 @@ function useOnboardManager() {
     isConnected: !!connectedChain,
     signer,
     provider,
-    notify,
+    notify: defaultNotify,
+    createNotify,
     account,
     chainId: (Number(wallet?.chains[0].id) as ChainId) || 0,
     error,

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -28,7 +28,7 @@ export function useConnection() {
     wallet,
     error,
     setChain,
-    createNotify,
+    setNotifyConfig,
   } = useOnboard();
 
   useEffect(() => {
@@ -53,7 +53,7 @@ export function useConnection() {
     signer,
     isConnected,
     notify,
-    createNotify,
+    setNotifyConfig,
     connect,
     disconnect,
     error,

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -28,6 +28,7 @@ export function useConnection() {
     wallet,
     error,
     setChain,
+    createNotify,
   } = useOnboard();
 
   useEffect(() => {
@@ -52,6 +53,7 @@ export function useConnection() {
     signer,
     isConnected,
     notify,
+    createNotify,
     connect,
     disconnect,
     error,

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -27,6 +27,7 @@ export function useConnection() {
     chainId,
     wallet,
     error,
+    setChain,
   } = useOnboard();
 
   useEffect(() => {
@@ -55,6 +56,7 @@ export function useConnection() {
     disconnect,
     error,
     wallet,
+    setChain,
     isContractAddress,
   };
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -716,3 +716,6 @@ export const usdcLpCushion = process.env.REACT_APP_USDC_LP_CUSHION || "0";
 export const wethLpCushion = process.env.REACT_APP_WETH_LP_CUSHION || "0";
 export const wbtcLpCushion = process.env.REACT_APP_WBTC_LP_CUSHION || "0";
 export const daiLpCushion = process.env.REACT_APP_DAI_LP_CUSHION || "0";
+
+// Chains where Blocknative Notify can be used. See https://docs.blocknative.com/notify#initialization
+export const supportedNotifyChainIds = [1, 3, 4, 5, 42, 56, 100, 137, 250];

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -717,5 +717,7 @@ export const wethLpCushion = process.env.REACT_APP_WETH_LP_CUSHION || "0";
 export const wbtcLpCushion = process.env.REACT_APP_WBTC_LP_CUSHION || "0";
 export const daiLpCushion = process.env.REACT_APP_DAI_LP_CUSHION || "0";
 
+export const maxRelayFee = 0.25; // 25%
+export const minRelayFee = 0.0003; // 0.03%
 // Chains where Blocknative Notify can be used. See https://docs.blocknative.com/notify#initialization
 export const supportedNotifyChainIds = [1, 3, 4, 5, 42, 56, 100, 137, 250];

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -162,7 +162,5 @@ export function formatPoolAPY(
 }
 
 export function formatWeiPct(wei: ethers.BigNumberish, precision: number = 3) {
-  return new Intl.NumberFormat("en-US", {
-    maximumFractionDigits: precision,
-  }).format(Number(ethers.utils.formatEther(wei)) * 100);
+  return (Number(ethers.utils.formatEther(wei)) * 100).toFixed(precision);
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -84,6 +84,10 @@ export function formatUnits(
   return smallNumberFormatter(value);
 }
 
+export function makeFormatUnits(decimals: number) {
+  return (wei: ethers.BigNumberish) => formatUnits(wei, decimals);
+}
+
 export function formatEther(wei: ethers.BigNumberish): string {
   return formatUnits(wei, 18);
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -157,11 +157,8 @@ export function formatPoolAPY(
   );
 }
 
-export function formatWeiPct(
-  wei: ethers.BigNumberish,
-  maxFractions: number = 3
-) {
+export function formatWeiPct(wei: ethers.BigNumberish, precision: number = 3) {
   return new Intl.NumberFormat("en-US", {
-    maximumFractionDigits: maxFractions,
+    maximumFractionDigits: precision,
   }).format(Number(ethers.utils.formatEther(wei)) * 100);
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -162,5 +162,7 @@ export function formatPoolAPY(
 }
 
 export function formatWeiPct(wei: ethers.BigNumberish, precision: number = 3) {
-  return (Number(ethers.utils.formatEther(wei)) * 100).toFixed(precision);
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: precision,
+  }).format(Number(ethers.utils.formatEther(wei)) * 100);
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -156,3 +156,12 @@ export function formatPoolAPY(
     Number(ethers.utils.formatUnits(wei, decimals))
   );
 }
+
+export function formatWeiPct(
+  wei: ethers.BigNumberish,
+  maxFractions: number = 3
+) {
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: maxFractions,
+  }).format(Number(ethers.utils.formatEther(wei)) * 100);
+}

--- a/src/views/Transactions/MyTransactions.tsx
+++ b/src/views/Transactions/MyTransactions.tsx
@@ -75,6 +75,7 @@ export function MyTransactions() {
           transferTuples={pendingTransferTuples}
           enablePartialFillInfoIcon
           isMobile={isMobile}
+          enableSpeedUps
         />
       }
       FilledTransactionsTable={

--- a/src/views/Transactions/Transactions.styles.tsx
+++ b/src/views/Transactions/Transactions.styles.tsx
@@ -14,7 +14,6 @@ export const TitleContainer = styled.div`
   max-width: 1425px;
   @media ${QUERIES.tabletAndDown} {
     flex-direction: column;
-    /* align-items: flex-start; */
   }
 `;
 

--- a/src/views/Transactions/components/SpeedUpModal/InputWithButton.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/InputWithButton.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from "react";
+import styled from "@emotion/styled";
+
+type Props = React.HTMLProps<HTMLInputElement> & {
+  label?: string;
+  error?: string;
+  Button: React.ReactElement;
+};
+
+export function InputWithButton({
+  label,
+  error,
+  Button,
+  onBlur,
+  onFocus,
+  ...inputProps
+}: Props) {
+  const [isInputFocused, setIsInputFocused] = useState(false);
+
+  return (
+    <Container>
+      <InputContainer>
+        {label && <label>{label}</label>}
+        <InputWithButtonContainer
+          isInputFocused={isInputFocused}
+          hasError={!!error}
+        >
+          <input
+            onFocus={(e) => {
+              setIsInputFocused(true);
+              onFocus && onFocus(e);
+            }}
+            onBlur={(e) => {
+              setIsInputFocused(false);
+              onBlur && onBlur(e);
+            }}
+            {...inputProps}
+          />
+          {Button}
+        </InputWithButtonContainer>
+      </InputContainer>
+      {error && <ErrorContainer>{error}</ErrorContainer>}
+    </Container>
+  );
+}
+
+const Container = styled.div``;
+
+const InputContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 16px;
+
+  label {
+    font-weight: 400;
+    font-size: ${18 / 16}rem;
+    line-height: ${26 / 16}rem;
+    color: #9daab2;
+  }
+`;
+
+const InputWithButtonContainer = styled.div<{
+  isInputFocused: boolean;
+  hasError: boolean;
+}>`
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  background: #2d2e33;
+  border: 1px solid
+    ${({ isInputFocused, hasError }) =>
+      hasError ? "#f96c6c" : isInputFocused ? "#E0F3FF" : "#3e4047"};
+  border-radius: 32px;
+  padding: 9px 24px;
+  height: 64px;
+  gap: 16px;
+
+  color: #9daab2;
+  font-weight: 400;
+
+  input {
+    flex: 1;
+    color: #9daab2;
+    font-weight: 400;
+    font-size: 18px;
+    line-height: 26px;
+
+    border: none;
+    outline: none;
+    background: transparent;
+  }
+
+  button {
+    cursor: pointer;
+    color: #9daab2;
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 14px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+
+    background-color: transparent;
+    border: 1px solid #4c4e57;
+    border-radius: 24px;
+    padding: 8px 10px 10px;
+
+    width: 44px;
+    height: 24px;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+`;
+
+const ErrorContainer = styled.div`
+  color: #f96c6c;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 14px;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 8px 16px;
+`;

--- a/src/views/Transactions/components/SpeedUpModal/InputWithButton.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/InputWithButton.tsx
@@ -23,7 +23,7 @@ export function InputWithButton({
         {label && <label>{label}</label>}
         <InputWithButtonContainer
           isInputFocused={isInputFocused}
-          hasError={!!error}
+          hasError={Boolean(error)}
         >
           <input
             onFocus={(e) => {

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.styles.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.styles.tsx
@@ -1,0 +1,130 @@
+import styled from "@emotion/styled";
+import { DialogContent, DialogOverlay } from "@reach/dialog";
+
+import { ButtonV2 } from "components/Buttons";
+
+export const Overlay = styled(DialogOverlay)`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 100000;
+`;
+
+export const Content = styled(DialogContent)`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+  background-color: #202024;
+  border: 1px solid #34353b;
+  border-radius: 16px;
+  width: 482px;
+`;
+
+export const SuccessContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+
+  svg {
+    stroke: #6cf9d8;
+    fill: #6cf9d8;
+  }
+`;
+
+export const Title = styled.h1`
+  font-size: ${22 / 16}rem;
+  line-height: ${26 / 16}rem;
+  font-weight: 400;
+`;
+
+export const InfoBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 16px;
+  background-color: rgba(249, 210, 108, 0.05);
+  border: 1px solid rgba(249, 210, 108, 0.15);
+  border-radius: 12px;
+
+  svg {
+    height: 24px;
+    width: 24px;
+    stroke: #f9d26c;
+    margin-right: 14px;
+  }
+
+  p {
+    font-size: ${16 / 16}rem;
+    line-height: ${20 / 16}rem;
+    font-weight: 400;
+    color: #f9d26c;
+  }
+`;
+
+export const ErrorBox = styled(InfoBox)`
+  background-color: #f96c6c25;
+  border: 1px solid #f96c6c5a;
+
+  button {
+    background-color: inherit;
+    font-size: inherit;
+    color: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+    border: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  svg {
+    stroke: #f96c6c;
+  }
+
+  p {
+    color: #f96c6c;
+  }
+`;
+
+export const ButtonsRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: 8px;
+`;
+
+export const ConfirmButton = styled(ButtonV2)<{ warning?: boolean }>`
+  border: 1px solid ${({ warning }) => (warning ? "#f9d26c" : "#6cf9d8")};
+  border-radius: 20px;
+  background-color: transparent;
+  color: ${({ warning }) => (warning ? "#f9d26c" : "#6cf9d8")};
+`;
+
+export const CancelButton = styled(ButtonV2)`
+  background-color: transparent;
+  color: #9daab2;
+  border: none;
+  :active {
+    ::after {
+      border: none;
+    }
+  }
+`;
+
+export const SpeedUpTxLinkContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+
+  a {
+    text-decoration: underline;
+    color: #9daab2;
+  }
+`;

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
@@ -41,6 +41,7 @@ export function SpeedUpModal({ isOpen, onClose, txTuple }: Props) {
     setChain,
     suggestedRelayerFeePct,
     isFetchingFees,
+    speedUpTxLink,
   } = useSpeedUp(transfer, token);
 
   useEffect(() => {
@@ -144,6 +145,13 @@ export function SpeedUpModal({ isOpen, onClose, txTuple }: Props) {
               </ConfirmButton>
             </ButtonsRow>
           </>
+        )}
+        {speedUpTxLink && (
+          <SpeedUpTxLinkContainer>
+            <a href={speedUpTxLink} target="_blank" rel="noreferrer">
+              View transaction
+            </a>
+          </SpeedUpTxLinkContainer>
         )}
       </Content>
     </Overlay>
@@ -367,5 +375,16 @@ const CancelButton = styled(ButtonV2)`
     ::after {
       border: none;
     }
+  }
+`;
+
+const SpeedUpTxLinkContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+
+  a {
+    text-decoration: underline;
+    color: #9daab2;
   }
 `;

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
@@ -25,8 +25,6 @@ type Props = {
   txTuple: SupportedTxTuple;
 };
 
-// TODO: replace with `currentRelayerFee` of transfer if sdk is updated
-const mockedCurrentRelayFeeWei = utils.parseEther("0.01"); // 1 %
 const maxRelayFee = "49.999%";
 
 export function SpeedUpModal({ isOpen, onClose, txTuple }: Props) {
@@ -66,14 +64,14 @@ export function SpeedUpModal({ isOpen, onClose, txTuple }: Props) {
     }
   };
 
-  const isRelayerFeeFairlyPriced = mockedCurrentRelayFeeWei.gte(
+  const isRelayerFeeFairlyPriced = transfer.currentRelayerFeePct.gte(
     fees?.relayerFee.pct || 0
   );
   const isSpeedUpPending = status === "pending";
 
   return (
     <Overlay isOpen={isOpen} onDismiss={onClose}>
-      <Content>
+      <Content aria-label="speed-up-modal">
         <Title>Speed up transaction</Title>
         {isRelayerFeeFairlyPriced && (
           <InfoBox>

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
@@ -1,0 +1,230 @@
+import React, { useState, useEffect } from "react";
+import styled from "@emotion/styled";
+import { Info } from "react-feather";
+import { utils } from "ethers";
+import { DialogContent, DialogOverlay } from "@reach/dialog";
+
+import { formatWeiPct } from "utils";
+import { useBridgeFees } from "hooks";
+import { ButtonV2 } from "components/Buttons";
+
+import { InputWithButton } from "./InputWithButton";
+import { SpeedUpStats } from "./SpeedUpStats";
+import {
+  removePercentageSign,
+  appendPercentageSign,
+  feeInputToBigNumberPct,
+} from "./utils";
+import { useSpeedUp } from "../../hooks/useSpeedUp";
+
+import { SupportedTxTuple } from "../../types";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  txTuple: SupportedTxTuple;
+};
+
+// TODO: replace with `currentRelayerFee` of transfer if sdk is updated
+const mockedCurrentRelayFeeWei = utils.parseEther("0.01"); // 1 %
+const maxRelayFee = "49.999%";
+
+export function SpeedUpModal({ isOpen, onClose, txTuple }: Props) {
+  const [token, transfer] = txTuple;
+
+  const [relayFeeInput, setRelayFeeInput] = useState("");
+  const [didSetInitialFee, setDidSetInitialFee] = useState(false);
+  const [inputError, setInputError] = useState("");
+
+  const { fees, isLoading } = useBridgeFees(
+    transfer.amount,
+    transfer.destinationChainId,
+    token.symbol
+  );
+  const { handleSpeedUp, status } = useSpeedUp();
+
+  useEffect(() => {
+    if (fees && !didSetInitialFee) {
+      setDidSetInitialFee(true);
+      setRelayFeeInput(appendPercentageSign(formatWeiPct(fees.relayerFee.pct)));
+    }
+  }, [fees, didSetInitialFee]);
+
+  const handleInputChange = (e: React.FormEvent<HTMLInputElement>) => {
+    const input = e.currentTarget.value;
+    setRelayFeeInput(input);
+
+    try {
+      validateFeeInput(input, {
+        maxFeeInput: Number(removePercentageSign(maxRelayFee)),
+        minFeeInput: 0.001,
+        maxDecimals: 3,
+      });
+      setInputError("");
+    } catch (error) {
+      setInputError((error as Error).message);
+    }
+  };
+
+  const isRelayerFeeFairlyPriced = mockedCurrentRelayFeeWei.gte(
+    fees?.relayerFee.pct || 0
+  );
+  const isSpeedUpPending = status === "pending";
+
+  return (
+    <Overlay isOpen={isOpen} onDismiss={onClose}>
+      <Content>
+        <Title>Speed up transaction</Title>
+        {isRelayerFeeFairlyPriced && (
+          <InfoBox>
+            <div>
+              <Info />
+            </div>
+            <p>
+              Note: The relay is already fairly priced compared to other
+              transactions with similar characteristics.
+            </p>
+          </InfoBox>
+        )}
+        <InputWithButton
+          label="Relay fee"
+          Button={
+            <button onClick={() => setRelayFeeInput(maxRelayFee)}>MAX</button>
+          }
+          value={relayFeeInput}
+          onChange={handleInputChange}
+          onFocus={() => setRelayFeeInput((prev) => removePercentageSign(prev))}
+          onBlur={() => setRelayFeeInput((prev) => appendPercentageSign(prev))}
+          error={inputError}
+          disabled={isLoading}
+        />
+        <SpeedUpStats
+          transferTokenTuple={txTuple}
+          inputError={inputError}
+          feeInput={relayFeeInput}
+        />
+        <ButtonsRow>
+          <CancelButton size="md" onClick={onClose}>
+            Cancel
+          </CancelButton>
+          <ConfirmButton
+            size="md"
+            disabled={!relayFeeInput || !!inputError || isSpeedUpPending}
+            warning={isRelayerFeeFairlyPriced}
+            onClick={() =>
+              handleSpeedUp(transfer, feeInputToBigNumberPct(relayFeeInput))
+            }
+          >
+            {isSpeedUpPending ? "Confirming..." : "Confirm"}
+          </ConfirmButton>
+        </ButtonsRow>
+      </Content>
+    </Overlay>
+  );
+}
+
+function validateFeeInput(
+  input: string,
+  opts: {
+    maxFeeInput: number;
+    minFeeInput: number;
+    maxDecimals: number;
+  }
+) {
+  const cleanedInput = removePercentageSign(input);
+  const inputNum = Number(cleanedInput);
+  if (isNaN(inputNum)) {
+    throw new Error("Invalid number");
+  }
+
+  if (inputNum > opts.maxFeeInput || inputNum <= opts.minFeeInput) {
+    throw new Error(
+      `Fee must be between ${opts.minFeeInput}% and ${opts.maxFeeInput}%`
+    );
+  }
+
+  if (
+    cleanedInput.includes(".") &&
+    cleanedInput.split(".")[1].length > opts.maxDecimals
+  ) {
+    throw new Error(`Max. ${opts.maxDecimals} decimals allowed`);
+  }
+}
+
+const Overlay = styled(DialogOverlay)`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Content = styled(DialogContent)`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+  background-color: #202024;
+  border: 1px solid #34353b;
+  border-radius: 16px;
+  width: 482px;
+`;
+
+const Title = styled.h1`
+  font-size: ${22 / 16}rem;
+  line-height: ${26 / 16}rem;
+  font-weight: 400;
+`;
+
+const InfoBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 16px;
+  background-color: rgba(249, 210, 108, 0.05);
+  border: 1px solid rgba(249, 210, 108, 0.15);
+  border-radius: 12px;
+
+  svg {
+    height: 24px;
+    width: 24px;
+    stroke: #f9d26c;
+    margin-right: 14px;
+  }
+
+  p {
+    font-size: ${16 / 16}rem;
+    line-height: ${20 / 16}rem;
+    font-weight: 400;
+    color: #f9d26c;
+  }
+`;
+
+const ButtonsRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: 8px;
+`;
+
+const ConfirmButton = styled(ButtonV2)<{ warning?: boolean }>`
+  border: 1px solid ${({ warning }) => (warning ? "#F9D26C" : "#6cf9d8")};
+  border-radius: 20px;
+  background-color: transparent;
+  color: ${({ warning }) => (warning ? "#F9D26C" : "#6cf9d8")};
+`;
+
+const CancelButton = styled(ButtonV2)`
+  background-color: transparent;
+  color: #9daab2;
+  border: none;
+  :active {
+    ::after {
+      border: none;
+    }
+  }
+`;

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import styled from "@emotion/styled";
-import { Info } from "react-feather";
+import { Info, Zap } from "react-feather";
 import { DialogContent, DialogOverlay } from "@reach/dialog";
 
 import { formatWeiPct, getChainInfo } from "utils";
@@ -33,8 +33,9 @@ export function SpeedUpModal({ isOpen, onClose, txTuple }: Props) {
   const [inputError, setInputError] = useState("");
 
   const {
-    handleSpeedUp,
+    speedUp,
     speedUpStatus,
+    speedUpErrorMsg,
     isCorrectChain,
     setChain,
     suggestedRelayerFeePct,
@@ -76,70 +77,136 @@ export function SpeedUpModal({ isOpen, onClose, txTuple }: Props) {
   return (
     <Overlay isOpen={isOpen} onDismiss={onClose}>
       <Content aria-label="speed-up-modal">
-        <Title>Speed up transaction</Title>
-        {isCorrectChain ? (
-          isRelayerFeeFairlyPriced && (
-            <InfoBox>
-              <div>
-                <Info />
-              </div>
-              <p>
-                Note: The relay is already fairly priced compared to other
-                transactions with similar characteristics.
-              </p>
-            </InfoBox>
-          )
+        {speedUpStatus === "success" ? (
+          <SuccessContent onClose={onClose} />
         ) : (
-          <ErrorBox>
-            <div>
-              <Info />
-            </div>
-            <p>
-              You are on an incorrect network. Please{" "}
-              <button
-                onClick={() =>
-                  setChain({
-                    chainId: `0x${transfer.sourceChainId.toString(16)}`,
-                  })
-                }
+          <>
+            <Title>Speed up transaction</Title>
+            <AlertBox
+              isCorrectChain={isCorrectChain}
+              speedUpError={speedUpErrorMsg}
+              isRelayerFeeFairlyPriced={isRelayerFeeFairlyPriced}
+              sourceChainId={transfer.sourceChainId}
+              onClickSwitch={() =>
+                setChain({
+                  chainId: `0x${transfer.sourceChainId.toString(16)}`,
+                })
+              }
+            />
+            <InputWithButton
+              label="Relay fee"
+              Button={
+                <button onClick={() => setRelayFeeInput(maxRelayFee)}>
+                  MAX
+                </button>
+              }
+              value={relayFeeInput}
+              onChange={handleInputChange}
+              onFocus={() =>
+                setRelayFeeInput((prev) => removePercentageSign(prev))
+              }
+              onBlur={() =>
+                setRelayFeeInput((prev) => appendPercentageSign(prev))
+              }
+              error={inputError}
+              disabled={isFetchingFees}
+            />
+            <SpeedUpStats
+              transferTokenTuple={txTuple}
+              inputError={inputError}
+              feeInput={relayFeeInput}
+            />
+            <ButtonsRow>
+              <CancelButton size="md" onClick={onClose}>
+                Cancel
+              </CancelButton>
+              <ConfirmButton
+                size="md"
+                disabled={isConfirmDisabled}
+                warning={isRelayerFeeFairlyPriced}
+                onClick={() => speedUp(feeInputToBigNumberPct(relayFeeInput))}
               >
-                switch to {getChainInfo(transfer.sourceChainId).name}
-              </button>
-            </p>
-          </ErrorBox>
+                {isSpeedUpPending ? "Confirming..." : "Confirm"}
+              </ConfirmButton>
+            </ButtonsRow>
+          </>
         )}
-        <InputWithButton
-          label="Relay fee"
-          Button={
-            <button onClick={() => setRelayFeeInput(maxRelayFee)}>MAX</button>
-          }
-          value={relayFeeInput}
-          onChange={handleInputChange}
-          onFocus={() => setRelayFeeInput((prev) => removePercentageSign(prev))}
-          onBlur={() => setRelayFeeInput((prev) => appendPercentageSign(prev))}
-          error={inputError}
-          disabled={isFetchingFees}
-        />
-        <SpeedUpStats
-          transferTokenTuple={txTuple}
-          inputError={inputError}
-          feeInput={relayFeeInput}
-        />
-        <ButtonsRow>
-          <CancelButton size="md" onClick={onClose}>
-            Cancel
-          </CancelButton>
-          <ConfirmButton
-            size="md"
-            disabled={isConfirmDisabled}
-            warning={isRelayerFeeFairlyPriced}
-            onClick={() => handleSpeedUp(feeInputToBigNumberPct(relayFeeInput))}
-          >
-            {isSpeedUpPending ? "Confirming..." : "Confirm"}
-          </ConfirmButton>
-        </ButtonsRow>
       </Content>
     </Overlay>
+  );
+}
+
+function AlertBox({
+  isCorrectChain,
+  speedUpError,
+  isRelayerFeeFairlyPriced,
+  sourceChainId,
+  onClickSwitch,
+}: {
+  isCorrectChain: boolean;
+  speedUpError?: string;
+  isRelayerFeeFairlyPriced: boolean;
+  sourceChainId: number;
+  onClickSwitch: () => void;
+}) {
+  if (!isCorrectChain) {
+    return (
+      <ErrorBox>
+        <div>
+          <Info />
+        </div>
+        <p>
+          You are on an incorrect network. Please{" "}
+          <button onClick={onClickSwitch}>
+            switch to {getChainInfo(sourceChainId).name}
+          </button>
+        </p>
+      </ErrorBox>
+    );
+  }
+
+  if (speedUpError) {
+    return (
+      <ErrorBox>
+        <div>
+          <Info />
+        </div>
+        <p>{speedUpError}</p>
+      </ErrorBox>
+    );
+  }
+
+  if (isRelayerFeeFairlyPriced) {
+    return (
+      <InfoBox>
+        <div>
+          <Info />
+        </div>
+        <p>
+          Note: The relay is already fairly priced compared to other
+          transactions with similar characteristics.
+        </p>
+      </InfoBox>
+    );
+  }
+
+  return null;
+}
+
+function SuccessContent({ onClose }: Pick<Props, "onClose">) {
+  return (
+    <>
+      <SuccessContainer>
+        <Title>Success</Title>
+        <Zap size={64} />
+        <p>Transaction was sped up successfully.</p>
+      </SuccessContainer>
+      <ButtonsRow>
+        <CancelButton size="md" onClick={onClose}>
+          Close
+        </CancelButton>
+      </ButtonsRow>
+    </>
   );
 }
 
@@ -193,6 +260,18 @@ const Content = styled(DialogContent)`
   border: 1px solid #34353b;
   border-radius: 16px;
   width: 482px;
+`;
+
+const SuccessContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+
+  svg {
+    stroke: #6cf9d8;
+    fill: #6cf9d8;
+  }
 `;
 
 const Title = styled.h1`

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
@@ -1,17 +1,28 @@
 import React, { useState, useEffect } from "react";
-import styled from "@emotion/styled";
 import { Info, Zap } from "react-feather";
-import { DialogContent, DialogOverlay } from "@reach/dialog";
 
 import { formatWeiPct, getChainInfo } from "utils";
-import { ButtonV2 } from "components/Buttons";
+import { maxRelayFee, minRelayFee } from "utils/constants";
 
+import {
+  Overlay,
+  Content,
+  SuccessContainer,
+  SpeedUpTxLinkContainer,
+  Title,
+  InfoBox,
+  ErrorBox,
+  ButtonsRow,
+  CancelButton,
+  ConfirmButton,
+} from "./SpeedUpModal.styles";
 import { InputWithButton } from "./InputWithButton";
 import { SpeedUpStats } from "./SpeedUpStats";
 import {
   removePercentageSign,
   appendPercentageSign,
   feeInputToBigNumberPct,
+  validateFeeInput,
 } from "./utils";
 import { useSpeedUp } from "../../hooks/useSpeedUp";
 
@@ -22,9 +33,6 @@ type Props = {
   onClose: () => void;
   txTuple: SupportedTxTuple;
 };
-
-const maxRelayFee = 0.25; // 25%
-const minRelayFee = 0.0003; // 0.03%
 
 export function SpeedUpModal({ isOpen, onClose, txTuple }: Props) {
   const [token, transfer] = txTuple;
@@ -227,160 +235,3 @@ function SuccessContent({ onClose }: Pick<Props, "onClose">) {
     </>
   );
 }
-
-function validateFeeInput(
-  input: string,
-  opts: {
-    maxFeePct: number;
-    minFeePct: number;
-    maxDecimals: number;
-  }
-) {
-  const cleanedInput = removePercentageSign(input);
-  const inputNum = Number(cleanedInput);
-  if (isNaN(inputNum)) {
-    throw new Error("Invalid number");
-  }
-
-  const inputPct = inputNum / 100;
-  if (inputPct > opts.maxFeePct || inputPct < opts.minFeePct) {
-    throw new Error(
-      `Fee must be between ${opts.minFeePct * 100}% and ${
-        opts.maxFeePct * 100
-      }%`
-    );
-  }
-
-  if (
-    cleanedInput.includes(".") &&
-    cleanedInput.split(".")[1].length > opts.maxDecimals
-  ) {
-    throw new Error(`Max. ${opts.maxDecimals} decimals allowed`);
-  }
-}
-
-const Overlay = styled(DialogOverlay)`
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.4);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 100000;
-`;
-
-const Content = styled(DialogContent)`
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-  padding: 24px;
-  background-color: #202024;
-  border: 1px solid #34353b;
-  border-radius: 16px;
-  width: 482px;
-`;
-
-const SuccessContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 24px;
-
-  svg {
-    stroke: #6cf9d8;
-    fill: #6cf9d8;
-  }
-`;
-
-const Title = styled.h1`
-  font-size: ${22 / 16}rem;
-  line-height: ${26 / 16}rem;
-  font-weight: 400;
-`;
-
-const InfoBox = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  padding: 16px;
-  background-color: rgba(249, 210, 108, 0.05);
-  border: 1px solid rgba(249, 210, 108, 0.15);
-  border-radius: 12px;
-
-  svg {
-    height: 24px;
-    width: 24px;
-    stroke: #f9d26c;
-    margin-right: 14px;
-  }
-
-  p {
-    font-size: ${16 / 16}rem;
-    line-height: ${20 / 16}rem;
-    font-weight: 400;
-    color: #f9d26c;
-  }
-`;
-
-const ErrorBox = styled(InfoBox)`
-  background-color: #f96c6c25;
-  border: 1px solid #f96c6c5a;
-
-  button {
-    background-color: inherit;
-    font-size: inherit;
-    color: inherit;
-    text-decoration: underline;
-    cursor: pointer;
-    border: none;
-    padding: 0;
-    margin: 0;
-  }
-
-  svg {
-    stroke: #f96c6c;
-  }
-
-  p {
-    color: #f96c6c;
-  }
-`;
-
-const ButtonsRow = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  gap: 8px;
-`;
-
-const ConfirmButton = styled(ButtonV2)<{ warning?: boolean }>`
-  border: 1px solid ${({ warning }) => (warning ? "#f9d26c" : "#6cf9d8")};
-  border-radius: 20px;
-  background-color: transparent;
-  color: ${({ warning }) => (warning ? "#f9d26c" : "#6cf9d8")};
-`;
-
-const CancelButton = styled(ButtonV2)`
-  background-color: transparent;
-  color: #9daab2;
-  border: none;
-  :active {
-    ::after {
-      border: none;
-    }
-  }
-`;
-
-const SpeedUpTxLinkContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-
-  a {
-    text-decoration: underline;
-    color: #9daab2;
-  }
-`;

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
@@ -57,7 +57,7 @@ export function SpeedUpModal({ isOpen, onClose, txTuple }: Props) {
       if (relayFeeInput) {
         const currentFeePct =
           Number(formatWeiPct(transfer.currentRelayerFeePct, 3)) / 100;
-        validateFeeInput(relayFeeInput, currentFeePct, {
+        validateFeeInput(relayFeeInput, {
           maxFeePct: maxRelayFee,
           minFeePct: Math.max(minRelayFee, currentFeePct),
           maxDecimals: 3,
@@ -226,7 +226,6 @@ function SuccessContent({ onClose }: Pick<Props, "onClose">) {
 
 function validateFeeInput(
   input: string,
-  currentFeePct: number,
   opts: {
     maxFeePct: number;
     minFeePct: number;

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
@@ -185,9 +185,7 @@ function AlertBox({
         </p>
       </ErrorBox>
     );
-  }
-
-  if (speedUpError) {
+  } else if (speedUpError) {
     return (
       <ErrorBox>
         <div>
@@ -196,9 +194,7 @@ function AlertBox({
         <p>{speedUpError}</p>
       </ErrorBox>
     );
-  }
-
-  if (isRelayerFeeFairlyPriced) {
+  } else if (isRelayerFeeFairlyPriced) {
     return (
       <InfoBox>
         <div>
@@ -361,10 +357,10 @@ const ButtonsRow = styled.div`
 `;
 
 const ConfirmButton = styled(ButtonV2)<{ warning?: boolean }>`
-  border: 1px solid ${({ warning }) => (warning ? "#F9D26C" : "#6cf9d8")};
+  border: 1px solid ${({ warning }) => (warning ? "#f9d26c" : "#6cf9d8")};
   border-radius: 20px;
   background-color: transparent;
-  color: ${({ warning }) => (warning ? "#F9D26C" : "#6cf9d8")};
+  color: ${({ warning }) => (warning ? "#f9d26c" : "#6cf9d8")};
 `;
 
 const CancelButton = styled(ButtonV2)`

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpStats.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpStats.tsx
@@ -1,0 +1,120 @@
+import styled from "@emotion/styled";
+import { utils } from "ethers";
+import { formatWeiPct, getChainInfo, formatUnits } from "utils";
+
+import { appendPercentageSign, feeInputToBigNumberPct } from "./utils";
+import { SupportedTxTuple } from "../../types";
+
+type Props = {
+  transferTokenTuple: SupportedTxTuple;
+  feeInput: string;
+  inputError?: string;
+};
+
+// TODO: replace with `currentRelayerFee` of transfer if sdk is updated
+const mockedCurrentRelayFeeWei = utils.parseEther("0.01"); // 1 %
+
+export function SpeedUpStats({
+  transferTokenTuple,
+  inputError,
+  feeInput,
+}: Props) {
+  const [token, transfer] = transferTokenTuple;
+
+  return (
+    <StatsBox>
+      <StatRow>
+        <div>Asset</div>
+        <div>
+          {token.symbol}{" "}
+          <img src={token.logoURI} alt={`token_logo_${token.symbol}`} />
+        </div>
+      </StatRow>
+      <StatRow>
+        <div>From → To</div>
+        <div>
+          {getChainInfo(transfer.sourceChainId).name} →{" "}
+          {getChainInfo(transfer.destinationChainId).name}
+        </div>
+      </StatRow>
+      <StatRow>
+        <div>Amount</div>
+        <div>{formatUnits(transfer.amount, token.decimals).toString()}</div>
+      </StatRow>
+      <StatRow>
+        <div>Current fee %</div>
+        <div>{formatWeiPct(mockedCurrentRelayFeeWei)}%</div>
+      </StatRow>
+      <StatRow>
+        <div>Current fee in {token.symbol}</div>
+        <div>
+          {formatUnits(
+            mockedCurrentRelayFeeWei
+              .mul(transfer.amount)
+              .div(utils.parseEther("1")),
+            token.decimals
+          ).toString()}
+        </div>
+      </StatRow>
+      <Divider />
+      <StatRow highlightValue>
+        <div>New fee %</div>
+        <div>{inputError ? "invalid " : appendPercentageSign(feeInput)}</div>
+      </StatRow>
+      <StatRow highlightValue>
+        <div>New fee in {token.symbol}</div>
+        <div>
+          {inputError
+            ? "invalid"
+            : formatUnits(
+                feeInputToBigNumberPct(feeInput || "0")
+                  .mul(transfer.amount)
+                  .div(utils.parseEther("1")),
+                token.decimals
+              ).toString()}
+        </div>
+      </StatRow>
+    </StatsBox>
+  );
+}
+
+const StatsBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 16px;
+  gap: 12px;
+
+  border: 1px solid #34353b;
+  border-radius: 12px;
+`;
+
+const StatRow = styled.div<{ highlightValue?: boolean }>`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  color: #9daab2;
+  font-weight: 400;
+  font-size: ${16 / 16}rem;
+  line-height: ${20 / 16}rem;
+
+  div:nth-of-type(2) {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    color: ${({ highlightValue }) => (highlightValue ? "#E0F3FF" : "inherit")};
+  }
+
+  img {
+    height: 16px;
+    width: 16px;
+  }
+`;
+
+const Divider = styled.div`
+  display: flex;
+  width: 100%;
+  border-top: 1px solid #34353b;
+`;

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpStats.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpStats.tsx
@@ -2,7 +2,11 @@ import styled from "@emotion/styled";
 import { utils } from "ethers";
 import { formatWeiPct, getChainInfo, formatUnits } from "utils";
 
-import { appendPercentageSign, feeInputToBigNumberPct } from "./utils";
+import {
+  appendPercentageSign,
+  removePercentageSign,
+  feeInputToBigNumberPct,
+} from "./utils";
 import { SupportedTxTuple } from "../../types";
 
 type Props = {
@@ -19,6 +23,8 @@ export function SpeedUpStats({
   isInitiallyFetchingFees,
 }: Props) {
   const [token, transfer] = transferTokenTuple;
+
+  const isInputInvalid = isNaN(Number(removePercentageSign(feeInput)));
 
   return (
     <StatsBox>
@@ -59,7 +65,7 @@ export function SpeedUpStats({
       <StatRow highlightValue>
         <div>New fee %</div>
         <div>
-          {inputError || isInitiallyFetchingFees
+          {inputError || isInitiallyFetchingFees || isInputInvalid
             ? "-"
             : appendPercentageSign(feeInput)}
         </div>
@@ -67,7 +73,7 @@ export function SpeedUpStats({
       <StatRow highlightValue>
         <div>New fee in {token.symbol}</div>
         <div>
-          {inputError || isInitiallyFetchingFees
+          {inputError || isInitiallyFetchingFees || isInputInvalid
             ? "-"
             : formatUnits(
                 feeInputToBigNumberPct(feeInput || "0")

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpStats.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpStats.tsx
@@ -9,12 +9,14 @@ type Props = {
   transferTokenTuple: SupportedTxTuple;
   feeInput: string;
   inputError?: string;
+  isInitiallyFetchingFees: boolean;
 };
 
 export function SpeedUpStats({
   transferTokenTuple,
   inputError,
   feeInput,
+  isInitiallyFetchingFees,
 }: Props) {
   const [token, transfer] = transferTokenTuple;
 
@@ -56,13 +58,17 @@ export function SpeedUpStats({
       <Divider />
       <StatRow highlightValue>
         <div>New fee %</div>
-        <div>{inputError ? "invalid " : appendPercentageSign(feeInput)}</div>
+        <div>
+          {inputError || isInitiallyFetchingFees
+            ? "-"
+            : appendPercentageSign(feeInput)}
+        </div>
       </StatRow>
       <StatRow highlightValue>
         <div>New fee in {token.symbol}</div>
         <div>
-          {inputError
-            ? "invalid"
+          {inputError || isInitiallyFetchingFees
+            ? "-"
             : formatUnits(
                 feeInputToBigNumberPct(feeInput || "0")
                   .mul(transfer.amount)

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpStats.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpStats.tsx
@@ -11,9 +11,6 @@ type Props = {
   inputError?: string;
 };
 
-// TODO: replace with `currentRelayerFee` of transfer if sdk is updated
-const mockedCurrentRelayFeeWei = utils.parseEther("0.01"); // 1 %
-
 export function SpeedUpStats({
   transferTokenTuple,
   inputError,
@@ -43,13 +40,13 @@ export function SpeedUpStats({
       </StatRow>
       <StatRow>
         <div>Current fee %</div>
-        <div>{formatWeiPct(mockedCurrentRelayFeeWei)}%</div>
+        <div>{formatWeiPct(transfer.currentRelayerFeePct)}%</div>
       </StatRow>
       <StatRow>
         <div>Current fee in {token.symbol}</div>
         <div>
           {formatUnits(
-            mockedCurrentRelayFeeWei
+            transfer.currentRelayerFeePct
               .mul(transfer.amount)
               .div(utils.parseEther("1")),
             token.decimals

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpStats.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpStats.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { utils } from "ethers";
-import { formatWeiPct, getChainInfo, formatUnits } from "utils";
+import { formatWeiPct, getChainInfo, makeFormatUnits } from "utils";
 
 import {
   appendPercentageSign,
@@ -24,6 +24,8 @@ export function SpeedUpStats({
 }: Props) {
   const [token, transfer] = transferTokenTuple;
 
+  const formatTokenUnits = makeFormatUnits(token.decimals);
+
   const isInputInvalid = isNaN(Number(removePercentageSign(feeInput)));
 
   return (
@@ -44,7 +46,7 @@ export function SpeedUpStats({
       </StatRow>
       <StatRow>
         <div>Amount</div>
-        <div>{formatUnits(transfer.amount, token.decimals).toString()}</div>
+        <div>{formatTokenUnits(transfer.amount).toString()}</div>
       </StatRow>
       <StatRow>
         <div>Current fee %</div>
@@ -53,11 +55,10 @@ export function SpeedUpStats({
       <StatRow>
         <div>Current fee in {token.symbol}</div>
         <div>
-          {formatUnits(
+          {formatTokenUnits(
             transfer.currentRelayerFeePct
               .mul(transfer.amount)
-              .div(utils.parseEther("1")),
-            token.decimals
+              .div(utils.parseEther("1"))
           ).toString()}
         </div>
       </StatRow>
@@ -75,11 +76,10 @@ export function SpeedUpStats({
         <div>
           {inputError || isInitiallyFetchingFees || isInputInvalid
             ? "-"
-            : formatUnits(
+            : formatTokenUnits(
                 feeInputToBigNumberPct(feeInput || "0")
                   .mul(transfer.amount)
-                  .div(utils.parseEther("1")),
-                token.decimals
+                  .div(utils.parseEther("1"))
               ).toString()}
         </div>
       </StatRow>

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpStats.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpStats.tsx
@@ -1,11 +1,11 @@
 import styled from "@emotion/styled";
-import { utils } from "ethers";
 import { formatWeiPct, getChainInfo, makeFormatUnits } from "utils";
 
 import {
   appendPercentageSign,
   removePercentageSign,
   feeInputToBigNumberPct,
+  calcPctOfTokenAmount,
 } from "./utils";
 import { SupportedTxTuple } from "../../types";
 
@@ -27,6 +27,7 @@ export function SpeedUpStats({
   const formatTokenUnits = makeFormatUnits(token.decimals);
 
   const isInputInvalid = isNaN(Number(removePercentageSign(feeInput)));
+  const hideNewFee = inputError || isInitiallyFetchingFees || isInputInvalid;
 
   return (
     <StatsBox>
@@ -46,7 +47,7 @@ export function SpeedUpStats({
       </StatRow>
       <StatRow>
         <div>Amount</div>
-        <div>{formatTokenUnits(transfer.amount).toString()}</div>
+        <div>{formatTokenUnits(transfer.amount)}</div>
       </StatRow>
       <StatRow>
         <div>Current fee %</div>
@@ -56,31 +57,26 @@ export function SpeedUpStats({
         <div>Current fee in {token.symbol}</div>
         <div>
           {formatTokenUnits(
-            transfer.currentRelayerFeePct
-              .mul(transfer.amount)
-              .div(utils.parseEther("1"))
-          ).toString()}
+            calcPctOfTokenAmount(transfer.currentRelayerFeePct, transfer.amount)
+          )}
         </div>
       </StatRow>
       <Divider />
       <StatRow highlightValue>
         <div>New fee %</div>
-        <div>
-          {inputError || isInitiallyFetchingFees || isInputInvalid
-            ? "-"
-            : appendPercentageSign(feeInput)}
-        </div>
+        <div>{hideNewFee ? "-" : appendPercentageSign(feeInput)}</div>
       </StatRow>
       <StatRow highlightValue>
         <div>New fee in {token.symbol}</div>
         <div>
-          {inputError || isInitiallyFetchingFees || isInputInvalid
+          {hideNewFee
             ? "-"
             : formatTokenUnits(
-                feeInputToBigNumberPct(feeInput || "0")
-                  .mul(transfer.amount)
-                  .div(utils.parseEther("1"))
-              ).toString()}
+                calcPctOfTokenAmount(
+                  feeInputToBigNumberPct(feeInput || "0"),
+                  transfer.amount
+                )
+              )}
         </div>
       </StatRow>
     </StatsBox>

--- a/src/views/Transactions/components/SpeedUpModal/index.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/index.tsx
@@ -1,0 +1,1 @@
+export { SpeedUpModal } from "./SpeedUpModal";

--- a/src/views/Transactions/components/SpeedUpModal/utils.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/utils.tsx
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers";
+import { BigNumber, utils } from "ethers";
 import { toWeiSafe } from "utils";
 
 export function appendPercentageSign(feeInput: string) {
@@ -13,4 +13,42 @@ export function feeInputToBigNumberPct(feeInput: string) {
   return toWeiSafe(removePercentageSign(feeInput) || "0").div(
     BigNumber.from(100)
   );
+}
+
+export function calcPctOfTokenAmount(
+  pctBigNumber: BigNumber,
+  tokenAmount: BigNumber
+) {
+  return pctBigNumber.mul(tokenAmount).div(utils.parseEther("1"));
+}
+
+export function validateFeeInput(
+  input: string,
+  opts: {
+    maxFeePct: number;
+    minFeePct: number;
+    maxDecimals: number;
+  }
+) {
+  const cleanedInput = removePercentageSign(input);
+  const inputNum = Number(cleanedInput);
+  if (isNaN(inputNum)) {
+    throw new Error("Invalid number");
+  }
+
+  const inputPct = inputNum / 100;
+  if (inputPct > opts.maxFeePct || inputPct < opts.minFeePct) {
+    throw new Error(
+      `Fee must be between ${opts.minFeePct * 100}% and ${
+        opts.maxFeePct * 100
+      }%`
+    );
+  }
+
+  if (
+    cleanedInput.includes(".") &&
+    cleanedInput.split(".")[1].length > opts.maxDecimals
+  ) {
+    throw new Error(`Max. ${opts.maxDecimals} decimals allowed`);
+  }
 }

--- a/src/views/Transactions/components/SpeedUpModal/utils.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/utils.tsx
@@ -10,6 +10,6 @@ export function removePercentageSign(feeInput: string) {
 
 export function feeInputToBigNumberPct(feeInput: string) {
   return utils
-    .parseEther(removePercentageSign(feeInput))
+    .parseEther(removePercentageSign(feeInput) || "0")
     .div(BigNumber.from(100));
 }

--- a/src/views/Transactions/components/SpeedUpModal/utils.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/utils.tsx
@@ -1,0 +1,15 @@
+import { utils, BigNumber } from "ethers";
+
+export function appendPercentageSign(feeInput: string) {
+  return feeInput.replace("%", "") + "%";
+}
+
+export function removePercentageSign(feeInput: string) {
+  return feeInput.replace("%", "");
+}
+
+export function feeInputToBigNumberPct(feeInput: string) {
+  return utils
+    .parseEther(removePercentageSign(feeInput))
+    .div(BigNumber.from(100));
+}

--- a/src/views/Transactions/components/SpeedUpModal/utils.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/utils.tsx
@@ -1,15 +1,16 @@
-import { utils, BigNumber } from "ethers";
+import { BigNumber } from "ethers";
+import { toWeiSafe } from "utils";
 
 export function appendPercentageSign(feeInput: string) {
-  return feeInput.replace("%", "") + "%";
+  return feeInput.replaceAll("%", "") + "%";
 }
 
 export function removePercentageSign(feeInput: string) {
-  return feeInput.replace("%", "");
+  return feeInput.replaceAll("%", "");
 }
 
 export function feeInputToBigNumberPct(feeInput: string) {
-  return utils
-    .parseEther(removePercentageSign(feeInput) || "0")
-    .div(BigNumber.from(100));
+  return toWeiSafe(removePercentageSign(feeInput) || "0").div(
+    BigNumber.from(100)
+  );
 }

--- a/src/views/Transactions/components/TransactionsTable/TransactionsTable.styles.tsx
+++ b/src/views/Transactions/components/TransactionsTable/TransactionsTable.styles.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+
 import { ReactComponent as AcrossPlusIcon } from "assets/across-plus-icon.svg";
 import { QUERIES } from "utils";
 import {
@@ -139,4 +140,28 @@ export const StyledPlus = styled(AcrossPlusIcon)`
   margin-top: 8px;
   margin-right: 4px;
   margin-left: 8px;
+`;
+
+export const SpeedUpHeadCell = styled(HeadCell)`
+  flex: 0.3;
+`;
+
+export const SpeedUpCell = styled(TableCell)`
+  cursor: pointer;
+  flex: 0.3;
+
+  svg {
+    opacity: 0;
+    height: 16px;
+    width: 16px;
+  }
+
+  :hover {
+    svg {
+      opacity: 1;
+      transition: opacity 0.3s ease-in-out;
+      fill: #44d2ff;
+      stroke: #44d2ff;
+    }
+  }
 `;

--- a/src/views/Transactions/components/TransactionsTable/TransactionsTable.styles.tsx
+++ b/src/views/Transactions/components/TransactionsTable/TransactionsTable.styles.tsx
@@ -33,7 +33,6 @@ export const TableRow = styled(BaseTableRow)`
       svg {
         opacity: 1;
         transition: opacity 0.3s ease-in-out;
-        fill: #44d2ff;
         stroke: #44d2ff;
       }
     }

--- a/src/views/Transactions/components/TransactionsTable/TransactionsTable.styles.tsx
+++ b/src/views/Transactions/components/TransactionsTable/TransactionsTable.styles.tsx
@@ -27,7 +27,18 @@ export const TableBody = BaseTableBody;
 
 export const TableHeadRow = BaseTableHeadRow;
 
-export const TableRow = BaseTableRow;
+export const TableRow = styled(BaseTableRow)`
+  :hover {
+    #speed-up-cell {
+      svg {
+        opacity: 1;
+        transition: opacity 0.3s ease-in-out;
+        fill: #44d2ff;
+        stroke: #44d2ff;
+      }
+    }
+  }
+`;
 
 export const EmptyRow = BaseEmptyRow;
 
@@ -154,14 +165,5 @@ export const SpeedUpCell = styled(TableCell)`
     opacity: 0;
     height: 16px;
     width: 16px;
-  }
-
-  :hover {
-    svg {
-      opacity: 1;
-      transition: opacity 0.3s ease-in-out;
-      fill: #44d2ff;
-      stroke: #44d2ff;
-    }
   }
 `;

--- a/src/views/Transactions/components/TransactionsTable/TransactionsTable.styles.tsx
+++ b/src/views/Transactions/components/TransactionsTable/TransactionsTable.styles.tsx
@@ -126,7 +126,7 @@ export const AccordionRow = styled.div`
     border-bottom: 1px solid #2c2f33;
     text-indent: 12px;
   }
-  &:nth-of-type(6) > div {
+  &:nth-of-type(7) > div {
     border-bottom: none;
   }
 `;

--- a/src/views/Transactions/components/TransactionsTable/TransactionsTable.tsx
+++ b/src/views/Transactions/components/TransactionsTable/TransactionsTable.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { HeadRow, DataRow, MobileDataRow } from "./rows";
 import { FillTxInfoModal } from "../FillTxInfoModal";
 import { FillTxsListModal } from "../FillTxsListModal";
+import { SpeedUpModal } from "../SpeedUpModal";
 import { doPartialFillsExist } from "../../utils";
 
 import { TxLink, SupportedTxTuple } from "../../types";
@@ -21,6 +22,7 @@ export type Props = {
   title: string;
   enablePartialFillInfoIcon?: boolean;
   isMobile?: boolean;
+  enableSpeedUps?: boolean;
 };
 
 export function TransactionsTable({
@@ -28,10 +30,12 @@ export function TransactionsTable({
   title,
   enablePartialFillInfoIcon = false,
   isMobile = false,
+  enableSpeedUps = false,
 }: Props) {
   const [fillTxLinks, setFillTxLinks] = useState<TxLink[]>([]);
   const [isPartialFillInfoModalOpen, setIsPartialFillInfoModalOpen] =
     useState(false);
+  const [txTupleToSpeedUp, setTxTupleToSpeedUp] = useState<SupportedTxTuple>();
 
   const [Container, Row] = isMobile
     ? [MobileWrapper, MobileDataRow]
@@ -51,6 +55,7 @@ export function TransactionsTable({
             }
             showPartialFillInfoIcon={showPartialFillInfoIcon}
             isMobile={isMobile}
+            enableSpeedUp={enableSpeedUps}
           />
           <TableBody>
             {transferTuples.length ? (
@@ -60,6 +65,8 @@ export function TransactionsTable({
                   token={token}
                   transfer={transfer}
                   onClickFillTxsCellExpandButton={setFillTxLinks}
+                  enableSpeedUp={enableSpeedUps}
+                  onClickSpeedUp={setTxTupleToSpeedUp}
                 />
               ))
             ) : (
@@ -77,6 +84,13 @@ export function TransactionsTable({
         isOpen={isPartialFillInfoModalOpen}
         onClose={() => setIsPartialFillInfoModalOpen(false)}
       />
+      {enableSpeedUps && txTupleToSpeedUp && (
+        <SpeedUpModal
+          isOpen={!!txTupleToSpeedUp}
+          onClose={() => setTxTupleToSpeedUp(undefined)}
+          txTuple={txTupleToSpeedUp}
+        />
+      )}
     </>
   );
 }

--- a/src/views/Transactions/components/TransactionsTable/TransactionsTable.tsx
+++ b/src/views/Transactions/components/TransactionsTable/TransactionsTable.tsx
@@ -86,7 +86,7 @@ export function TransactionsTable({
       />
       {enableSpeedUps && txTupleToSpeedUp && (
         <SpeedUpModal
-          isOpen={!!txTupleToSpeedUp}
+          isOpen={Boolean(txTupleToSpeedUp)}
           onClose={() => setTxTupleToSpeedUp(undefined)}
           txTuple={txTupleToSpeedUp}
         />

--- a/src/views/Transactions/components/TransactionsTable/rows/DataRow.tsx
+++ b/src/views/Transactions/components/TransactionsTable/rows/DataRow.tsx
@@ -1,14 +1,6 @@
-import {
-  TableLink,
-  TableRow,
-  TableCell,
-  StyledPlus,
-} from "../TransactionsTable.styles";
-import { Token } from "utils/config";
-import { shortenTransactionHash } from "utils/format";
-import { getChainInfo } from "utils/constants";
+import { Zap } from "react-feather";
 import { Transfer } from "@across-protocol/sdk-v2/dist/transfers-history/model";
-import { ChainId } from "utils";
+import { ChainId, Token, shortenTransactionHash, getChainInfo } from "utils";
 
 import {
   ChainCell,
@@ -18,18 +10,29 @@ import {
   SymbolCell,
   AmountCell,
 } from "../cells";
+import {
+  TableLink,
+  TableRow,
+  TableCell,
+  StyledPlus,
+  SpeedUpCell,
+} from "../TransactionsTable.styles";
 import { TxLink } from "../../../types";
 
 type Props = {
   transfer: Transfer;
   token: Token;
   onClickFillTxsCellExpandButton: (fillTxLinks: TxLink[]) => void;
+  enableSpeedUp?: boolean;
+  onClickSpeedUp?: (tuple: [token: Token, transfer: Transfer]) => void;
 };
 
 export function DataRow({
   transfer,
   onClickFillTxsCellExpandButton,
   token,
+  enableSpeedUp,
+  onClickSpeedUp,
 }: Props) {
   return (
     <TableRow>
@@ -56,6 +59,13 @@ export function DataRow({
         destinationChainId={transfer.destinationChainId}
         onClickExpandButton={onClickFillTxsCellExpandButton}
       />
+      {enableSpeedUp && (
+        <SpeedUpCell
+          onClick={() => onClickSpeedUp && onClickSpeedUp([token, transfer])}
+        >
+          <Zap />
+        </SpeedUpCell>
+      )}
     </TableRow>
   );
 }

--- a/src/views/Transactions/components/TransactionsTable/rows/DataRow.tsx
+++ b/src/views/Transactions/components/TransactionsTable/rows/DataRow.tsx
@@ -61,6 +61,7 @@ export function DataRow({
       />
       {enableSpeedUp && (
         <SpeedUpCell
+          id="speed-up-cell"
           onClick={() => onClickSpeedUp && onClickSpeedUp([token, transfer])}
         >
           <Zap />

--- a/src/views/Transactions/components/TransactionsTable/rows/HeadRow.tsx
+++ b/src/views/Transactions/components/TransactionsTable/rows/HeadRow.tsx
@@ -2,12 +2,17 @@ import styled from "@emotion/styled";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
 
-import { TableHeadRow, HeadCell } from "../TransactionsTable.styles";
+import {
+  TableHeadRow,
+  HeadCell,
+  SpeedUpHeadCell,
+} from "../TransactionsTable.styles";
 
 type Props = {
   isMobile?: boolean;
   showPartialFillInfoIcon?: boolean;
   onClickPartialFillInfoIcon: () => void;
+  enableSpeedUp?: boolean;
 };
 
 const InfoIcon = styled(FontAwesomeIcon)`
@@ -40,6 +45,7 @@ export function HeadRow(props: Props) {
           <HeadCell>Amount</HeadCell>
           <HeadCell>Deposit tx</HeadCell>
           <HeadCell>Fill tx(s)</HeadCell>
+          {props.enableSpeedUp && <SpeedUpHeadCell> </SpeedUpHeadCell>}
         </>
       )}
     </TableHeadRow>

--- a/src/views/Transactions/components/TransactionsTable/rows/MobileDataRow.tsx
+++ b/src/views/Transactions/components/TransactionsTable/rows/MobileDataRow.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { Zap } from "react-feather";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
+import styled from "@emotion/styled";
 import { Transfer } from "@across-protocol/sdk-v2/dist/transfers-history";
 
 import {
@@ -26,9 +28,16 @@ import {
 type Props = {
   transfer: Transfer;
   token: Token;
+  enableSpeedUp?: boolean;
+  onClickSpeedUp?: (tuple: [token: Token, transfer: Transfer]) => void;
 };
 
-export function MobileDataRow({ transfer, token }: Props) {
+export function MobileDataRow({
+  transfer,
+  token,
+  enableSpeedUp,
+  onClickSpeedUp,
+}: Props) {
   const [isAccordionOpen, setIsAccordionOpen] = React.useState(false);
 
   const toggleAccordion = React.useCallback(() => {
@@ -85,6 +94,18 @@ export function MobileDataRow({ transfer, token }: Props) {
               destinationChainId={transfer.destinationChainId}
             />
           </AccordionRow>
+          {enableSpeedUp && (
+            <AccordionRow>
+              <div>Speed up</div>
+              <MobileSpeedUpCell
+                onClick={() =>
+                  onClickSpeedUp && onClickSpeedUp([token, transfer])
+                }
+              >
+                <Zap />
+              </MobileSpeedUpCell>
+            </AccordionRow>
+          )}
         </AccordionWrapper>
       )}
     </>
@@ -129,3 +150,9 @@ function ToggleAccordionCell(props: { isOpen: boolean }) {
     </MobileCell>
   );
 }
+
+const MobileSpeedUpCell = styled(MobileCell)`
+  svg {
+    padding-left: 8px;
+  }
+`;

--- a/src/views/Transactions/hooks/useSpeedUp.tsx
+++ b/src/views/Transactions/hooks/useSpeedUp.tsx
@@ -1,0 +1,140 @@
+import { useState, useEffect } from "react";
+import { BigNumber, utils } from "ethers";
+import { Transfer } from "@across-protocol/sdk-v2/dist/transfers-history";
+import { JsonRpcSigner } from "@uma/sdk/dist/types/oracle/types/ethers";
+import { SetChainOptions } from "hooks/useOnboard";
+
+import { useConnection } from "state/hooks";
+import { useError } from "hooks";
+import { getConfig, getChainInfo } from "utils";
+
+type SpeedUpStatus = "idle" | "pending" | "success" | "error";
+
+export function useSpeedUp() {
+  const config = getConfig();
+  const { chainId, signer, setChain, notify } = useConnection();
+  const { addError } = useError();
+
+  const [status, setStatus] = useState<SpeedUpStatus>("idle");
+  const [txHashWithLink, setTxHashWithLink] = useState<
+    | {
+        link: string;
+        txHash: string;
+      }
+    | undefined
+  >();
+
+  useEffect(() => {
+    if (status === "pending" && txHashWithLink) {
+      const { emitter } = notify.hash(txHashWithLink.txHash);
+      emitter.on("txSent", () => {
+        return {
+          link: txHashWithLink.link,
+        };
+      });
+      emitter.on("txConfirmed", () => {
+        setStatus("success");
+        notify.unsubscribe(txHashWithLink.txHash);
+      });
+      emitter.on("txFailed", (state) => {
+        setStatus("error");
+        notify.unsubscribe(txHashWithLink.txHash);
+      });
+
+      return () => notify.unsubscribe(txHashWithLink.txHash);
+    }
+  }, [status, txHashWithLink, notify]);
+
+  const handleSpeedUp = async (
+    depositToSpeedUp: Transfer,
+    newRelayerFeePct: BigNumber
+  ) => {
+    try {
+      setStatus("pending");
+
+      if (!signer) {
+        throw new Error(`Wallet is not connected`);
+      }
+
+      await assertCorrectChain(
+        chainId,
+        depositToSpeedUp.sourceChainId,
+        setChain
+      );
+
+      const depositorSignature = await getDepositorSignature(signer, {
+        originChainId: depositToSpeedUp.sourceChainId,
+        newRelayerFeePct,
+        depositId: depositToSpeedUp.depositId,
+      });
+
+      const spokePool = config.getSpokePool(
+        depositToSpeedUp.sourceChainId,
+        signer
+      );
+      const txResponse = await spokePool.speedUpDeposit(
+        await signer.getAddress(),
+        newRelayerFeePct,
+        depositToSpeedUp.depositId,
+        depositorSignature
+      );
+
+      setTxHashWithLink({
+        txHash: txResponse.hash,
+        link: getChainInfo(
+          depositToSpeedUp.sourceChainId
+        ).constructExplorerLink(txResponse.hash),
+      });
+    } catch (error) {
+      setStatus("error");
+      console.error(error);
+      addError(error as Error);
+    }
+  };
+
+  return {
+    handleSpeedUp,
+    status,
+  };
+}
+
+async function assertCorrectChain(
+  connectedChainId: number,
+  requiredChainId: number,
+  setChain: (opts: SetChainOptions) => Promise<boolean>
+) {
+  if (connectedChainId !== requiredChainId) {
+    const didChange = await setChain({
+      chainId: `0x${requiredChainId.toString(16)}`,
+    });
+
+    if (!didChange) {
+      throw new Error(
+        `Wallet needs to be connected to chain with id "${requiredChainId}"`
+      );
+    }
+  }
+}
+
+async function getDepositorSignature(
+  signer: JsonRpcSigner,
+  relayerFeeMessage: {
+    originChainId: number;
+    newRelayerFeePct: BigNumber;
+    depositId: number;
+  }
+) {
+  const depositorMessageHash = utils.keccak256(
+    utils.defaultAbiCoder.encode(
+      ["string", "uint64", "uint32", "uint32"],
+      [
+        "ACROSS-V2-FEE-1.0",
+        relayerFeeMessage.newRelayerFeePct,
+        relayerFeeMessage.depositId,
+        relayerFeeMessage.originChainId,
+      ]
+    )
+  );
+
+  return signer.signMessage(utils.arrayify(depositorMessageHash));
+}

--- a/src/views/Transactions/hooks/useSpeedUp.tsx
+++ b/src/views/Transactions/hooks/useSpeedUp.tsx
@@ -14,6 +14,7 @@ export function useSpeedUp(transfer: Transfer, token: Token) {
   const { chainId, signer, setChain } = useConnection();
   const { fees, isLoading } = useBridgeFees(
     transfer.amount,
+    transfer.sourceChainId,
     transfer.destinationChainId,
     token.symbol
   );

--- a/src/views/Transactions/hooks/useSpeedUp.tsx
+++ b/src/views/Transactions/hooks/useSpeedUp.tsx
@@ -11,7 +11,7 @@ type SpeedUpStatus = "idle" | "pending" | "success" | "error";
 
 export function useSpeedUp(transfer: Transfer, token: Token) {
   const config = getConfig();
-  const { chainId, signer, setChain, notify } = useConnection();
+  const { chainId, signer, setChain, createNotify } = useConnection();
   const { fees, isLoading } = useBridgeFees(
     transfer.amount,
     transfer.destinationChainId,
@@ -58,6 +58,9 @@ export function useSpeedUp(transfer: Transfer, token: Token) {
         depositorSignature
       );
 
+      const notify = createNotify({
+        networkId: transfer.sourceChainId,
+      });
       const { emitter } = notify.hash(txResponse.hash);
       emitter.on("txSent", () => {
         return {

--- a/src/views/Transactions/hooks/useSpeedUp.tsx
+++ b/src/views/Transactions/hooks/useSpeedUp.tsx
@@ -11,7 +11,8 @@ type SpeedUpStatus = "idle" | "pending" | "success" | "error";
 
 export function useSpeedUp(transfer: Transfer, token: Token) {
   const config = getConfig();
-  const { chainId, signer, setChain, createNotify } = useConnection();
+  const { chainId, signer, setChain, notify, setNotifyConfig } =
+    useConnection();
   const { fees, isLoading } = useBridgeFees(
     transfer.amount,
     transfer.destinationChainId,
@@ -58,7 +59,7 @@ export function useSpeedUp(transfer: Transfer, token: Token) {
         depositorSignature
       );
 
-      const notify = createNotify({
+      setNotifyConfig({
         networkId: transfer.sourceChainId,
       });
       const { emitter } = notify.hash(txResponse.hash);
@@ -72,11 +73,17 @@ export function useSpeedUp(transfer: Transfer, token: Token) {
       emitter.on("txConfirmed", () => {
         setSpeedUpStatus("success");
         notify.unsubscribe(txResponse.hash);
+        setNotifyConfig({
+          networkId: 1,
+        });
       });
       emitter.on("txFailed", (state) => {
         setSpeedUpStatus("error");
         setSpeedUpErrorMsg(`Tx failed`);
         notify.unsubscribe(txResponse.hash);
+        setNotifyConfig({
+          networkId: 1,
+        });
       });
     } catch (error) {
       setSpeedUpStatus("error");

--- a/src/views/Transactions/hooks/useSpeedUp.tsx
+++ b/src/views/Transactions/hooks/useSpeedUp.tsx
@@ -35,9 +35,10 @@ export function useSpeedUp(transfer: Transfer, token: Token) {
     }
   }, [fees]);
 
-  const handleSpeedUp = async (newRelayerFeePct: BigNumber) => {
+  const speedUp = async (newRelayerFeePct: BigNumber) => {
     try {
       setSpeedUpStatus("pending");
+      setSpeedUpErrorMsg("");
 
       if (!signer) {
         throw new Error(`Wallet is not connected`);
@@ -71,7 +72,7 @@ export function useSpeedUp(transfer: Transfer, token: Token) {
       });
       emitter.on("txFailed", (state) => {
         setSpeedUpStatus("error");
-        setSpeedUpErrorMsg("Tx failed");
+        setSpeedUpErrorMsg(`Tx failed`);
         notify.unsubscribe(txResponse.hash);
       });
     } catch (error) {
@@ -82,7 +83,7 @@ export function useSpeedUp(transfer: Transfer, token: Token) {
   };
 
   return {
-    handleSpeedUp,
+    speedUp,
     speedUpStatus,
     speedUpErrorMsg,
     isCorrectChain,

--- a/src/views/Transactions/hooks/useTxClient.ts
+++ b/src/views/Transactions/hooks/useTxClient.ts
@@ -104,5 +104,13 @@ function getUpdatedTransferTuples(
     return nextTransferTuples;
   }
 
+  const didSpeedUpsChange = prevTransferTuples.some(
+    ([, prevTransfer], i) =>
+      prevTransfer.speedUps.length !== nextTransferTuples[i][1].speedUps.length
+  );
+  if (didSpeedUpsChange) {
+    return nextTransferTuples;
+  }
+
   return prevTransferTuples;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@^0.1.25":
-  version "0.1.25"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.1.25.tgz#b2a9bfb072ef81db5e10364446d1bcd00dcfae55"
-  integrity sha512-MKNPvD6EjRop+6UG0GyEcyINGU3WuIAhL/YLkQThmUU8JC+JWAqa+wyMQX4orYkSvsdERusSIwBLVqrmYa4Zrg==
+"@across-protocol/sdk-v2@^0.1.26":
+  version "0.1.26"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.1.26.tgz#b73744a8d61e87cacd73245d467516f9c6503d00"
+  integrity sha512-VjtS2P+nE8JpH3tUJZJQ0XPDUKJF6sdLCQ0kpjhaC1x3Qq4r66Uuzm5CVaxltxQf9rZ5gvKhigKLHBy7UB0/fw==
   dependencies:
     "@across-protocol/contracts-v2" "^0.0.50"
     "@eth-optimism/sdk" "^1.1.4"


### PR DESCRIPTION
This adds a first-pass version of the speed up modal. There is one optional TODO/blocker but this can be adjusted in an upcoming PR.

Testing this feature is a bit tricky. I tested it by setting a very low relayer in the `useBridge.ts` hook locally, e.g.
```
relayerFeePct: ethers.utils.parseEther("0.0001"), // 0.01%
```

**TODOs:**
- [x] Use `/suggested-fees` API / hook from https://github.com/across-protocol/frontend-v2/pull/256 (optional)

Videos of user flow

https://user-images.githubusercontent.com/17645687/190171829-df8abbe4-24da-4977-aac6-9a8d671bcb77.mov

