### PR TITLE
feat: Account for route-specific rate models

### DIFF
--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -112,7 +112,7 @@ const handler = async (
           blockTag,
         },
         computedOriginChainId,
-        destinationChainId
+        Number(destinationChainId)
       ),
       getCachedTokenPrice(l1Token, baseCurrency),
     ]);

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -106,9 +106,14 @@ const handler = async (
       hubPool.callStatic.liquidityUtilizationPostRelay(l1Token, amount, {
         blockTag,
       }),
-      configStoreClient.getRateModel(l1Token, {
-        blockTag,
-      }),
+      configStoreClient.getRateModel(
+        l1Token,
+        {
+          blockTag,
+        },
+        computedOriginChainId,
+        destinationChainId
+      ),
       getCachedTokenPrice(l1Token, baseCurrency),
     ]);
     const realizedLPFeePct = sdk.lpFeeCalculator.calculateRealizedLpFeePct(

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@across-protocol/across-token": "^0.0.2",
     "@across-protocol/contracts-v2": "^1.0.7",
-    "@across-protocol/sdk-v2": "^0.2.2",
+    "@across-protocol/sdk-v2": "^0.3.3",
     "@datapunt/matomo-tracker-js": "^0.5.1",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,10 +58,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.2.2.tgz#fb2192e4fbdd73744d703541de4438618360372c"
-  integrity sha512-JcSQ2cut1pdRnLoAeW+xu887n9rnxLqWrVgL5IVg1YkcH2H75tN9xUpbtsVCLm9n9CiLyQI50bNTw2o+fvyWVA==
+"@across-protocol/sdk-v2@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.3.3.tgz#5644ea9bc7112625ae986c71e31f1bd1167e5972"
+  integrity sha512-G+ZJUbStWH+W3+h7BidXOPvljaZbWa0p8VIccjmEeBVkJhXE1jsQOV4Iv4z76hkKwkHodCC2JsePuH5l/WSuQg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/contracts-v2" "^2.0.1"


### PR DESCRIPTION
LP fees should distinguish rate models for certain deposit paths

Let's not merge this until we add the `routeRateModel` on-chain in the ConfigStore. I'll run some `e2e` tests from the `sdk-v2` to make sure that the FE will be able to read these new rate models