### PR TITLE
fix: gas limit multiplier stake and unstake + env var 

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -436,6 +436,9 @@ assert(
 );
 
 // PROCESS.ENV variables
+export const gasEstimationMultiplier = Number(
+  process.env.REACT_APP_GAS_ESTIMATION_MULTIPLIER || 2
+);
 export const rewardsApiUrl = process.env.REACT_APP_REWARDS_API_URL;
 export const airdropWindowIndex = Number(
   process.env.REACT_APP_AIRDROP_WINDOW_INDEX || 0

--- a/src/views/Airdrop/hooks/useClaimAndStake.tsx
+++ b/src/views/Airdrop/hooks/useClaimAndStake.tsx
@@ -7,7 +7,7 @@ import { useConnection, useIsWrongNetwork } from "hooks";
 import { useAirdropRecipient } from "./useAirdropRecipient";
 import { useIsAirdropClaimed } from "./useIsAirdropClaimed";
 import { parseEther } from "@ethersproject/units";
-import { fixedPointAdjustment } from "utils";
+import { fixedPointAdjustment, gasEstimationMultiplier } from "utils";
 
 const config = getConfig();
 
@@ -46,7 +46,9 @@ export function useClaimAndStake() {
     const claimAndStakeTx = await claimAndStakeContract.claimAndStake(
       parameters,
       {
-        gasLimit: gasEstimate.mul(parseEther("2.0")).div(fixedPointAdjustment),
+        gasLimit: gasEstimate
+          .mul(parseEther(String(gasEstimationMultiplier)))
+          .div(fixedPointAdjustment),
       }
     );
     await notificationEmitter(claimAndStakeTx.hash, notify, 0);


### PR DESCRIPTION
This adds a buffer to the stake and unstake actions. This also adds an env var to control the gas limit multiplier.