### PR TITLE
fix: :ambulance: remove duplicate funds from pool position that are staked

### DIFF
--- a/src/components/PoolForm/PoolForm.tsx
+++ b/src/components/PoolForm/PoolForm.tsx
@@ -68,7 +68,6 @@ const PoolForm: FC<Props> = ({
   decimals,
   totalPoolSize,
   totalPosition,
-  stakedPosition,
   apy,
   position,
   feesEarned,
@@ -86,7 +85,6 @@ const PoolForm: FC<Props> = ({
   projectedApr,
   chainId,
   refetchPool,
-  convertFromLP: inputConvertFromLP,
   convertToLP: inputConvertToLP,
 }) => {
   const poolClient = getPoolClient();
@@ -101,7 +99,6 @@ const PoolForm: FC<Props> = ({
   );
   const { isConnected, signer } = useConnection();
 
-  const convertFromLP = inputConvertFromLP ?? ((v: BigNumber) => v);
   const convertToLP = inputConvertToLP ?? ((v: BigNumber) => v);
 
   // update our add-liquidity to contract call gas usage on an interval for eth only
@@ -171,11 +168,7 @@ const PoolForm: FC<Props> = ({
         <PositionItem>
           <div>Position Size</div>
           <div data-cy="pool-position">
-            {formatUnits(
-              totalPosition.add(convertFromLP(stakedPosition)),
-              decimals
-            ).replace("-", "")}{" "}
-            {symbol}
+            {formatUnits(totalPosition, decimals).replace("-", "")} {symbol}
           </div>
         </PositionItem>
         <PositionItem>


### PR DESCRIPTION
This change aims to resolve the double accounting for staking positions on both the FE & the SDK. 

Initial Bug Report:
![image](https://user-images.githubusercontent.com/96435344/207700582-eab2caee-000f-44b9-9963-e4767bf53b3c.png)
