### PR TITLE
feat: split up staking pool hooks

### DIFF
--- a/src/data/routes_5_0xA44A832B994f796452e4FaF191a041F791AD8A0A.json
+++ b/src/data/routes_5_0xA44A832B994f796452e4FaF191a041F791AD8A0A.json
@@ -20,6 +20,51 @@
       "fromTokenSymbol": "MATIC",
       "isNative": true,
       "l1TokenAddress": "0x499d11E0b6eAC7c0593d8Fb292DCBbF815Fb29Ae"
+    },
+    {
+      "fromChain": 80001,
+      "toChain": 5,
+      "fromTokenAddress": "0xe6b8a5CF854791412c1f6EFC7CAf629f5Df1c747",
+      "fromSpokeAddress": "0x45fF03629D024b7763275e732a2d80202c18b31C",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xd35CCeEAD182dcee0F148EbaC9447DA2c4D449c4"
+    },
+    {
+      "fromChain": 5,
+      "toChain": 80001,
+      "fromTokenAddress": "0xd35CCeEAD182dcee0F148EbaC9447DA2c4D449c4",
+      "fromSpokeAddress": "0xEc88d3C08E2939562Ff8188B4e30A52236C3FF09",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xd35CCeEAD182dcee0F148EbaC9447DA2c4D449c4"
+    },
+    {
+      "fromChain": 80001,
+      "toChain": 5,
+      "fromTokenAddress": "0xe6b8a5CF854791412c1f6EFC7CAf629f5Df1c747",
+      "fromSpokeAddress": "0x45fF03629D024b7763275e732a2d80202c18b31C",
+      "fromTokenSymbol": "USDC",
+      "isNative": false,
+      "l1TokenAddress": "0xd35CCeEAD182dcee0F148EbaC9447DA2c4D449c4"
+    },
+    {
+      "fromChain": 5,
+      "toChain": 80001,
+      "fromTokenAddress": "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
+      "fromSpokeAddress": "0xEc88d3C08E2939562Ff8188B4e30A52236C3FF09",
+      "fromTokenSymbol": "ETH",
+      "isNative": true,
+      "l1TokenAddress": "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6"
+    },
+    {
+      "fromChain": 5,
+      "toChain": 80001,
+      "fromTokenAddress": "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
+      "fromSpokeAddress": "0xEc88d3C08E2939562Ff8188B4e30A52236C3FF09",
+      "fromTokenSymbol": "WETH",
+      "isNative": false,
+      "l1TokenAddress": "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6"
     }
   ]
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -13,3 +13,4 @@ export * from "./useScrollPosition";
 export * from "./useNotify";
 export * from "./useCenteredInViewport";
 export * from "./useConnection";
+export * from "./useIsWrongNetwork";

--- a/src/hooks/useIsWrongNetwork.ts
+++ b/src/hooks/useIsWrongNetwork.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+import { useConnection } from "hooks";
+import { hubPoolChainId, switchChain } from "utils";
+
+export function useIsWrongNetwork() {
+  const { provider, chainId } = useConnection();
+
+  const [isWrongNetwork, setIsWrongNetwork] = useState(false);
+
+  useEffect(() => {
+    setIsWrongNetwork(String(chainId) !== String(hubPoolChainId));
+  }, [chainId]);
+
+  const isWrongNetworkHandler = () =>
+    provider && switchChain(provider, hubPoolChainId);
+
+  return {
+    isWrongNetwork,
+    isWrongNetworkHandler,
+  };
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -252,7 +252,7 @@ export class ConfigClient {
     return sortBy(reachableTokens, (token) => this.tokenOrder[token.symbol]);
   }
   getPoolSymbols(): string[] {
-    const tokenList = this.getTokenList(this.getHubPoolChainId());
+    const tokenList = this.getTokenList(constants.hubPoolChainId);
     const poolSymbols = tokenList.map((token) => token.symbol.toLowerCase());
     return poolSymbols;
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -252,7 +252,7 @@ export class ConfigClient {
     return sortBy(reachableTokens, (token) => this.tokenOrder[token.symbol]);
   }
   getPoolSymbols(): string[] {
-    const tokenList = this.getTokenList(1);
+    const tokenList = this.getTokenList(this.getHubPoolChainId());
     const poolSymbols = tokenList.map((token) => token.symbol.toLowerCase());
     return poolSymbols;
   }

--- a/src/views/Staking/Staking.tsx
+++ b/src/views/Staking/Staking.tsx
@@ -4,10 +4,6 @@ import { useStakingView } from "./hooks/useStakingView";
 import Footer from "components/Footer";
 import { repeatableTernaryBuilder } from "utils/ternary";
 import { BigNumber, BigNumberish } from "ethers";
-import {
-  StakingActionFunctionType,
-  stakingActionNOOPFn,
-} from "./hooks/useStakingActionsResolver";
 import { SuperHeader } from "components";
 import { getChainInfo, hubPoolChainId } from "utils";
 
@@ -17,28 +13,24 @@ const Staking = () => {
     poolLogoURI,
     isConnected,
     connectWalletHandler,
-    stakingData,
-    isStakingDataLoading,
+    stakingPoolQuery,
+    stakeActionMutation,
+    unstakeActionMutation,
     isWrongNetwork,
     isWrongNetworkHandler,
   } = useStakingView();
 
   const numericTernary = repeatableTernaryBuilder<BigNumberish>(
-    !isStakingDataLoading,
+    !stakingPoolQuery.isLoading,
     "0"
   );
   const numberTernary = repeatableTernaryBuilder<number>(
-    !isStakingDataLoading,
+    !stakingPoolQuery.isLoading,
     0
   );
   const stringTernary = repeatableTernaryBuilder<string>(
-    !isStakingDataLoading,
+    !stakingPoolQuery.isLoading,
     ""
-  );
-
-  const stakingFnTernary = repeatableTernaryBuilder<StakingActionFunctionType>(
-    !isStakingDataLoading,
-    stakingActionNOOPFn
   );
 
   return (
@@ -56,43 +48,52 @@ const Staking = () => {
       <Wrapper>
         <StakingExitAction poolName={poolName} poolLogoURI={poolLogoURI} />
         <StakingForm
-          isDataLoading={isStakingDataLoading}
+          isDataLoading={stakingPoolQuery.isLoading}
+          isMutating={
+            stakeActionMutation.isLoading || unstakeActionMutation.isLoading
+          }
           isWrongNetwork={isWrongNetwork}
           isConnected={isConnected}
           walletConnectionHandler={connectWalletHandler}
-          lpTokenFormatter={stakingData?.lpTokenFormatter ?? (() => "0")}
-          lpTokenParser={
-            stakingData?.lpTokenParser ?? (() => BigNumber.from("0"))
+          lpTokenFormatter={
+            stakingPoolQuery.data?.lpTokenFormatter ?? (() => "0")
           }
-          estimatedPoolApy={numericTernary(stakingData?.estimatedApy)}
-          lpTokenName={stringTernary(stakingData?.lpTokenSymbolName)}
-          stakeActionFn={stakingFnTernary(stakingData?.stakeActionFn)}
-          unstakeActionFn={stakingFnTernary(stakingData?.unstakeActionFn)}
-          usersTotalLPTokens={numericTernary(stakingData?.usersTotalLPTokens)}
+          lpTokenParser={
+            stakingPoolQuery.data?.lpTokenParser ?? (() => BigNumber.from("0"))
+          }
+          estimatedPoolApy={numericTernary(stakingPoolQuery.data?.estimatedApy)}
+          lpTokenName={stringTernary(stakingPoolQuery.data?.lpTokenSymbolName)}
+          stakeActionFn={stakeActionMutation.mutateAsync}
+          unstakeActionFn={unstakeActionMutation.mutateAsync}
+          usersTotalLPTokens={numericTernary(
+            stakingPoolQuery.data?.usersTotalLPTokens
+          )}
           userCumulativeStake={numericTernary(
-            stakingData?.userAmountOfLPStaked
+            stakingPoolQuery.data?.userAmountOfLPStaked
           )}
           currentMultiplier={numericTernary(
-            stakingData?.currentUserRewardMultiplier
+            stakingPoolQuery.data?.currentUserRewardMultiplier
           )}
           usersMultiplierPercentage={numberTernary(
-            stakingData?.usersMultiplierPercentage
+            stakingPoolQuery.data?.usersMultiplierPercentage
           )}
           globalCumulativeStake={numericTernary(
-            stakingData?.globalAmountOfLPStaked
+            stakingPoolQuery.data?.globalAmountOfLPStaked
           )}
-          ageOfCapital={numberTernary(stakingData?.elapsedTimeSinceAvgDeposit)}
+          ageOfCapital={numberTernary(
+            stakingPoolQuery.data?.elapsedTimeSinceAvgDeposit
+          )}
           availableLPTokenBalance={numericTernary(
-            stakingData?.availableLPTokenBalance
+            stakingPoolQuery.data?.availableLPTokenBalance
           )}
-          shareOfPool={numericTernary(stakingData?.shareOfPool)}
+          shareOfPool={numericTernary(stakingPoolQuery.data?.shareOfPool)}
         />
         <StakingReward
           maximumClaimableAmount={numericTernary(
-            stakingData?.outstandingRewards
+            stakingPoolQuery.data?.outstandingRewards
           )}
           usersMultiplierPercentage={numberTernary(
-            stakingData?.usersMultiplierPercentage
+            stakingPoolQuery.data?.usersMultiplierPercentage
           )}
           isConnected={isConnected}
           walletConnectionHandler={connectWalletHandler}

--- a/src/views/Staking/components/StakingForm/StakingForm.tsx
+++ b/src/views/Staking/components/StakingForm/StakingForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Card,
   Tabs,

--- a/src/views/Staking/components/StakingForm/StakingForm.tsx
+++ b/src/views/Staking/components/StakingForm/StakingForm.tsx
@@ -53,22 +53,19 @@ export const StakingForm = ({
   isWrongNetwork,
   estimatedPoolApy,
   isDataLoading,
+  isMutating,
 }: StakingFormPropType) => {
   const [activeTab, setActiveTab] = useState<StakeTab>("stake");
   const [isPoolInfoVisible, setIsPoolInfoVisible] = useState(false);
   const [stakeAmount, setStakeAmount] = useState("");
-  const [isTransitioning, setTransitioning] = useState(false);
-  const isRendered = useRef(false);
 
   const buttonHandler = isWrongNetwork
     ? () => {}
     : isConnected
     ? () => {
-        (activeTab === "stake" ? stakeActionFn : unstakeActionFn)(
-          parseLPToken(stakeAmount),
-          setTransitioning,
-          isRendered
-        );
+        (activeTab === "stake" ? stakeActionFn : unstakeActionFn)({
+          amount: parseLPToken(stakeAmount),
+        });
       }
     : walletConnectionHandler;
 
@@ -88,21 +85,14 @@ export const StakingForm = ({
   );
 
   useEffect(() => {
-    if (!isTransitioning) {
+    if (!isMutating) {
       setStakeAmount("");
     }
-  }, [activeTab, isTransitioning]);
+  }, [activeTab, isMutating]);
 
   useEffect(() => {
     setIsPoolInfoVisible(false);
   }, [isConnected]);
-
-  useEffect(() => {
-    isRendered.current = true;
-    return () => {
-      isRendered.current = false;
-    };
-  }, []);
 
   return (
     <SectionTitleWrapperV2 title="Staking">
@@ -131,7 +121,7 @@ export const StakingForm = ({
             maxValue={buttonMaxValueText}
             omitInput={!isConnected}
             onClickHandler={buttonHandler}
-            displayLoader={isTransitioning}
+            displayLoader={isMutating}
           />
         </InputBlockWrapper>
         <Divider />

--- a/src/views/Staking/hooks/useStakingAction.ts
+++ b/src/views/Staking/hooks/useStakingAction.ts
@@ -1,0 +1,118 @@
+import { useMutation } from "react-query";
+import { BigNumber, Signer } from "ethers";
+import { ERC20__factory } from "@across-protocol/contracts-v2";
+import { API } from "bnc-notify";
+
+import { useConnection } from "hooks";
+import { getConfig, MAX_APPROVAL_AMOUNT, notificationEmitter } from "utils";
+
+import { useStakingPool } from "./useStakingPool";
+
+export type StakingActionFunctionArgs = { amount: BigNumber };
+export type StakingActionFunctionType = (
+  args: StakingActionFunctionArgs
+) => Promise<void>;
+
+export function useStakeAction(tokenAddress?: string) {
+  const { signer, notify } = useConnection();
+  const stakingPoolQuery = useStakingPool(tokenAddress);
+
+  const stakeActionFn: StakingActionFunctionType = async (
+    args: StakingActionFunctionArgs
+  ) => {
+    if (stakingPoolQuery.data && signer && tokenAddress) {
+      const { lpTokenAddress, requiresApproval } = stakingPoolQuery.data;
+      performStakingActionBuilderFn(
+        lpTokenAddress,
+        signer,
+        "stake",
+        requiresApproval,
+        notify
+      )(args.amount);
+    }
+  };
+  return useMutation(stakeActionFn, {
+    onSuccess: () => stakingPoolQuery.refetch(),
+  });
+}
+
+export function useUnstakeAction(tokenAddress?: string) {
+  const { signer, notify } = useConnection();
+  const stakingPoolQuery = useStakingPool(tokenAddress);
+
+  const unstakeActionFn: StakingActionFunctionType = async (
+    args: StakingActionFunctionArgs
+  ) => {
+    if (stakingPoolQuery.data && signer && tokenAddress) {
+      const { lpTokenAddress, requiresApproval } = stakingPoolQuery.data;
+      performStakingActionBuilderFn(
+        lpTokenAddress,
+        signer,
+        "unstake",
+        requiresApproval,
+        notify
+      )(args.amount);
+    }
+  };
+  return useMutation(unstakeActionFn, {
+    onSuccess: () => stakingPoolQuery.refetch(),
+  });
+}
+
+/**
+ * A function builder which returns a closure of a function that can be used to stake/unstake with the AcceleratingDistributor contract
+ * @param lpTokenAddress The ERC20 address of the LP Token
+ * @param signer A valid ethers signer
+ * @param action The action that will build this function. Either 'stake' or 'unstake'
+ * @param requiresApproval Whether or not this function will first attempt have the user set an allowance with the AcceleratingDistributor contract
+ * @param notify A BNC notification API that will be used to visually notify the user of a successful/rejected transaction
+ * @returns A closure function that is designed to stake or unstake a given LP token with the AcceleratingDistributor contract
+ */
+const performStakingActionBuilderFn = (
+  lpTokenAddress: string,
+  signer: Signer,
+  action: "stake" | "unstake",
+  requiresApproval: boolean,
+  notify: API
+) => {
+  // The purpose of this variable is to keep track of whether or not
+  // the closure needs to request approval from the ERC20 token to be
+  // used within the AcceleratingDistributor contract. This allows us
+  // to stake/unstake multiple times without needing to directly refresh
+  // to determine if approval is required anymore
+  let innerApprovalRequired = requiresApproval;
+
+  /**
+   * Enables the user to stake/unstake with the AcceleratingDistributor contract
+   * @param amount The amount of LP tokens to either stake or unstake
+   */
+  const closure = async (amount: BigNumber): Promise<void> => {
+    // Resolve the AcceleratingDistributor and connect it with
+    // the signer to execute transactions on behalf of the wallet
+    // holder
+    const acceleratingDistributor = getConfig()
+      .getAcceleratingDistributor()
+      .connect(signer);
+    // Check if this wallet has permissions to interract with the
+    // AcceleratingDistibutor function regarding staking/unstaking
+    // with the provided LP Token
+    if (innerApprovalRequired) {
+      const lpER20 = ERC20__factory.connect(lpTokenAddress, signer);
+      const approvalResult = await lpER20.approve(
+        acceleratingDistributor.address,
+        MAX_APPROVAL_AMOUNT
+      );
+      // Wait for the transaction to return successful
+      await notificationEmitter(approvalResult.hash, notify);
+      innerApprovalRequired = false;
+    }
+    const callingFn = acceleratingDistributor[action];
+    const amountAsBigNumber = BigNumber.from(amount);
+
+    // Call the generate the transaction to stake/unstake and
+    // wait until the tx has been resolved
+    const result = await callingFn(lpTokenAddress, amountAsBigNumber);
+    await notificationEmitter(result.hash, notify);
+  };
+  return closure;
+};

--- a/src/views/Staking/hooks/useStakingPool.ts
+++ b/src/views/Staking/hooks/useStakingPool.ts
@@ -1,0 +1,221 @@
+import { useQuery, useQueries, QueryFunctionContext } from "react-query";
+import { useConnection } from "hooks";
+import {
+  fixedPointAdjustment,
+  formattedBigNumberToNumber,
+  formatUnitsFnBuilder,
+  getConfig,
+  hubPoolChainId,
+  parseEtherLike,
+  safeDivide,
+  toWeiSafe,
+} from "utils";
+import { BigNumber, BigNumberish, providers } from "ethers";
+import { ERC20__factory } from "@across-protocol/contracts-v2";
+import axios from "axios";
+
+const config = getConfig();
+
+export type FormatterFnType = (wei: BigNumberish) => string;
+export type ParserFnType = (wei: string) => BigNumber;
+
+type ResolvedDataType =
+  | {
+      lpTokenAddress: string;
+      lpTokenSymbolName: string;
+      acrossTokenAddress: string;
+      poolEnabled: boolean;
+      globalAmountOfLPStaked: BigNumberish;
+      userAmountOfLPStaked: BigNumberish;
+      maxMultiplier: BigNumberish;
+      outstandingRewards: BigNumberish;
+      currentUserRewardMultiplier: BigNumberish;
+      availableLPTokenBalance: BigNumberish;
+      elapsedTimeSinceAvgDeposit: number;
+      usersMultiplierPercentage: number;
+      usersTotalLPTokens: BigNumberish;
+      shareOfPool: BigNumberish;
+      estimatedApy: BigNumberish;
+      requiresApproval: boolean;
+      lpTokenFormatter: FormatterFnType;
+      lpTokenParser: ParserFnType;
+    }
+  | undefined;
+
+export function useStakingPool(tokenAddress?: string) {
+  const { account, provider } = useConnection();
+
+  return useQuery(
+    getStakingPoolQueryKey(tokenAddress, account),
+    () => fetchStakingPool(tokenAddress, provider, account),
+    {
+      enabled: Boolean(provider && tokenAddress),
+    }
+  );
+}
+
+export function useAllStakingPools() {
+  const { account, provider } = useConnection();
+
+  const tokenList = config.getTokenList(hubPoolChainId);
+
+  return useQueries(
+    tokenList.map((token) => ({
+      queryKey: getStakingPoolQueryKey(
+        token.isNative ? config.getWethAddress() : token.address,
+        account
+      ),
+      queryFn: ({
+        queryKey,
+      }: QueryFunctionContext<[string, string?, string?]>) =>
+        fetchStakingPool(queryKey[1], provider, queryKey[2]),
+      enabled: Boolean(provider),
+    }))
+  );
+}
+
+function getStakingPoolQueryKey(
+  tokenAddress?: string,
+  account?: string
+): [string, string?, string?] {
+  return ["staking-pool", tokenAddress, account];
+}
+
+/**
+ * Calls on-chain data & the ACX API to resolve information about the AcceleratingDistributor Contract
+ * @param tokenAddress The address of the ERC-20 token on the current chain
+ * @param account A user address to query against the on-chain data
+ */
+const fetchStakingPool = async (
+  tokenAddress?: string,
+  provider?: providers.Provider | null,
+  account?: string
+): Promise<ResolvedDataType> => {
+  if (!tokenAddress || !provider) {
+    return;
+  }
+
+  const hubPool = config.getHubPool();
+  const acceleratingDistributor = config.getAcceleratingDistributor();
+  const acceleratingDistributorAddress = acceleratingDistributor.address;
+
+  // Get the corresponding LP token from the hub pool directly
+  // Resolve the ACX reward token address from the AcceleratingDistributor
+  const [{ lpToken: lpTokenAddress }, acrossTokenAddress] = await Promise.all([
+    hubPool.pooledTokens(tokenAddress),
+    acceleratingDistributor.rewardToken(),
+  ]);
+
+  const lpTokenERC20 = ERC20__factory.connect(lpTokenAddress, provider);
+
+  // Check information about this LP token on the AcceleratingDistributor contract
+  // Resolve the provided account's outstanding rewards (if an account is connected) as well
+  // as the global pool information
+  const [
+    { enabled: poolEnabled, maxMultiplier },
+    currentUserRewardMultiplier,
+    {
+      rewardsOutstanding: outstandingRewards,
+      cumulativeBalance: userAmountOfLPStaked,
+      averageDepositTime,
+    },
+    availableLPTokenBalance,
+    lpTokenDecimalCount,
+    lpTokenAllowance,
+    lpTokenSymbolName,
+    poolQuery,
+  ] = await Promise.all([
+    acceleratingDistributor.stakingTokens(lpTokenAddress) as Promise<{
+      enabled: boolean;
+      baseEmissionRate: BigNumber;
+      maxMultiplier: BigNumber;
+      cumulativeStaked: BigNumber;
+    }>,
+    account
+      ? acceleratingDistributor.getUserRewardMultiplier(lpTokenAddress, account)
+      : Promise.resolve(BigNumber.from(0)),
+    account
+      ? acceleratingDistributor.getUserStake(lpTokenAddress, account)
+      : Promise.resolve({
+          rewardsOutstanding: BigNumber.from(0),
+          cumulativeBalance: BigNumber.from(0),
+          averageDepositTime: BigNumber.from(0),
+        }),
+    account ? lpTokenERC20.balanceOf(account) : BigNumber.from(0),
+    lpTokenERC20.decimals(),
+    account
+      ? lpTokenERC20.allowance(account, acceleratingDistributorAddress)
+      : BigNumber.from(0),
+    Promise.resolve((await lpTokenERC20.symbol()).slice(4)),
+    axios.get(`/api/pools`, {
+      params: { token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
+    }),
+  ]);
+
+  // Resolve the data retrieved from the serverless /pools API call
+  const { estimatedApy: estimatedApyFromQuery, totalPoolSize } =
+    poolQuery.data as {
+      estimatedApy: string;
+      totalPoolSize: BigNumberish;
+    };
+
+  // The Average Deposit Time retrieves the # seconds since the last
+  // deposit, weighted by all the deposits in a user's account. To calculate the
+  // days elapsed, we can divide by 1 day in seconds (86,400 seconds)
+  const daysElapsed = formattedBigNumberToNumber(
+    averageDepositTime.mul(fixedPointAdjustment).div(86400)
+  );
+
+  // Resolve the users reward multiplier as a percentage.
+  const usersMultiplierPercentage = formattedBigNumberToNumber(
+    currentUserRewardMultiplier
+      .mul(fixedPointAdjustment)
+      .div(maxMultiplier)
+      .mul(100)
+  );
+
+  // We need the amount of tokens that the user has in both their balance
+  // and in the staked contract. We can add the staked + balance to get this
+  // figure.
+  const usersTotalLPTokens = availableLPTokenBalance.add(userAmountOfLPStaked);
+
+  // We can divide the amount of LP staked in the contract with the total pool
+  // size.
+  const shareOfPool = safeDivide(
+    userAmountOfLPStaked.mul(fixedPointAdjustment),
+    BigNumber.from(totalPoolSize)
+  ).mul(100);
+
+  const estimatedApy = parseEtherLike(estimatedApyFromQuery).mul(100);
+
+  // We can resolve custom formatter & parsers for the current LP
+  // token that we are working with.
+  const lpTokenFormatter = formatUnitsFnBuilder(lpTokenDecimalCount);
+  const lpTokenParser = (wei: BigNumberish) =>
+    toWeiSafe(wei.toString(), lpTokenDecimalCount);
+
+  // Determine if the contract has an allowance of at least the current
+  // user's entire balance.
+  const requiresApproval = lpTokenAllowance.lte(availableLPTokenBalance);
+
+  return {
+    lpTokenAddress,
+    acrossTokenAddress,
+    poolEnabled,
+    globalAmountOfLPStaked: totalPoolSize,
+    userAmountOfLPStaked,
+    maxMultiplier,
+    outstandingRewards,
+    currentUserRewardMultiplier,
+    availableLPTokenBalance,
+    elapsedTimeSinceAvgDeposit: daysElapsed,
+    lpTokenSymbolName,
+    usersMultiplierPercentage,
+    usersTotalLPTokens,
+    shareOfPool,
+    estimatedApy,
+    requiresApproval,
+    lpTokenFormatter,
+    lpTokenParser,
+  };
+};

--- a/src/views/Staking/hooks/useStakingView.ts
+++ b/src/views/Staking/hooks/useStakingView.ts
@@ -1,29 +1,30 @@
-import { useConnection } from "hooks";
-import { useStakingActionsResolver } from "./useStakingActionsResolver";
+import { useConnection, useIsWrongNetwork } from "hooks";
+
 import { useStakingPoolResolver } from "./useStakingPoolResolver";
+import { useStakingPool } from "./useStakingPool";
+import { useStakeAction, useUnstakeAction } from "./useStakingAction";
 
 export const useStakingView = () => {
   const { isConnected, provider, connect } = useConnection();
+  const { isWrongNetwork, isWrongNetworkHandler } = useIsWrongNetwork();
+
   const { poolId, exitLinkURI, poolLogoURI, poolName, mainnetAddress } =
     useStakingPoolResolver();
-
-  const {
-    isStakingDataLoading,
-    stakingData,
-    isWrongNetwork,
-    isWrongNetworkHandler,
-  } = useStakingActionsResolver();
+  const stakingPoolQuery = useStakingPool(mainnetAddress);
+  const stakeActionMutation = useStakeAction(mainnetAddress);
+  const unstakeActionMutation = useUnstakeAction(mainnetAddress);
 
   return {
+    stakingPoolQuery,
+    stakeActionMutation,
+    unstakeActionMutation,
     poolId,
     exitLinkURI,
     poolLogoURI,
     poolName,
     mainnetAddress,
-    isStakingDataLoading: isStakingDataLoading,
     isWrongNetwork,
     isWrongNetworkHandler,
-    stakingData,
     isConnected,
     provider,
     connectWalletHandler: () => connect(),

--- a/src/views/Staking/types.ts
+++ b/src/views/Staking/types.ts
@@ -1,9 +1,6 @@
 import { BigNumberish } from "ethers";
-import {
-  FormatterFnType,
-  ParserFnType,
-  StakingActionFunctionType,
-} from "./hooks/useStakingActionsResolver";
+import { FormatterFnType, ParserFnType } from "./hooks/useStakingPool";
+import { StakingActionFunctionType } from "./hooks/useStakingAction";
 
 type GenericStakingComponentProps = {
   isConnected: boolean;
@@ -32,4 +29,5 @@ export type StakingFormPropType = GenericStakingComponentProps & {
   stakeActionFn: StakingActionFunctionType;
   unstakeActionFn: StakingActionFunctionType;
   isDataLoading: boolean;
+  isMutating: boolean;
 };


### PR DESCRIPTION
This PR splits the existing `src/views/Staking/hooks/useStakingActionsResolver.ts` hook into composable hooks and allows the reusage of them on `/rewards/staking/{pool}` page, as well as on `/rewards` page.

I also refactored them to be based on `react-query`, so loading/fetching states are handled automatically. 

~I left this as a draft until @james-a-morris gave me some guidance on how to test this properly. Afterward, I will also remove the refactored monolithic `useStakingActionsResolver` hook.~ Tested locally.