### PR TITLE
fix: refetch rewards on successful discord auth

### DIFF
--- a/src/utils/query-keys.ts
+++ b/src/utils/query-keys.ts
@@ -111,7 +111,7 @@ export function depositsQueryKey(
   return ["deposits", status, limit, offset];
 }
 
-export function prelaunchDataQueryKey(address: string, jwt?: string) {
+export function prelaunchDataQueryKey(address?: string, jwt?: string) {
   return ["prelaunch-data", address, jwt];
 }
 

--- a/src/utils/query-keys.ts
+++ b/src/utils/query-keys.ts
@@ -111,8 +111,8 @@ export function depositsQueryKey(
   return ["deposits", status, limit, offset];
 }
 
-export function prelaunchDataQueryKey(address: string) {
-  return ["prelaunch-data", address];
+export function prelaunchDataQueryKey(address: string, jwt?: string) {
+  return ["prelaunch-data", address, jwt];
 }
 
 export function prelaunchUserDetailsQueryKey(jwt: string) {

--- a/src/views/PreLaunchAirdrop/api/useGetPrelaunchRewards.ts
+++ b/src/views/PreLaunchAirdrop/api/useGetPrelaunchRewards.ts
@@ -5,7 +5,7 @@ import getPrelaunchRewards from "./getPrelaunchRewards";
 
 export function useGetPrelaunchRewards(address?: string, jwt?: string) {
   const queryKey = !!address
-    ? prelaunchDataQueryKey(address)
+    ? prelaunchDataQueryKey(address, jwt)
     : "DISABLED_ADDRESS_SUMMARY_KEY";
 
   const { data, ...other } = useQuery(
@@ -14,9 +14,6 @@ export function useGetPrelaunchRewards(address?: string, jwt?: string) {
       return getPrelaunchRewards(address!, jwt);
     },
     {
-      // refetch based on the chain polling interval
-      // disable this temporary
-      // refetchInterval: 60000,
       enabled: !!address,
     }
   );

--- a/src/views/PreLaunchAirdrop/api/useGetPrelaunchRewards.ts
+++ b/src/views/PreLaunchAirdrop/api/useGetPrelaunchRewards.ts
@@ -4,9 +4,7 @@ import { RewardsApiInterface } from "utils/serverless-api/types";
 import getPrelaunchRewards from "./getPrelaunchRewards";
 
 export function useGetPrelaunchRewards(address?: string, jwt?: string) {
-  const queryKey = !!address
-    ? prelaunchDataQueryKey(address, jwt)
-    : "DISABLED_ADDRESS_SUMMARY_KEY";
+  const queryKey = prelaunchDataQueryKey(address, jwt);
 
   const { data, ...other } = useQuery(
     queryKey,


### PR DESCRIPTION
The community eligibility data didn't update instantly after a successful Discord authentication. To solve this we make the query key dependent on the JWT.