### PR TITLE
fix: :ambulance: resolve pool UI formatting

### DIFF
--- a/src/components/PoolForm/PoolForm.tsx
+++ b/src/components/PoolForm/PoolForm.tsx
@@ -25,7 +25,6 @@ import {
   formatNumberMaxFracDigits,
   toWeiSafe,
   formatUnits,
-  formatEther,
 } from "utils";
 import { ConverterFnType, useConnection } from "hooks";
 import type { ShowSuccess } from "views/Pool";
@@ -174,7 +173,7 @@ const PoolForm: FC<Props> = ({
         <PositionItem>
           <div>Total fees earned</div>
           <div>
-            {formatEther(convertToLP(feesEarned))} {symbol}
+            {formatUnits(convertToLP(feesEarned), decimals)} {symbol}
           </div>
         </PositionItem>
       </Position>


### PR DESCRIPTION
This change utilizes the specific number of decimals that are available to a LP token position. The previous change used formatEther which defaulted to 18 decimals of precision.
