### PR TITLE
feat: add BAL, UMA, and BOBA cushions

### DIFF
--- a/api/limits.ts
+++ b/api/limits.ts
@@ -35,6 +35,9 @@ const handler = async (
       REACT_APP_WETH_LP_CUSHION,
       REACT_APP_DAI_LP_CUSHION,
       REACT_APP_WBTC_LP_CUSHION,
+      REACT_APP_BAL_LP_CUSHION,
+      REACT_APP_UMA_LP_CUSHION,
+      REACT_APP_BOBA_LP_CUSHION,
     } = process.env;
     const providerUrl = `https://mainnet.infura.io/v3/${REACT_APP_PUBLIC_INFURA_ID}`;
     const provider = new ethers.providers.StaticJsonRpcProvider(providerUrl);
@@ -174,6 +177,18 @@ const handler = async (
       ],
       "0x6B175474E89094C44Da98b954EedeAC495271d0F": [
         REACT_APP_DAI_LP_CUSHION,
+        18,
+      ],
+      "0xba100000625a3754423978a60c9317c58a424e3D": [
+        REACT_APP_BAL_LP_CUSHION,
+        18,
+      ],
+      "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828": [
+        REACT_APP_UMA_LP_CUSHION,
+        18,
+      ],
+      "0x42bBFa2e77757C645eeaAd1655E0911a7553Efbc": [
+        REACT_APP_BOBA_LP_CUSHION,
         18,
       ],
     };

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -25,7 +25,6 @@ import {
   balLpCushion,
   umaLpCushion,
   bobaLpCushion,
-
 } from "./constants";
 import { getProvider } from "./providers";
 import { parseEther, tagAddress } from "./format";

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -22,6 +22,10 @@ import {
   wethLpCushion,
   wbtcLpCushion,
   daiLpCushion,
+  balLpCushion,
+  umaLpCushion,
+  bobaLpCushion,
+
 } from "./constants";
 import { getProvider } from "./providers";
 import { parseEther, tagAddress } from "./format";
@@ -336,6 +340,30 @@ export default class LpFeeCalculator {
       // Add DAI cushion to LP liquidity.
       liquidReserves = pooledTokens.liquidReserves.sub(
         ethers.utils.parseUnits(daiLpCushion || "0", 18)
+      );
+    } else if (
+      ethers.utils.getAddress(tokenAddress) ===
+      ethers.utils.getAddress("0xba100000625a3754423978a60c9317c58a424e3D")
+    ) {
+      // Add BAL cushion to LP liquidity.
+      liquidReserves = pooledTokens.liquidReserves.sub(
+        ethers.utils.parseUnits(balLpCushion || "0", 18)
+      );
+    } else if (
+      ethers.utils.getAddress(tokenAddress) ===
+      ethers.utils.getAddress("0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828")
+    ) {
+      // Add UMA cushion to LP liquidity.
+      liquidReserves = pooledTokens.liquidReserves.sub(
+        ethers.utils.parseUnits(umaLpCushion || "0", 18)
+      );
+    } else if (
+      ethers.utils.getAddress(tokenAddress) ===
+      ethers.utils.getAddress("0x42bBFa2e77757C645eeaAd1655E0911a7553Efbc")
+    ) {
+      // Add BOBA cushion to LP liquidity.
+      liquidReserves = pooledTokens.liquidReserves.sub(
+        ethers.utils.parseUnits(bobaLpCushion || "0", 18)
       );
     }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -631,6 +631,9 @@ export const usdcLpCushion = process.env.REACT_APP_USDC_LP_CUSHION || "0";
 export const wethLpCushion = process.env.REACT_APP_WETH_LP_CUSHION || "0";
 export const wbtcLpCushion = process.env.REACT_APP_WBTC_LP_CUSHION || "0";
 export const daiLpCushion = process.env.REACT_APP_DAI_LP_CUSHION || "0";
+export const balLpCushion = process.env.REACT_APP_BAL_LP_CUSHION || "0";
+export const umaLpCushion = process.env.REACT_APP_UMA_LP_CUSHION || "0";
+export const bobaLpCushion = process.env.REACT_APP_BOBA_LP_CUSHION || "0";
 
 export const maxRelayFee = 0.25; // 25%
 export const minRelayFee = 0.0001; // 0.01%


### PR DESCRIPTION
This adds code to allow LP cushions for BAL, UMA, and BOBA similar to the ones we already have for WETH, DAI, USDC, and WBTC.