### PR TITLE
feat(limits): Support minimum deposit floor

### DIFF
--- a/api/limits.ts
+++ b/api/limits.ts
@@ -209,7 +209,7 @@ const handler = async (
       : ethers.utils
           .parseUnits(
             (minDeposits[destinationChainId] ?? 0).toString(),
-            decimals
+            l1Tokens[symbol].decimals
           )
           .mul(ethers.utils.parseUnits("1"))
           .div(tokenPriceUsd);

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -21,18 +21,19 @@ import {
   handleErrorCondition,
 } from "./_utils";
 
+// Note: Addresses must be checksummed.
 const l1Tokens: { [symbol: string]: { address: string; decimals: number } } = {
   BAL: { address: "0xba100000625a3754423978a60c9317c58a424e3D", decimals: 18 },
   DAI: { address: "0x6B175474E89094C44Da98b954EedeAC495271d0F", decimals: 18 },
   UMA: { address: "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828", decimals: 18 },
   MATIC: {
-    address: "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+    address: "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
     decimals: 18,
   },
   BOBA: { address: "0x42bBFa2e77757C645eeaAd1655E0911a7553Efbc", decimals: 18 },
   USDC: { address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", decimals: 6 },
   WBTC: { address: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", decimals: 8 },
-  WETH: { address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", decimals: 18 },
+  WETH: { address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", decimals: 18 },
 };
 
 const handler = async (

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -47,10 +47,15 @@ const handler = async (
       REACT_APP_PUBLIC_INFURA_ID,
       REACT_APP_FULL_RELAYERS, // These are relayers running a full auto-rebalancing strategy.
       REACT_APP_TRANSFER_RESTRICTED_RELAYERS, // These are relayers whose funds stay put.
+      REACT_APP_MIN_DEPOSIT_USD,
     } = process.env;
     const providerUrl = `https://mainnet.infura.io/v3/${REACT_APP_PUBLIC_INFURA_ID}`;
     const provider = new ethers.providers.StaticJsonRpcProvider(providerUrl);
     logger.debug({ at: "limits", message: `Using provider at ${providerUrl}` });
+
+    const minDeposits = REACT_APP_MIN_DEPOSIT_USD
+      ? JSON.parse(REACT_APP_MIN_DEPOSIT_USD)
+      : {};
 
     const fullRelayers = !REACT_APP_FULL_RELAYERS
       ? []
@@ -125,8 +130,14 @@ const handler = async (
     ];
 
     // @todo: Generalise the resolution of chainId => gasToken.
-    const baseCurrency = destinationChainId === "137" ? "matic" : "eth";
-    const tokenPrice = await getCachedTokenPrice(l1Token, baseCurrency);
+    const [tokenPriceNative, _tokenPriceUsd] = await Promise.all([
+      getCachedTokenPrice(
+        l1Token,
+        destinationChainId === "137" ? "matic" : "eth"
+      ),
+      getCachedTokenPrice(l1Token, "usd"),
+    ]);
+    const tokenPriceUsd = ethers.utils.parseUnits(_tokenPriceUsd.toString());
 
     const [
       relayerFeeDetails,
@@ -139,7 +150,7 @@ const handler = async (
         l1Token,
         ethers.BigNumber.from("10").pow(18),
         Number(destinationChainId),
-        tokenPrice
+        tokenPriceNative
       ),
       hubPool.callStatic.multicall(multicallInput, { blockTag: BLOCK_TAG_LAG }),
       Promise.all(
@@ -187,15 +198,29 @@ const handler = async (
       .parseEther(maxRelayFeePct.toString())
       .sub(relayerFeeDetails.capitalFeePercent);
 
+    // Ensure a maximum ratio of gas fee / deposit amount, then apply a floor afterwards.
+    const minDeposit = ethers.BigNumber.from(relayerFeeDetails.gasFeeTotal)
+      .mul(ethers.utils.parseEther("1"))
+      .div(maxGasFee);
+
+    // Normalise the environment-set USD minimum to units of the token being bridged.
+    const minDepositFloor = tokenPriceUsd.lte(0)
+      ? tokenPriceUsd
+      : ethers.utils
+          .parseUnits(
+            (minDeposits[destinationChainId] ?? 0).toString(),
+            decimals
+          )
+          .mul(ethers.utils.parseUnits("1"))
+          .div(tokenPriceUsd);
+
     const transferBalances = fullRelayerBalances.map((balance, i) =>
       balance.add(fullRelayerMainnetBalances[i])
     );
 
     const responseJson = {
-      minDeposit: ethers.BigNumber.from(relayerFeeDetails.gasFeeTotal)
-        .mul(ethers.utils.parseEther("1"))
-        .div(maxGasFee)
-        .toString(),
+      // Absolute minimum may be overridden by the environment.
+      minDeposit: maxBN(minDeposit, minDepositFloor).toString(),
       maxDeposit: liquidReserves.toString(),
       // Note: max is used here rather than sum because relayers currently do not partial fill.
       maxDepositInstant: minBN(

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -205,7 +205,7 @@ const handler = async (
 
     // Normalise the environment-set USD minimum to units of the token being bridged.
     const minDepositFloor = tokenPriceUsd.lte(0)
-      ? tokenPriceUsd
+      ? ethers.BigNumber.from(0)
       : ethers.utils
           .parseUnits(
             (minDeposits[destinationChainId] ?? 0).toString(),

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -23,6 +23,7 @@ import {
 
 // Note: Addresses must be checksummed.
 const l1Tokens: { [symbol: string]: { address: string; decimals: number } } = {
+  ACX: { address: "0x44108f0223A3C3028F5Fe7AEC7f9bb2E66beF82F", decimals: 18 },
   BAL: { address: "0xba100000625a3754423978a60c9317c58a424e3D", decimals: 18 },
   DAI: { address: "0x6B175474E89094C44Da98b954EedeAC495271d0F", decimals: 18 },
   UMA: { address: "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828", decimals: 18 },


### PR DESCRIPTION
Requested by a partner, this will allow a lower bound for the minimum
deposit to be specified in the environment via the
REACT_APP_MIN_DEPOSIT_USD env var. This env var is specified as a JSON
object, mapping chain ID to the floor amount in USD.
    
An initial proposed REACT_APP_MIN_DEPOSIT_USD config would be:
    
  `'{ "1": 10, "10": 5, "137": 2, "288": 5, "42161": 5 }'`