### PR TITLE
improve(api): Add quote timestamp buffer to suggested-fees route

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -58,7 +58,7 @@ export const relayerFeeCapitalCostConfig = {
 };
 
 // If `timestamp` is not passed into a suggested-fees query, then return the latest mainnet timestamp minus this buffer.
-export const QUOTE_TIMESTAMP_BUFFER = 12 * 60 * 25; // ~25 blocks on mainnet (12s/block), ~= 5 minutes.
+export const DEFAULT_QUOTE_TIMESTAMP_BUFFER = 12 * 60 * 25; // ~25 blocks on mainnet (12s/block), ~= 5 minutes.
 
 export const BLOCK_TAG_LAG = -1;
 

--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -58,7 +58,7 @@ export const relayerFeeCapitalCostConfig = {
 };
 
 // If `timestamp` is not passed into a suggested-fees query, then return the latest mainnet timestamp minus this buffer.
-export const DEFAULT_QUOTE_TIMESTAMP_BUFFER = 12 * 60 * 25; // ~25 blocks on mainnet (12s/block), ~= 5 minutes.
+export const DEFAULT_QUOTE_TIMESTAMP_BUFFER = 12 * 25; // ~25 blocks on mainnet (12s/block), ~= 5 minutes.
 
 export const BLOCK_TAG_LAG = -1;
 

--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -58,9 +58,9 @@ export const relayerFeeCapitalCostConfig = {
 };
 
 // If `timestamp` is not passed into a suggested-fees query, then return the latest mainnet timestamp minus this buffer.
-export const QUOTE_TIMESTAMP_BUFFER = 12 * 60 * 4; // ~4 blocks on mainnet (12s/block)
-export const BLOCK_TAG_LAG = (-1 * QUOTE_TIMESTAMP_BUFFER) / 12 / 60; // Number of blocks behind HEAD to query the
-// HubPool utilization.
+export const QUOTE_TIMESTAMP_BUFFER = 12 * 60 * 25; // ~25 blocks on mainnet (12s/block), ~= 5 minutes.
+
+export const BLOCK_TAG_LAG = -1;
 
 // Note: this is a small subset of all the supported base currencies, but since we don't expect to use the others,
 // we've decided to keep this list small for now.

--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -57,7 +57,10 @@ export const relayerFeeCapitalCostConfig = {
   },
 };
 
-export const BLOCK_TAG_LAG = -1;
+// If `timestamp` is not passed into a suggested-fees query, then return the latest mainnet timestamp minus this buffer.
+export const QUOTE_TIMESTAMP_BUFFER = 12 * 60 * 4; // ~4 blocks on mainnet (12s/block)
+export const BLOCK_TAG_LAG = (-1 * QUOTE_TIMESTAMP_BUFFER) / 12 / 60; // Number of blocks behind HEAD to query the
+// HubPool utilization.
 
 // Note: this is a small subset of all the supported base currencies, but since we don't expect to use the others,
 // we've decided to keep this list small for now.


### PR DESCRIPTION
This should be combined with a change to the relayer code [here](https://github.com/across-protocol/relayer-v2/pull/340) that will make relayer ignore any quote times that do not sufficiently lag HEAD

