### PR TITLE
feat: additional delay calc logic configurable by REACT_APP_DEPOSIT_DELAY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,5 +75,5 @@ CHROMATIC_PROJECT_TOKEN=
 # Disable bridge send transactions in UI and show an error when this is set to `true`.
 REACT_APP_BRIDGE_DISABLED= 
 
-# JSON string with format: {[chainId]: numberInSeconds}, eg: { "1": 60, "10": 240, "137": 100, "600": 4, "42161": 240 }
+# JSON string with format: {[chainId]: numberInSeconds}, eg: { "1": 60, "10": 240, "137": 100, "288": 4, "42161": 240 }
 REACT_APP_DEPOSIT_DELAY=

--- a/.env.example
+++ b/.env.example
@@ -75,5 +75,5 @@ CHROMATIC_PROJECT_TOKEN=
 # Disable bridge send transactions in UI and show an error when this is set to `true`.
 REACT_APP_BRIDGE_DISABLED= 
 
-# JSON string with format: {[chainId]: numberInSeconds}, eg: `{ "1": 60, "10": 240, "137": 100, "600": 4, "42161": 240 }`
+# JSON string with format: {[chainId]: numberInSeconds}, eg: { "1": 60, "10": 240, "137": 100, "600": 4, "42161": 240 }
 REACT_APP_DEPOSIT_DELAY=

--- a/.env.example
+++ b/.env.example
@@ -74,3 +74,6 @@ CHROMATIC_PROJECT_TOKEN=
 
 # Disable bridge send transactions in UI and show an error when this is set to `true`.
 REACT_APP_BRIDGE_DISABLED= 
+
+# JSON with format: {chainId: numberInSeconds}, eg: { "1": 60, "10": 240, "137": 100, "288": 30, "42161": 240 }
+DEPOSIT_DELAY=

--- a/.env.example
+++ b/.env.example
@@ -75,5 +75,5 @@ CHROMATIC_PROJECT_TOKEN=
 # Disable bridge send transactions in UI and show an error when this is set to `true`.
 REACT_APP_BRIDGE_DISABLED= 
 
-# JSON with format: {chainId: numberInSeconds}, eg: { "1": 60, "10": 240, "137": 100, "288": 30, "42161": 240 }
-DEPOSIT_DELAY=
+# JSON string with format: {[chainId]: numberInSeconds}, eg: `{ "1": 60, "10": 240, "137": 100, "600": 4, "42161": 240 }`
+REACT_APP_DEPOSIT_DELAY=

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -51,8 +51,13 @@ const SendAction: React.FC<Props> = ({ onDeposit }) => {
   const tokenInfo = tokenSymbol ? getToken(tokenSymbol) : undefined;
   const isWETH = tokenInfo?.symbol === "WETH";
   let timeToRelay = "loading";
-  if (limits && toChain) {
-    timeToRelay = getConfirmationDepositTime(amount, limits, toChain);
+  if (limits && toChain && fromChain) {
+    timeToRelay = getConfirmationDepositTime(
+      amount,
+      limits,
+      toChain,
+      fromChain
+    );
   } else if (limitsError) {
     timeToRelay = "estimation failed";
   }

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -165,7 +165,7 @@ export const getConfirmationDepositTime = (
 ) => {
   // Add this estimate for Ethereum 2.0
   if (toChain === ChainId.MAINNET) {
-    return "~4-7 minutes";
+    return "~6-7 minutes";
   }
   if (amount.lte(limits.maxDepositInstant)) {
     // 1 bot run, assuming it runs every 2 minutes.

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -166,33 +166,30 @@ export const getConfirmationDepositTime = (
 ) => {
   const config = getConfig();
   const depositDelay = config.depositDelays()[fromChain] || 0;
-  const calculateBridgeTimeRangeInMinutes = (
+  const getTimeEstimateString = (
     lowEstimate: number,
     highEstimate: number
-  ): [number, number] => {
-    return [lowEstimate + depositDelay, highEstimate + depositDelay];
-  };
-  const getTimeEstimateString = (estimates: [number, number]): string => {
-    return `~${estimates[0]}-${estimates[1]} minutes`;
+  ): string => {
+    return `~${lowEstimate + depositDelay}-${
+      highEstimate + depositDelay
+    } minutes`;
   };
 
   if (amount.lte(limits.maxDepositInstant)) {
-    return getTimeEstimateString(calculateBridgeTimeRangeInMinutes(1, 4));
+    return getTimeEstimateString(1, 4);
   } else if (amount.lte(limits.maxDepositShortDelay)) {
     // This is just a rough estimate of how long 2 bot runs (1-4 minutes allocated for each) + an arbitrum transfer of 3-10 minutes would take.
-    if (toChain === ChainId.ARBITRUM)
-      return getTimeEstimateString(calculateBridgeTimeRangeInMinutes(5, 15));
+    if (toChain === ChainId.ARBITRUM) return getTimeEstimateString(5, 15);
 
     // Optimism transfers take about 10-20 minutes anecdotally. Boba is presumed to be similar.
     if (toChain === ChainId.OPTIMISM || toChain === ChainId.BOBA)
-      return getTimeEstimateString(calculateBridgeTimeRangeInMinutes(12, 25));
+      return getTimeEstimateString(12, 25);
 
     // Polygon transfers take 20-30 minutes anecdotally.
-    if (toChain === ChainId.POLYGON)
-      return getTimeEstimateString(calculateBridgeTimeRangeInMinutes(20, 35));
+    if (toChain === ChainId.POLYGON) return getTimeEstimateString(20, 35);
 
     // Typical numbers for an arbitrary L2.
-    return getTimeEstimateString(calculateBridgeTimeRangeInMinutes(10, 30));
+    return getTimeEstimateString(10, 30);
   }
 
   // If the deposit size is above those, but is allowed by the app, we assume the pool will slow relay it.

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -165,12 +165,8 @@ export const getConfirmationDepositTime = (
   fromChain: ChainId
 ) => {
   const config = getConfig();
-  const depositDelays = config.depositDelays();
-  const timeRange = calculateBridgeTimeRangeInMinutes(
-    fromChain,
-    // Pass in 0 if depositDelay value undefined for that ChainId.
-    depositDelays[fromChain] || 0
-  );
+  const depositDelay = config.depositDelays()[fromChain] || 0;
+  const timeRange = calculateBridgeTimeRangeInMinutes(fromChain, depositDelay);
 
   if (amount.lte(limits.maxDepositInstant)) {
     return `~${timeRange[0]}-${timeRange[1]} minutes`;
@@ -401,11 +397,11 @@ const MIN_DEPOSIT_CONFIRMATIONS: Record<
   },
   [ChainId.OPTIMISM]: {
     blocks: 240,
-    averageBlockTime: 13,
+    averageBlockTime: 1,
   },
   [ChainId.POLYGON]: { blocks: 100, averageBlockTime: 2.5 },
-  [ChainId.BOBA]: { blocks: 4, averageBlockTime: 120 },
-  [ChainId.ARBITRUM]: { blocks: 240, averageBlockTime: 13 },
+  [ChainId.BOBA]: { blocks: 4, averageBlockTime: 30 },
+  [ChainId.ARBITRUM]: { blocks: 240, averageBlockTime: 1 },
 };
 
 /**

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -164,6 +164,8 @@ export const getConfirmationDepositTime = (
   toChain: ChainId,
   fromChain: ChainId
 ) => {
+  const config = getConfig();
+  console.log(config.depositDelays());
   // Add this estimate for Ethereum 2.0
   if (fromChain === ChainId.MAINNET) {
     return "~6-7 minutes";
@@ -388,3 +390,19 @@ export function relayFeeCalculatorConfig(
     queries,
   };
 }
+
+export const MIN_DEPOSIT_CONFIRMATIONS = {
+  [ChainId.MAINNET]: {
+    blocks: 6,
+    averageBlockTime: 13.5,
+  },
+  [ChainId.OPTIMISM]: {
+    blocks: 240,
+    averageBlockTime: 13,
+  },
+  [ChainId.POLYGON]: { blocks: 100 },
+  [ChainId.BOBA]: { blocks: 4 },
+  [ChainId.ARBITRUM]: { blocks: 240 },
+};
+
+function calculateBridgeTimeRange(fromChain: ChainId, additionalDelay = 0) {}

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -163,6 +163,10 @@ export const getConfirmationDepositTime = (
   limits: BridgeLimits,
   toChain: ChainId
 ) => {
+  // Add this estimate for Ethereum 2.0
+  if (toChain === ChainId.MAINNET) {
+    return "~4-7 minutes";
+  }
   if (amount.lte(limits.maxDepositInstant)) {
     // 1 bot run, assuming it runs every 2 minutes.
     return "~1-4 minutes";

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -420,9 +420,8 @@ function calculateBridgeTimeRangeInMinutes(
   additionalDelay = 0
 ): number[] {
   const { blocks, averageBlockTime } = MIN_DEPOSIT_CONFIRMATIONS[fromChain];
-  const max = Math.round((averageBlockTime * blocks + additionalDelay) / 60);
-  const min = Math.round(
-    (0.25 * averageBlockTime * blocks + additionalDelay) / 60
-  );
+  const calc = (averageBlockTime * blocks + additionalDelay) / 60;
+  const max = Math.round(calc);
+  const min = Math.round(0.25 * calc);
   return [min, max];
 }

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -168,7 +168,8 @@ export const getConfirmationDepositTime = (
   const depositDelays = config.depositDelays();
   const timeRange = calculateBridgeTimeRangeInMinutes(
     fromChain,
-    depositDelays[fromChain]
+    // Pass in 0 if depositDelay value undefined for that ChainId.
+    depositDelays[fromChain] || 0
   );
 
   if (amount.lte(limits.maxDepositInstant)) {

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -161,10 +161,11 @@ export async function getBridgeFees({
 export const getConfirmationDepositTime = (
   amount: BigNumber,
   limits: BridgeLimits,
-  toChain: ChainId
+  toChain: ChainId,
+  fromChain: ChainId
 ) => {
   // Add this estimate for Ethereum 2.0
-  if (toChain === ChainId.MAINNET) {
+  if (fromChain === ChainId.MAINNET) {
     return "~6-7 minutes";
   }
   if (amount.lte(limits.maxDepositInstant)) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -17,6 +17,10 @@ export type Token = constants.TokenInfo & {
 };
 export type TokenList = Token[];
 
+export interface DepositDelays {
+  [chainId: string]: number;
+}
+
 export class ConfigClient {
   public readonly spokeAddresses: Record<number, string> = {};
   public readonly spokeChains: Set<number> = new Set();
@@ -193,6 +197,20 @@ export class ConfigClient {
     // use token sorting when returning reachable tokens
     return sortBy(reachableTokens, (token) => this.tokenOrder[token.symbol]);
   }
+  depositDelays() {
+    try {
+      const dd = process.env.REACT_APP_DEPOSIT_DELAY;
+      if (dd) {
+        console.log("deposit delay", JSON.parse(dd));
+        return JSON.parse(dd) as DepositDelays;
+      } else {
+        return {};
+      }
+    } catch (err) {
+      console.error(err);
+      return {};
+    }
+  }
 }
 
 // singleton
@@ -200,5 +218,6 @@ let config: ConfigClient | undefined;
 export function getConfig(): ConfigClient {
   if (config) return config;
   config = new ConfigClient(constants.routeConfig);
+  console.log(config.depositDelays());
   return config;
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -201,8 +201,6 @@ export class ConfigClient {
     try {
       const dd = process.env.REACT_APP_DEPOSIT_DELAY;
       if (dd) {
-        console.log("deposit delay", dd);
-        console.log("parsed", JSON.parse(dd));
         return JSON.parse(dd) as DepositDelays;
       } else {
         return {};
@@ -219,6 +217,5 @@ let config: ConfigClient | undefined;
 export function getConfig(): ConfigClient {
   if (config) return config;
   config = new ConfigClient(constants.routeConfig);
-  console.log(config.depositDelays());
   return config;
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -201,7 +201,6 @@ export class ConfigClient {
     try {
       const dd = process.env.REACT_APP_DEPOSIT_DELAY;
       if (dd) {
-        console.log("deposit delay", JSON.parse(dd));
         return JSON.parse(dd) as DepositDelays;
       } else {
         return {};

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -201,7 +201,8 @@ export class ConfigClient {
     try {
       const dd = process.env.REACT_APP_DEPOSIT_DELAY;
       if (dd) {
-        console.log("deposit delay", dd, JSON.parse(dd));
+        console.log("deposit delay", dd);
+        console.log("parsed", JSON.parse(dd));
         return JSON.parse(dd) as DepositDelays;
       } else {
         return {};

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -218,6 +218,5 @@ let config: ConfigClient | undefined;
 export function getConfig(): ConfigClient {
   if (config) return config;
   config = new ConfigClient(constants.routeConfig);
-  console.log(config.depositDelays());
   return config;
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -201,6 +201,7 @@ export class ConfigClient {
     try {
       const dd = process.env.REACT_APP_DEPOSIT_DELAY;
       if (dd) {
+        console.log("deposit delay", dd);
         return JSON.parse(dd) as DepositDelays;
       } else {
         return {};

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -201,7 +201,7 @@ export class ConfigClient {
     try {
       const dd = process.env.REACT_APP_DEPOSIT_DELAY;
       if (dd) {
-        console.log("deposit delay", dd);
+        console.log("deposit delay", dd, JSON.parse(dd));
         return JSON.parse(dd) as DepositDelays;
       } else {
         return {};
@@ -218,5 +218,6 @@ let config: ConfigClient | undefined;
 export function getConfig(): ConfigClient {
   if (config) return config;
   config = new ConfigClient(constants.routeConfig);
+  console.log(config.depositDelays());
   return config;
 }

--- a/src/views/Confirmation/Confirmation.tsx
+++ b/src/views/Confirmation/Confirmation.tsx
@@ -70,7 +70,8 @@ const Confirmation: React.FC<Props> = ({ deposit, onClose }) => {
     timeEstimate = getConfirmationDepositTime(
       deposit.amount,
       limits,
-      deposit.toChain
+      deposit.toChain,
+      deposit.fromChain
     );
     fundsArrivalText = `Your funds will arrive in ${timeEstimate}`;
   } else if (isError) {


### PR DESCRIPTION
1. Built utility functions to help with time range calculation.
2. Tested via REACT_APP_DEPOSIT_DELAY= { "1": 2, "10": 2, "137": 2, "288": 2, "42161": 2 }

QA: Each of the different `toChain` paths for a given `fromChain` should show the current time estimates + 2 mins