### PR TITLE
fix(ampli): eth polygon from to addresses extraction

### DIFF
--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -222,17 +222,11 @@ export function generateTransferSubmitted(
   referralProgramAddress: string,
   initialQuoteTime: number
 ): TransferSubmittedProperties {
-  // Retrieves the from symbol by address from the config
-  const fromAddress = getConfig().getTokenInfoBySymbol(
+  const { fromAddress, toAddress } = getConfig().getFromToAddressesBySymbol(
+    quote.tokenSymbol,
     Number(quote.fromChainId),
-    quote.tokenSymbol
-  ).address;
-  // Retrieves the to symbol by address from the config
-  const toAddress = getConfig().getTokenInfoBySymbol(
-    Number(quote.toChainId),
-    quote.tokenSymbol
-  ).address;
-
+    Number(quote.toChainId)
+  );
   return {
     ...quote,
     fromTokenAddress: fromAddress,
@@ -252,17 +246,11 @@ export function generateTransferSigned(
   initialSubmissionTime: number,
   txHash: string
 ): TransferSignedProperties {
-  // Retrieves the from symbol by address from the config
-  const fromAddress = getConfig().getTokenInfoBySymbol(
+  const { fromAddress, toAddress } = getConfig().getFromToAddressesBySymbol(
+    quote.tokenSymbol,
     Number(quote.fromChainId),
-    quote.tokenSymbol
-  ).address;
-  // Retrieves the to symbol by address from the config
-  const toAddress = getConfig().getTokenInfoBySymbol(
-    Number(quote.toChainId),
-    quote.tokenSymbol
-  ).address;
-
+    Number(quote.toChainId)
+  );
   return {
     ...quote,
     fromTokenAddress: fromAddress,
@@ -284,17 +272,11 @@ export function generateDepositConfirmed(
   success: boolean,
   txCompletedTimestamp: number
 ): TransferDepositCompletedProperties {
-  // Retrieves the from symbol by address from the config
-  const fromAddress = getConfig().getTokenInfoBySymbol(
+  const { fromAddress, toAddress } = getConfig().getFromToAddressesBySymbol(
+    quote.tokenSymbol,
     Number(quote.fromChainId),
-    quote.tokenSymbol
-  ).address;
-  // Retrieves the to symbol by address from the config
-  const toAddress = getConfig().getTokenInfoBySymbol(
-    Number(quote.toChainId),
-    quote.tokenSymbol
-  ).address;
-
+    Number(quote.toChainId)
+  );
   return {
     ...quote,
     fromTokenAddress: fromAddress,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -260,6 +260,33 @@ export class ConfigClient {
       l1TokenAddress: token.l1TokenAddress,
     };
   }
+  getTokenInfoByL1TokenAddress(chainId: number, l1TokenAddress: string): Token {
+    const tokens = this.getTokenList(chainId);
+    const token = tokens.find(
+      (token) => token.l1TokenAddress === l1TokenAddress
+    );
+    assert(
+      token,
+      `Token not found on chain ${chainId} and l1TokenAddress ${l1TokenAddress}`
+    );
+    return token;
+  }
+  getFromToAddressesBySymbol(
+    symbol: string,
+    fromChainId: number,
+    toChainId: number
+  ) {
+    const { l1TokenAddress } = this.getTokenInfoBySymbol(fromChainId, symbol);
+    const fromAddress = this.getTokenInfoByL1TokenAddress(
+      fromChainId,
+      l1TokenAddress
+    ).address;
+    const toAddress = this.getTokenInfoByL1TokenAddress(
+      toChainId,
+      l1TokenAddress
+    ).address;
+    return { fromAddress, toAddress };
+  }
   getNativeTokenInfo(chainId: number): constants.TokenInfo {
     const chainInfo = constants.getChainInfo(chainId);
     return constants.getToken(chainInfo.nativeCurrencySymbol);


### PR DESCRIPTION
There was an assertion error thrown in our Amplitude helpers when trying to bridge ETH from Mainnet to Polygon. The problem was that we tried to get the token info by symbol but the assertion failed with
```
Token not found on chain 137 and symbol ETH
```
because `getTokenInfoBySymbol` tries to find a route on the given chain but there is no route from Polygon to Mainnet for ETH (only for WETH).

We fix this by adding two new helpers:
- `getTokenInfoByL1TokenAddress`
  - Allows to retrieve the token info based on `l1Address` on a given chain. This returns the same result for ETH and WETH.
- `getFromToAddressesBySymbol`
  - Uses above method to retrieve the `fromAddress` and `toAddress` by symbol. This returns the same result for ETH and WETH.