### PR TITLE
fix: stake/unstake max button value

### DIFF
--- a/src/views/Staking/components/StakingForm/StakingForm.tsx
+++ b/src/views/Staking/components/StakingForm/StakingForm.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { utils } from "ethers";
 import {
   Card,
   Tabs,
@@ -59,9 +60,10 @@ export const StakingForm = ({
   };
 
   const buttonMaxValue = maximumValue;
-  const buttonMaxValueText = poolData
-    .lpTokenFormatter(buttonMaxValue)
-    .replaceAll(",", "");
+  const buttonMaxValueText = utils.formatUnits(
+    buttonMaxValue,
+    poolData.lpTokenDecimalCount
+  );
 
   const ArrowIcon = isPoolInfoVisible ? ArrowIconUp : ArrowIconDown;
 


### PR DESCRIPTION
Our custom `formatUnits` also shortens and rounds the decimals and therefore loses precision. We fix this by using the `formatUnits` of ethers for setting the max values during staking/unstaking.

In the future, it could make sense to rename our custom formatter to smth like `formatUnitsMaxDecimals` or similar so that it is clear that this utility also rounds decimals.