### PR TITLE
feat(vercel-api): support `timestamp` query param cg price

### DIFF
--- a/api/_types/routes/coingecko-routes.types.ts
+++ b/api/_types/routes/coingecko-routes.types.ts
@@ -3,4 +3,5 @@ import { TypedVercelRequest } from "../generic.types";
 export type CoinGeckoInputRequest = TypedVercelRequest<{
   l1Token: string;
   baseCurrencySymbol: string;
+  timestamp?: string;
 }>;

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -398,12 +398,13 @@ export const getRelayerFeeDetails = (
  */
 export const getCachedTokenPrice = async (
   l1Token: string,
-  baseCurrency: string = "eth"
+  baseCurrency: string = "eth",
+  timestamp?: string
 ): Promise<number> => {
   return Number(
     (
       await axios(`${resolveVercelEndpoint()}/api/coingecko`, {
-        params: { l1Token, baseCurrency },
+        params: { l1Token, baseCurrency, timestamp },
       })
     ).data.price
   );


### PR DESCRIPTION
This allows specifying a `timestamp` query param
in the `GET /api/coingecko` handler to retrieve a historic price using the `getHistoricContractPrices` method of the sdk `CoingeckoClient`.

Note, that this is preliminary work in order to retrieve historic `suggested-fees` for a given timestamp.