### PR TITLE
fix: old layout min height

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -127,8 +127,7 @@ const Wrapper = styled.div`
   display: grid;
   padding: 0 10px;
   grid-template-columns: 1fr min(var(--central-content), 100%) 1fr;
-  min-height: 100%;
-  height: fit-content;
+  min-height: 100vh;
   @media ${QUERIES.tabletAndUp} {
     padding: 0 30px;
   }


### PR DESCRIPTION
While fixing the stickyness of the header when scrolling, the old layout component wasn't updated.