### PR TITLE
improve(limits): Reduce unnecessary getAddress() calls

### DIFF
--- a/api/limits.ts
+++ b/api/limits.ts
@@ -158,41 +158,47 @@ const handler = async (
       multicallOutput[1]
     );
 
-    if (
-      ethers.utils.getAddress(l1Token) ===
-      ethers.utils.getAddress("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
-    ) {
-      // Add WETH cushion to LP liquidity.
-      liquidReserves = liquidReserves.sub(
-        ethers.utils.parseEther(REACT_APP_WETH_LP_CUSHION || "0")
-      );
-    } else if (
-      ethers.utils.getAddress(l1Token) ===
-      ethers.utils.getAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
-    ) {
-      // Add USDC cushion to LP liquidity.
-      liquidReserves = liquidReserves.sub(
-        ethers.utils.parseUnits(REACT_APP_USDC_LP_CUSHION || "0", 6)
-      );
-    } else if (
-      ethers.utils.getAddress(l1Token) ===
-      ethers.utils.getAddress("0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599")
-    ) {
-      // Add WBTC cushion to LP liquidity.
-      liquidReserves = liquidReserves.sub(
-        ethers.utils.parseUnits(REACT_APP_WBTC_LP_CUSHION || "0", 8)
-      );
-    } else if (
-      ethers.utils.getAddress(l1Token) ===
-      ethers.utils.getAddress("0x6B175474E89094C44Da98b954EedeAC495271d0F")
-    ) {
-      // Add DAI cushion to LP liquidity.
-      liquidReserves = liquidReserves.sub(
-        ethers.utils.parseUnits(REACT_APP_DAI_LP_CUSHION || "0", 18)
-      );
-    }
+    switch (ethers.utils.getAddress(l1Token)) {
+      case ethers.utils.getAddress(
+        "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+      ):
+        // Add WETH cushion to LP liquidity.
+        liquidReserves = liquidReserves.sub(
+          ethers.utils.parseEther(REACT_APP_WETH_LP_CUSHION || "0")
+        );
+        break;
 
-    if (liquidReserves.lt(0)) liquidReserves = ethers.BigNumber.from(0);
+      case ethers.utils.getAddress(
+        "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      ):
+        // Add USDC cushion to LP liquidity.
+        liquidReserves = liquidReserves.sub(
+          ethers.utils.parseUnits(REACT_APP_USDC_LP_CUSHION || "0", 6)
+        );
+        break;
+
+      case ethers.utils.getAddress(
+        "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+      ):
+        // Add WBTC cushion to LP liquidity.
+        liquidReserves = liquidReserves.sub(
+          ethers.utils.parseUnits(REACT_APP_WBTC_LP_CUSHION || "0", 8)
+        );
+        break;
+
+      case ethers.utils.getAddress(
+        "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+      ):
+        // Add DAI cushion to LP liquidity.
+        liquidReserves = liquidReserves.sub(
+          ethers.utils.parseUnits(REACT_APP_DAI_LP_CUSHION || "0", 18)
+        );
+        break;
+
+      default:
+        liquidReserves = ethers.BigNumber.from(0);
+        break;
+    }
 
     const maxGasFee = ethers.utils
       .parseEther(maxRelayFeePct.toString())


### PR DESCRIPTION
Per the existing implementation, for DAI, UMA, BAL (and future ACX) , we've called getAddress()
4 times on the same token address.

The new code unfortunately got a bit squashed by the formatter...it'd be a lot more concise if
the lpCushions object declaration/assignment could be handled on one line per key/value.