### PR TITLE
fix: footer links old layout

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -12,7 +12,7 @@ export const NAV_LINKS = [
   {
     key: "faq",
     name: "FAQ",
-    url: "",
+    url: "https://docs.across.to/additional-info/faq",
     icon: "",
   },
   {

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -23,7 +23,6 @@ const FooterWrapper = styled.div`
 `;
 
 const Wrapper = styled.div`
-  position: relative;
   display: grid;
   padding: 0 10px;
   grid-template-columns: 1fr min(var(--central-content), 100%) 1fr;


### PR DESCRIPTION
Footer links for routes `/pool` and `/bridge` could not be clicked.