### PR TITLE
fix: pool removal crashing with small amounts

### DIFF
--- a/src/components/PoolForm/RemoveLiquidityForm.tsx
+++ b/src/components/PoolForm/RemoveLiquidityForm.tsx
@@ -162,7 +162,10 @@ const RemoveLiqudityForm: FC<Props> = ({
           feesEarned: max(feesEarned, 0),
           positionValue: totalPosition,
         },
-        removeAmountSlider / 100
+        // the sdk type specifies this needs to be a number but actually can take bignumberish.
+        // without setting tofixed is possible to crash the bignumber calculation with decimals
+        // longer than 18 digits by inputting very small amounts to withdraw.
+        (removeAmountSlider / 100).toFixed(18) as unknown as number
       )
     : null;
 


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

Motivation

UI was crashing when inputting very small numbers to withdraw from pool

Solution

We have to call tofixed on the decimal when passing into the preview. unfortunately for now the sdk specifies this is passed as a decimal, and probably should be sanitizing in there, but this will acheive the same effect easier by making the change on the FE
