### PR TITLE
fix: remove depreceated fee file

### DIFF
--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -17,7 +17,6 @@ import {
   getConfigStoreAddress,
   queriesTable,
   FLAT_RELAY_CAPITAL_FEE,
-  relayerFeeCapitalCostConfig,
   referrerDelimiterHex,
   usdcLpCushion,
   wethLpCushion,
@@ -379,7 +378,6 @@ export function relayFeeCalculatorConfig(
     nativeTokenDecimals: token.decimals,
     feeLimitPercent: MAX_RELAY_FEE_PERCENT,
     capitalCostsPercent: FLAT_RELAY_CAPITAL_FEE,
-    capitalCostsConfig: relayerFeeCapitalCostConfig,
     queries,
   };
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -572,59 +572,6 @@ const getRoute = (
   return route;
 };
 
-export const relayerFeeCapitalCostConfig: {
-  [token: string]: relayFeeCalculator.CapitalCostConfig;
-} = {
-  ETH: {
-    lowerBound: ethers.utils.parseUnits("0.0003").toString(),
-    upperBound: ethers.utils.parseUnits("0.0006").toString(),
-    cutoff: ethers.utils.parseUnits("750").toString(),
-    decimals: 18,
-  },
-  WETH: {
-    lowerBound: ethers.utils.parseUnits("0.0003").toString(),
-    upperBound: ethers.utils.parseUnits("0.0006").toString(),
-    cutoff: ethers.utils.parseUnits("750").toString(),
-    decimals: 18,
-  },
-  WBTC: {
-    lowerBound: ethers.utils.parseUnits("0.0003").toString(),
-    upperBound: ethers.utils.parseUnits("0.0025").toString(),
-    cutoff: ethers.utils.parseUnits("10").toString(),
-    decimals: 8,
-  },
-  DAI: {
-    lowerBound: ethers.utils.parseUnits("0.0003").toString(),
-    upperBound: ethers.utils.parseUnits("0.002").toString(),
-    cutoff: ethers.utils.parseUnits("250000").toString(),
-    decimals: 18,
-  },
-  USDC: {
-    lowerBound: ethers.utils.parseUnits("0.0003").toString(),
-    upperBound: ethers.utils.parseUnits("0.00075").toString(),
-    cutoff: ethers.utils.parseUnits("1500000").toString(),
-    decimals: 6,
-  },
-  UMA: {
-    lowerBound: ethers.utils.parseUnits("0.0003").toString(),
-    upperBound: ethers.utils.parseUnits("0.00075").toString(),
-    cutoff: ethers.utils.parseUnits("5000").toString(),
-    decimals: 18,
-  },
-  BADGER: {
-    lowerBound: ethers.utils.parseUnits("0.0003").toString(),
-    upperBound: ethers.utils.parseUnits("0.001").toString(),
-    cutoff: ethers.utils.parseUnits("5000").toString(),
-    decimals: 18,
-  },
-  BOBA: {
-    lowerBound: ethers.utils.parseUnits("0.0003").toString(),
-    upperBound: ethers.utils.parseUnits("0.001").toString(),
-    cutoff: ethers.utils.parseUnits("100000").toString(),
-    decimals: 18,
-  },
-};
-
 const getQueriesTable = () => {
   const optimismUsdcRoute = getRoute(ChainId.MAINNET, ChainId.OPTIMISM, "USDC");
   const arbitrumUsdcRoute = getRoute(ChainId.MAINNET, ChainId.ARBITRUM, "USDC");


### PR DESCRIPTION
This PR removes the `relayerFeeCapitalCostConfig` object from the Across FE.