### PR TITLE
test: add basic set of airdrop e2e tests

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -6,9 +6,8 @@ on:
   push:
     branches:
       - master
+      - epic/**
   pull_request:
-    branches:
-      - master
 
 jobs:
   lint:

--- a/cypress/e2e/prelaunch.cy.ts
+++ b/cypress/e2e/prelaunch.cy.ts
@@ -1,0 +1,27 @@
+describe("prelaunch", () => {
+  const cardIds = [
+    "bridge-traveler-card",
+    "community-rewards-card",
+    "liquidity-provider-card",
+    "bridge-user-card",
+  ];
+
+  it("render in initial state", () => {
+    cy.visit("/airdrop");
+    cy.dataCy("connect-wallet").should("be.visible");
+  });
+
+  it("display airdrop details", () => {
+    cy.dataCy("airdrop-details-button").click();
+    cy.dataCy("airdrop-details").should("be.visible");
+
+    cy.dataCy("back-button").click();
+    cy.dataCy("airdrop-details-button").should("be.visible");
+  });
+
+  it("display all cards for disconnected wallet", () => {
+    for (const cardId of cardIds) {
+      cy.dataCy(cardId).scrollIntoView().should("be.visible");
+    }
+  });
+});

--- a/src/components/GlobalStyles/GlobalStyles.tsx
+++ b/src/components/GlobalStyles/GlobalStyles.tsx
@@ -91,14 +91,14 @@ const globalStyles = css`
   }
   html,
   body {
-    height: 100%;
+    min-height: 100vh;
   }
   body {
     background-color: var(--color-gray);
     color: var(--color-white);
   }
   #root {
-    height: 100%;
+    min-height: 100vh;
     isolation: isolate;
   }
   // iphone query

--- a/src/views/PreLaunchAirdrop/components/AirdropCard.tsx
+++ b/src/views/PreLaunchAirdrop/components/AirdropCard.tsx
@@ -18,6 +18,7 @@ type AirdropCardContentProps = {
   rewardAmount?: string;
   // Internal React-router link, eg: /pools
   buttonLink?: string;
+  "data-cy"?: string;
 };
 
 const AirdropCard: React.FC<AirdropCardContentProps> = ({
@@ -33,11 +34,13 @@ const AirdropCard: React.FC<AirdropCardContentProps> = ({
   rewardAmount,
   buttonLink,
   boxShadowOnHover,
+  ...restProps
 }) => (
   <Wrapper
     eligible={check ?? "undetermined"}
     boxShadowOnHover={boxShadowOnHover}
     hideBoxShadow={hideBoxShadow}
+    data-cy={restProps["data-cy"]}
   >
     <WrapperBackground />
     <CardContent

--- a/src/views/PreLaunchAirdrop/components/MoreInfoFlow/MoreInfoFlow.tsx
+++ b/src/views/PreLaunchAirdrop/components/MoreInfoFlow/MoreInfoFlow.tsx
@@ -17,9 +17,9 @@ type Props = {
 
 export function MoreInfoFlow({ onClickBack }: Props) {
   return (
-    <Container>
+    <Container data-cy="airdrop-details">
       <TitleContainer>
-        <BackButton onClick={onClickBack}>
+        <BackButton data-cy="back-button" onClick={onClickBack}>
           <ChevronLeft size={24} strokeWidth={1} /> Back
         </BackButton>
         <h3>Airdrop details</h3>

--- a/src/views/PreLaunchAirdrop/components/TitleSection.tsx
+++ b/src/views/PreLaunchAirdrop/components/TitleSection.tsx
@@ -28,11 +28,18 @@ const TitleSection = ({
       </TextStack>
       <ButtonStack>
         {!isConnected && (
-          <StyledButton onClick={walletConnectionHandler} size="lg">
+          <StyledButton
+            data-cy="connect-wallet"
+            onClick={walletConnectionHandler}
+            size="lg"
+          >
             Connect to check eligibility
           </StyledButton>
         )}
-        <EligibilityLink onClick={airdropDetailsLinkHandler}>
+        <EligibilityLink
+          data-cy="airdrop-details-button"
+          onClick={airdropDetailsLinkHandler}
+        >
           <InnerLinkText>Airdrop details</InnerLinkText>
           <StyledArrowIcon />
         </EligibilityLink>

--- a/src/views/PreLaunchAirdrop/components/cards/BridgeTravelerCard.tsx
+++ b/src/views/PreLaunchAirdrop/components/cards/BridgeTravelerCard.tsx
@@ -77,6 +77,7 @@ const BridgeTravelerCard: React.FC<Props> = ({
   return (
     <AirdropCard
       boxShadowOnHover
+      data-cy="bridge-traveler-card"
       title="Bridge Traveler Program"
       description={cardDescription}
       Icon={TravelerIcon}

--- a/src/views/PreLaunchAirdrop/components/cards/BridgeUserCard.tsx
+++ b/src/views/PreLaunchAirdrop/components/cards/BridgeUserCard.tsx
@@ -51,6 +51,7 @@ const BridgeUserCard: React.FC<Props> = ({
   return (
     <AirdropCard
       boxShadowOnHover
+      data-cy="bridge-user-card"
       title="Early Bridge User"
       description={cardDescription}
       Icon={BridgeIcon}

--- a/src/views/PreLaunchAirdrop/components/cards/CommunityRewardCard.tsx
+++ b/src/views/PreLaunchAirdrop/components/cards/CommunityRewardCard.tsx
@@ -146,6 +146,7 @@ const CommunityRewardCard = ({
     <>
       <AirdropCard
         boxShadowOnHover
+        data-cy="community-rewards-card"
         title="Community Member"
         description={cardDescription}
         Icon={DiscordIcon}

--- a/src/views/PreLaunchAirdrop/components/cards/LiquidityProviderCard.tsx
+++ b/src/views/PreLaunchAirdrop/components/cards/LiquidityProviderCard.tsx
@@ -59,6 +59,7 @@ const LiquidityProviderCard: React.FC<Props> = ({
   return (
     <AirdropCard
       boxShadowOnHover
+      data-cy="liquidity-provider-card"
       title="Liquidity Provider"
       description={cardDescription}
       Icon={LPArrow}


### PR DESCRIPTION
This adds some basic /airdrop route e2e tests. For the more refined ones (connected wallets with different eligibility states), I don't know yet which approach we should take, i.e. I will open separate PRs.