### PR TITLE
feat: Add general maintenance banner.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,6 @@ REACT_APP_REWARDS_BANNER_WARNING=
 
 # Define Hardhat Infura ID for testing
 HARDHAT_INFURA_ID= 
+
+# Define a configurable message to display to users in environment.
+REACT_APP_GENERAL_MAINTENANCE_MESSAGE = Message to display in top banner.

--- a/.env.example
+++ b/.env.example
@@ -67,4 +67,4 @@ REACT_APP_REWARDS_BANNER_WARNING=
 HARDHAT_INFURA_ID= 
 
 # Define a configurable message to display to users in environment.
-REACT_APP_GENERAL_MAINTENANCE_MESSAGE = Message to display in top banner.
+REACT_APP_GENERAL_MAINTENANCE_MESSAGE=Message to display in top banner.

--- a/.env.example
+++ b/.env.example
@@ -67,4 +67,4 @@ REACT_APP_REWARDS_BANNER_WARNING=
 HARDHAT_INFURA_ID= 
 
 # Define a configurable message to display to users in environment.
-REACT_APP_GENERAL_MAINTENANCE_MESSAGE=Message to display in top banner.
+REACT_APP_GENERAL_MAINTENANCE_MESSAGE="Message to display in top banner."

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -18,6 +18,7 @@ import {
   enableMigration,
   WrongNetworkError,
   rewardsBannerWarning,
+  generalMaintenanceMessage,
 } from "utils";
 import { ReactComponent as InfoLogo } from "assets/icons/info-24.svg";
 import Toast from "components/Toast";
@@ -64,6 +65,9 @@ const Routes: React.FC = () => {
 
   return (
     <>
+      {generalMaintenanceMessage && (
+        <SuperHeader size="lg">{generalMaintenanceMessage}</SuperHeader>
+      )}
       {disableDeposits && (
         <SuperHeader>
           Across is experiencing issues. Deposits are currently disabled into
@@ -88,6 +92,7 @@ const Routes: React.FC = () => {
       {isContractAddress && (
         <SuperHeader size="lg">{warningMessage}</SuperHeader>
       )}
+
       <SuperHeader darkMode>
         <i>USDT currently disabled for Across contract upgrade.</i>
       </SuperHeader>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -574,6 +574,8 @@ export const hubPoolAddress = routeConfig.hubPoolAddress;
 export const migrationPoolV2Warning =
   process.env.REACT_APP_MIGRATION_POOL_V2_WARNING;
 export const enableMigration = process.env.REACT_APP_ENABLE_MIGRATION;
+export const generalMaintenanceMessage =
+  process.env.REACT_APP_GENERAL_MAINTENANCE_MESSAGE;
 
 // Note: this address is used as the from address for simulated relay transactions on Optimism and Arbitrum since
 // gas estimates require a live estimate and not a pre-configured gas amount. This address should be pre-loaded with


### PR DESCRIPTION
Proposed solution for:  https://linear.app/uma/issue/ACX-260/prepare-banner-warning-users-that-bridge-will-be-offline-before-and

Make a generalized configurable message that can be changed in Vercel. We can't do formatting much this way but it might be useful to have something we can do without a PR in Vercel at a moment's notice.

To test, you should start this branch locally and add to your local .env, as I don't want to add this to environment variables until we are ready.

<img width="1289" alt="Screen Shot 2022-09-07 at 11 12 49 AM" src="https://user-images.githubusercontent.com/12792146/188949292-4b2e016a-d09c-4a58-920e-f3031650a931.png">


