### PR TITLE
feat(api): Exit early from debug level logs if boolean is switched on

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -45,7 +45,7 @@ export const log = (
   severity: "DEBUG" | "INFO" | "WARN" | "ERROR",
   data: LogType
 ) => {
-  if (DISABLE_DEBUG_LOGS === "true") return;
+  if (DISABLE_DEBUG_LOGS === "true" && severity === "DEBUG") return;
   let message = JSON.stringify(data, null, 4);
   // Fire and forget. we don't wait for this to finish.
   gcpLogger

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -23,6 +23,7 @@ const {
   REACT_APP_GOOGLE_SERVICE_ACCOUNT,
   VERCEL_ENV,
   GAS_MARKUP,
+  DISABLE_DEBUG_LOGS,
 } = process.env;
 
 const GOOGLE_SERVICE_ACCOUNT = REACT_APP_GOOGLE_SERVICE_ACCOUNT
@@ -44,6 +45,7 @@ export const log = (
   severity: "DEBUG" | "INFO" | "WARN" | "ERROR",
   data: LogType
 ) => {
+  if (DISABLE_DEBUG_LOGS === "true") return;
   let message = JSON.stringify(data, null, 4);
   // Fire and forget. we don't wait for this to finish.
   gcpLogger

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -45,7 +45,10 @@ export const log = (
   severity: "DEBUG" | "INFO" | "WARN" | "ERROR",
   data: LogType
 ) => {
-  if (DISABLE_DEBUG_LOGS === "true" && severity === "DEBUG") return;
+  if (DISABLE_DEBUG_LOGS === "true" && severity === "DEBUG") {
+    console.log(data);
+    return;
+  }
   let message = JSON.stringify(data, null, 4);
   // Fire and forget. we don't wait for this to finish.
   gcpLogger


### PR DESCRIPTION
Vercel logging can be expensive and we're not in control of when clients trigger the API that log. We should be able to turn off non-critical logs with a boolean flip easily