### PR TITLE
perf: throttle scroll handler

### DIFF
--- a/src/components/Sidebar/useSidebar.ts
+++ b/src/components/Sidebar/useSidebar.ts
@@ -37,12 +37,12 @@ export default function useSidebar(openSidebar: boolean) {
       title: "Pool",
     },
     {
-      pathName: "/transactions",
-      title: "Transactions",
-    },
-    {
       pathName: "/rewards",
       title: "Rewards",
+    },
+    {
+      pathName: "/transactions",
+      title: "Transactions",
     },
     {
       pathName: "/airdrop",

--- a/src/components/Sidebar/useSidebar.ts
+++ b/src/components/Sidebar/useSidebar.ts
@@ -45,6 +45,10 @@ export default function useSidebar(openSidebar: boolean) {
       title: "Rewards",
     },
     {
+      pathName: "/airdrop",
+      title: "Airdrop",
+    },
+    {
       pathName: "/about",
       title: "About",
     },

--- a/src/hooks/useScrollPosition.ts
+++ b/src/hooks/useScrollPosition.ts
@@ -1,12 +1,13 @@
 import { useState, useEffect } from "react";
+import throttle from "lodash/throttle";
 
 const useScrollPosition = () => {
   const [scrollPosition, setScrollPosition] = useState(0);
 
   useEffect(() => {
-    const updatePosition = () => {
+    const updatePosition = throttle(() => {
       setScrollPosition(window.pageYOffset);
-    };
+    }, 50);
     window.addEventListener("scroll", updatePosition);
     updatePosition();
     return () => window.removeEventListener("scroll", updatePosition);


### PR DESCRIPTION
On some devices and also on the preview links, the opacity change animation was a bit laggy. Not sure if that only happens on my machine 🤔  I added a throttle with a wait of 50ms so that it still feels smooth but drastically reduces the number of state updates. Also added the `/airdrop` link to the sidebar.