### PR TITLE
fix: remove max relayer fee button

### DIFF
--- a/src/views/Transactions/components/SpeedUpModal/InputWithButton.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/InputWithButton.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 type Props = React.HTMLProps<HTMLInputElement> & {
   label?: string;
   error?: string;
-  Button: React.ReactElement;
+  Button?: React.ReactElement;
 };
 
 export function InputWithButton({
@@ -36,7 +36,7 @@ export function InputWithButton({
             }}
             {...inputProps}
           />
-          {Button}
+          {Button && Button}
         </InputWithButtonContainer>
       </InputContainer>
       {error && <ErrorContainer>{error}</ErrorContainer>}

--- a/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
+++ b/src/views/Transactions/components/SpeedUpModal/SpeedUpModal.tsx
@@ -111,17 +111,6 @@ export function SpeedUpModal({ isOpen, onClose, txTuple }: Props) {
             />
             <InputWithButton
               label="Relay fee"
-              Button={
-                <button
-                  onClick={() =>
-                    setRelayFeeInput(
-                      appendPercentageSign(String(maxRelayFee * 100))
-                    )
-                  }
-                >
-                  MAX
-                </button>
-              }
               value={relayFeeInput}
               onChange={handleInputChange}
               onFocus={() =>


### PR DESCRIPTION
Remove `MAX` button in speed up modal for now, until better-suited function is found.