### PR TITLE
feat: integrate staking pool tables with hooks

### DIFF
--- a/src/components/RewardTable/RewardTable.tsx
+++ b/src/components/RewardTable/RewardTable.tsx
@@ -19,6 +19,7 @@ interface Props {
   title?: string;
   scrollable: boolean;
   emptyMessage: string;
+  isLoading?: boolean;
 }
 
 const RewardMyPoolsTable: FC<Props> = ({
@@ -26,6 +27,7 @@ const RewardMyPoolsTable: FC<Props> = ({
   headers,
   title,
   scrollable = true,
+  isLoading,
   emptyMessage,
 }) => {
   return (
@@ -54,7 +56,7 @@ const RewardMyPoolsTable: FC<Props> = ({
               );
             })
           ) : (
-            <EmptyRow>{emptyMessage}</EmptyRow>
+            <EmptyRow>{isLoading ? "Loading..." : emptyMessage}</EmptyRow>
           )}
         </TableBody>
       </TableWrapper>

--- a/src/components/RewardTable/RewardTables.styles.tsx
+++ b/src/components/RewardTable/RewardTables.styles.tsx
@@ -278,6 +278,10 @@ export const ReferralIconContainer = styled.div`
 `;
 
 export const StyledETHIcon = styled(ETHLogo)``;
+export const StyledPoolIcon = styled.img`
+  width: 32px;
+  height: 32px;
+`;
 
 export const StyledUNILogo = styled(UNILogo)``;
 export const StyledUSDCLogo = styled(USDCLogo)``;

--- a/src/views/Rewards/Rewards.tsx
+++ b/src/views/Rewards/Rewards.tsx
@@ -22,7 +22,9 @@ const Rewards = () => {
     referralVolume,
     referralWallets,
 
-    poolData,
+    areStakingPoolsLoading,
+    myPoolData,
+    allPoolData,
 
     formatterFn,
   } = useRewards();
@@ -54,11 +56,18 @@ const Rewards = () => {
             <DisconnectedReferralBox connectHandler={connectHandler} />
           )}
         </SectionWrapper>
+
         <SectionWrapper title="My pools">
-          <GenericStakingPoolTable poolData={poolData} />
+          <GenericStakingPoolTable
+            poolData={myPoolData}
+            isLoading={areStakingPoolsLoading}
+          />
         </SectionWrapper>
         <SectionWrapper title="All pools">
-          <GenericStakingPoolTable poolData={poolData} />
+          <GenericStakingPoolTable
+            poolData={allPoolData}
+            isLoading={areStakingPoolsLoading}
+          />
         </SectionWrapper>
       </InnerSectionWrapper>
     </Wrapper>

--- a/src/views/Rewards/components/GenericStakingPoolTable/GenericStakingPoolFormatter.tsx
+++ b/src/views/Rewards/components/GenericStakingPoolTable/GenericStakingPoolFormatter.tsx
@@ -19,6 +19,7 @@ import {
   StakedTokenCellInner,
   StyledProgressBar,
 } from "./GenericStakingPoolTable.styles";
+import { StyledPoolIcon } from "components/RewardTable/RewardTables.styles";
 
 type RowData = GenericStakingPoolRowData;
 type MetaData = {
@@ -98,7 +99,7 @@ function RowPoolCell({ data }: PoolRowCellType) {
   return (
     <PoolCell>
       <LogoWrapper>
-        <data.logo />
+        <StyledPoolIcon src={data.tokenLogoURI} />
       </LogoWrapper>
       <Text size="md" color="white-100">
         {data.poolName.toUpperCase()}
@@ -113,10 +114,10 @@ function RowMultiplierCell({ data, meta }: PoolRowCellType) {
       <StyledProgressBar
         className="pool-progress-bar"
         active={meta.hasLPStake}
-        percent={(data.multiplier / 3) * 100}
+        percent={data.usersMultiplierPercentage}
       />
       <Text size="md" color={`white-${meta.hasLPStake ? "100" : "70"}`}>
-        {data.multiplier.toFixed(2)}x
+        {Number(formatEther(data.multiplier)).toFixed(2)}x
       </Text>
     </MultiplierCell>
   );
@@ -135,7 +136,7 @@ function RowStakedLPCell({ data, meta }: PoolRowCellType) {
         </Text>
       </StakedTokenCellInner>
       <Text size="sm" color="white-70">
-        {data.poolName.toUpperCase()}-LP
+        {data.poolName.toUpperCase()}
       </Text>
     </StackedCell>
   );
@@ -172,7 +173,7 @@ function RowRewardCell({ data, meta }: PoolRowCellType) {
 
 function RowButtonCell({ data, meta }: PoolRowCellType) {
   let button: JSX.Element | undefined = undefined;
-  const specificPoolLink = `/rewards/staking/${data.poolName}`;
+  const specificPoolLink = `/rewards/staking/${data.tokenSymbol}`;
   if (meta.hasLPStake) {
     button = (
       <ExternalLinkButton to={specificPoolLink}>

--- a/src/views/Rewards/components/GenericStakingPoolTable/GenericStakingPoolTable.tsx
+++ b/src/views/Rewards/components/GenericStakingPoolTable/GenericStakingPoolTable.tsx
@@ -1,19 +1,21 @@
-import styled, { StyledComponent } from "@emotion/styled";
+import styled from "@emotion/styled";
 import RewardTable from "components/RewardTable";
-import { BigNumberish } from "ethers";
+import { BigNumberish, BigNumber } from "ethers";
 import { formatRow, headers } from "./GenericStakingPoolFormatter";
 
 export type GenericStakingPoolRowData = {
-  logo: StyledComponent<any>;
+  tokenSymbol: string;
+  tokenLogoURI: string;
   poolName: string;
-  multiplier: number;
+  multiplier: BigNumber;
+  usersMultiplierPercentage: number;
 
-  rewardAPY: BigNumberish;
-  baseAPY: BigNumberish;
-  rewards: BigNumberish;
+  rewardAPY: BigNumber;
+  baseAPY: BigNumber;
+  rewards: BigNumber;
 
-  usersStakedLP: BigNumberish;
-  usersTotalLP: BigNumberish;
+  usersStakedLP: BigNumber;
+  usersTotalLP: BigNumber;
 
   ageOfCapital: number;
 
@@ -23,16 +25,19 @@ export type GenericStakingPoolRowData = {
 
 type GenericStakingPoolTableType = {
   poolData?: GenericStakingPoolRowData[];
+  isLoading?: boolean;
 };
 
 const GenericStakingPoolTable = ({
   poolData = [],
+  isLoading,
 }: GenericStakingPoolTableType) => {
   const rows = poolData.map((datum) => formatRow(datum));
   return (
     <Wrapper>
       <RewardTable
-        emptyMessage="Loading..."
+        emptyMessage="No pools"
+        isLoading={isLoading}
         scrollable={true}
         rows={rows}
         headers={headers}

--- a/src/views/Rewards/hooks/useRewards.ts
+++ b/src/views/Rewards/hooks/useRewards.ts
@@ -1,13 +1,19 @@
-import { StyledETHIcon } from "components/RewardTable/RewardTables.styles";
-import { useConnection } from "hooks";
+import { StakingPool, useConnection } from "hooks";
 import { ReferralsSummary, useReferralSummary } from "hooks/useReferralSummary";
-import { formatUnitsFnBuilder, parseUnits } from "utils";
+import { formatUnitsFnBuilder } from "utils";
 import { repeatableTernaryBuilder } from "utils/ternary";
 import { GenericStakingPoolRowData } from "../components/GenericStakingPoolTable/GenericStakingPoolTable";
+import { useStakingPools } from "./useStakingPools";
 
 export function useRewards() {
   const { isConnected, connect, account } = useConnection();
   const { summary, isLoading } = useReferralSummary(account);
+
+  const {
+    myPools,
+    allPools,
+    isLoading: areStakingPoolsLoading,
+  } = useStakingPools();
 
   return {
     isConnected,
@@ -16,7 +22,9 @@ export function useRewards() {
     totalRewards: "726.45 ACX",
     stakedTokens: "$942,021.23",
     ...formatReferralSummary(summary, !isLoading && isConnected),
-    poolData: formatPoolData(),
+    areStakingPoolsLoading,
+    myPoolData: formatPoolData(myPools),
+    allPoolData: formatPoolData(allPools),
   };
 }
 
@@ -41,33 +49,24 @@ function formatReferralSummary(summary: ReferralsSummary, isValid: boolean) {
   };
 }
 
-function formatPoolData(): GenericStakingPoolRowData[] {
-  return [
-    {
-      poolName: "ETH",
-      logo: StyledETHIcon,
-      multiplier: 2,
-      rewardAPY: parseUnits(".0278", 18),
-      baseAPY: parseUnits(".0139", 18),
-      rewardFormatter: formatUnitsFnBuilder(18),
-      lpTokenFormatter: formatUnitsFnBuilder(6),
-      rewards: parseUnits("1", 18),
-      ageOfCapital: 3,
-      usersStakedLP: parseUnits("942021.23", 6),
-      usersTotalLP: parseUnits("1242021.23", 6),
-    },
-    {
-      poolName: "ETH",
-      logo: StyledETHIcon,
-      multiplier: 2,
-      rewardAPY: parseUnits(".0278", 18),
-      baseAPY: parseUnits(".0139", 18),
-      rewardFormatter: formatUnitsFnBuilder(18),
-      lpTokenFormatter: formatUnitsFnBuilder(6),
-      rewards: parseUnits("1", 18),
-      ageOfCapital: 3,
-      usersStakedLP: parseUnits("0", 6),
-      usersTotalLP: parseUnits("1242021.23", 6),
-    },
-  ];
+function formatPoolData(pools: StakingPool[]): GenericStakingPoolRowData[] {
+  return pools.map(formatPool);
+}
+
+function formatPool(pool: StakingPool): GenericStakingPoolRowData {
+  return {
+    poolName: pool.lpTokenSymbolName,
+    tokenLogoURI: pool.tokenLogoURI,
+    tokenSymbol: pool.tokenSymbol,
+    multiplier: pool.currentUserRewardMultiplier,
+    usersMultiplierPercentage: pool.usersMultiplierPercentage,
+    rewardAPY: pool.estimatedApy, // TODO: use correct pool value
+    baseAPY: pool.estimatedApy, // TODO: use correct pool value
+    rewardFormatter: formatUnitsFnBuilder(18),
+    lpTokenFormatter: pool.lpTokenFormatter,
+    rewards: pool.outstandingRewards,
+    ageOfCapital: pool.elapsedTimeSinceAvgDeposit,
+    usersStakedLP: pool.userAmountOfLPStaked,
+    usersTotalLP: pool.usersTotalLPTokens,
+  };
 }

--- a/src/views/Rewards/hooks/useStakingPools.tsx
+++ b/src/views/Rewards/hooks/useStakingPools.tsx
@@ -1,0 +1,21 @@
+import { useAllStakingPools } from "hooks";
+
+export const useStakingPools = () => {
+  const allStakingPoolsQueries = useAllStakingPools();
+  const isLoading = allStakingPoolsQueries.some((query) => query.isLoading);
+  const stakingPools = allStakingPoolsQueries.flatMap(
+    (query) => query.data || []
+  );
+  const myPools = stakingPools.filter(
+    (pool) => pool.poolEnabled && pool.isStakingPoolOfUser
+  );
+  const allPools = stakingPools.filter(
+    (pool) => pool.poolEnabled && !pool.isStakingPoolOfUser
+  );
+
+  return {
+    myPools,
+    allPools,
+    isLoading,
+  };
+};


### PR DESCRIPTION
Integrates the staking pool tables with on-chain data / hooks. Leaving as draft until base PR #390 is merged.

I also wasn't sure which exact values to put for `baseAPY` and `rewardAPY` in the table and marked theses values as TODOs.