### PR TITLE
fix(limits): Fix minDeposit derivation on Polygon

### DIFF
--- a/api/limits.ts
+++ b/api/limits.ts
@@ -106,7 +106,9 @@ const handler = async (
       hubPool.interface.encodeFunctionData("pooledTokens", [l1Token]),
     ];
 
-    let tokenPrice = await getCachedTokenPrice(l1Token);
+    // @todo: Generalise the resolution of chainId => gasToken.
+    const baseCurrency = destinationChainId === "137" ? "matic" : "eth";
+    const tokenPrice = await getCachedTokenPrice(l1Token, baseCurrency);
 
     const [
       relayerFeeDetails,


### PR DESCRIPTION
The limits API endpoint assumes that the L1 (bridged) token is priced in the native gas token. getCachedTokenPrice() defaults to returning prices in ETH terms when baseCurrency is not specified.

When pricing the bridged token in ETH terms on Polygon, it incorrectly devalues the bridged token and therefore produces an artificially high minimum deposit amount.

Issue initially reported by the curious minds over at Rango Exchange.
