### PR TITLE
build: fix by adapting to new sdk version

### DIFF
--- a/src/views/Transactions/utils.ts
+++ b/src/views/Transactions/utils.ts
@@ -32,12 +32,16 @@ export function doPartialFillsExist(pendingTransferTuples: SupportedTxTuple[]) {
   });
 }
 
+/**
+ * @todo Use proper values for `initialRelayerFeePct`, `currentRelayerFeePct`
+ * and `speedUps` instead of placeholders.
+ */
 export function formatToTransfer(deposit: Deposit): Transfer {
   return {
     ...deposit,
     filled: BigNumber.from(deposit.filled),
     amount: BigNumber.from(deposit.amount),
-    // TODO: replace with proper values if scraper-api supports relayer fee
+    // replace with proper values if scraper-api supports relayer fee
     initialRelayerFeePct: BigNumber.from(0),
     currentRelayerFeePct: BigNumber.from(0),
     speedUps: [],

--- a/src/views/Transactions/utils.ts
+++ b/src/views/Transactions/utils.ts
@@ -37,5 +37,9 @@ export function formatToTransfer(deposit: Deposit): Transfer {
     ...deposit,
     filled: BigNumber.from(deposit.filled),
     amount: BigNumber.from(deposit.amount),
+    // TODO: replace with proper values if scraper-api supports relayer fee
+    initialRelayerFeePct: BigNumber.from(0),
+    currentRelayerFeePct: BigNumber.from(0),
+    speedUps: [],
   };
 }


### PR DESCRIPTION
The all transactions view PR https://github.com/across-protocol/frontend-v2/pull/221 didn't have merge conflicts but was based on an older across-sdk version with incompatible types. This fixes it.