### PR TITLE
fix: lp icon size

### DIFF
--- a/src/views/PreLaunchAirdrop/components/CardContent.tsx
+++ b/src/views/PreLaunchAirdrop/components/CardContent.tsx
@@ -81,6 +81,10 @@ const Wrapper = styled.div`
   @media screen and (max-width: 624px) {
     flex-direction: column;
   }
+
+  a {
+    text-decoration: none;
+  }
 `;
 
 const TextStack = styled.div`

--- a/src/views/PreLaunchAirdrop/components/CardIcon.tsx
+++ b/src/views/PreLaunchAirdrop/components/CardIcon.tsx
@@ -67,6 +67,11 @@ const IconWrapper = styled.div<IconWrapperType>`
 
   height: ${({ addPadding }) => (addPadding ? "calc(100% - 2px)" : "100%")};
   width: ${({ addPadding }) => (addPadding ? "calc(100% - 2px)" : "100%")};
+
+  svg {
+    height: 56px;
+    width: 56px;
+  }
 `;
 
 const UndeterminedStyledCheckMark = styled(CheckMark)`


### PR DESCRIPTION
The LP icon size was a bit off. I adjusted the wrapper to enforce a fixed size. Also removed the text-decoration from the "Go to Pools" button.

Previous
![image](https://user-images.githubusercontent.com/17645687/193001611-f4a95702-8b65-45d2-b846-2a1b0c691a10.png)
<img width="138" alt="image" src="https://user-images.githubusercontent.com/17645687/193003679-bad91c79-daa3-4e64-9d00-c0715837be0b.png">

Now
![image](https://user-images.githubusercontent.com/17645687/193002260-444ae72c-c9c8-4691-8677-2b05fabc3803.png)
<img width="130" alt="image" src="https://user-images.githubusercontent.com/17645687/193003744-9e4e08a1-4998-4789-8a61-d7a0bd2c7df5.png">

