### PR TITLE
chore(across-v2): Bump SDK -> 0.1.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@across-protocol/contracts-v2": "^0.0.34",
-    "@across-protocol/sdk-v2": "^0.1.25",
+    "@across-protocol/sdk-v2": "^0.1.26",
     "@datapunt/matomo-tracker-js": "^0.5.1",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",


### PR DESCRIPTION
**Overview**
 - Less logging.
 - Longer timeout on CoinGecko price lookups.

**Acceptance Criteria**
No observable regressions from basic testing.