### PR TITLE
improve: Upgrade sdk-v2 to 0.1.34

### DIFF
--- a/api/pools.ts
+++ b/api/pools.ts
@@ -24,17 +24,13 @@ const handler = async (
     token = ethers.utils.getAddress(token);
 
     await hubPoolClient.updatePool(token);
-    let poolState = hubPoolClient.getPoolState(token);
-
-    poolState.estimatedApr = Number(poolState.estimatedApr).toFixed(18);
-    poolState.estimatedApy = Number(poolState.estimatedApy).toFixed(18);
 
     // Instruct Vercel to cache limit data for this token for 5 minutes. Caching can be used to limit number of
     // Vercel invocations and run time for this serverless function and trades off potential inaccuracy in times of
     // high volume. "max-age=0" instructs browsers not to cache, while s-maxage instructs Vercel edge caching
     // to cache the responses and invalidate when deployments update.
     response.setHeader("Cache-Control", "s-maxage=300");
-    response.status(200).json(poolState);
+    response.status(200).json(hubPoolClient.getPoolState(token));
   } catch (error: unknown) {
     return handleErrorCondition("pools", response, logger, error);
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@across-protocol/across-token": "^0.0.2",
     "@across-protocol/contracts-v2": "^1.0.7",
-    "@across-protocol/sdk-v2": "0.1.33",
+    "@across-protocol/sdk-v2": "0.1.34",
     "@datapunt/matomo-tracker-js": "^0.5.1",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,10 +50,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.1.33":
-  version "0.1.33"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.1.33.tgz#f4cb44dcd8de3f8a7cef74ade5db188801b0dafe"
-  integrity sha512-XIHJZZkcG4sqUXmfrGqUrZaAy6CLeqMJ4JyuwkjMYxf1L2WxI0fht3qMT3DzzaYntmCAXLpnDm0PSTa5szk2Fg==
+"@across-protocol/sdk-v2@0.1.34":
+  version "0.1.34"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.1.34.tgz#8670069d0bcf21edba6b4a9673a34dcef38eb9fe"
+  integrity sha512-BE18lXYG5eJnfaKaSVICqK1+/4CGdvUH/acdJ+HFAoZCbD+VQ62o+n+/daH1myqAJ9SUrdG5QmhQuOOyrivdrQ==
   dependencies:
     "@across-protocol/contracts-v2" "^1.0.3"
     "@eth-optimism/sdk" "^1.6.0"


### PR DESCRIPTION
No longer need to fix estimatedApr and estimatedApy from /pools route to 18 decimals
