### PR TITLE
fix: bridge limits hook token address

### DIFF
--- a/src/views/Bridge/hooks/useBridge.ts
+++ b/src/views/Bridge/hooks/useBridge.ts
@@ -94,6 +94,10 @@ export function useBridge() {
         (route) => route.fromChain === (hubPoolChainId ?? 1)
       );
 
+      if (availableRoutesThatStartAtCurrentChain.length === 0) {
+        return;
+      }
+
       if (currentToRoute) {
         const toRouteStillAvailable = availableRoutes.some(
           (route) => route.toChain === currentToRoute
@@ -200,7 +204,7 @@ export function useBridge() {
   );
 
   const { limits } = useBridgeLimits(
-    getToken(currentToken).mainnetAddress,
+    currentRoute?.fromTokenAddress,
     currentFromRoute,
     currentToRoute
   );


### PR DESCRIPTION
User couldn't bridge because of wrong token address.