### PR TITLE
fix: correct remove liquidity amount

### DIFF
--- a/src/views/LiquidityPool/components/ActionInputBlock.tsx
+++ b/src/views/LiquidityPool/components/ActionInputBlock.tsx
@@ -58,7 +58,7 @@ export function ActionInputBlock({ action, selectedToken }: Props) {
   }, [action, selectedToken.symbol]);
 
   const handleAction = async () => {
-    if (!maxAmountsQuery.data) {
+    if (!maxAmountsQuery.data || !stakingPoolQuery.data) {
       return;
     }
 
@@ -82,6 +82,7 @@ export function ActionInputBlock({ action, selectedToken }: Props) {
         {
           amountInput: amount,
           maxRemovableAmount,
+          convertUnderlyingToLP: stakingPoolQuery.data.convertUnderlyingToLP,
         },
         {
           onSuccess: () => {

--- a/src/views/LiquidityPool/hooks/useLiquidityAction.ts
+++ b/src/views/LiquidityPool/hooks/useLiquidityAction.ts
@@ -1,4 +1,4 @@
-import { useConnection } from "hooks";
+import { ConverterFnType, useConnection } from "hooks";
 import { useMutation } from "react-query";
 import { BigNumber } from "ethers";
 
@@ -92,6 +92,7 @@ export function useRemoveLiquidity(
   const handleRemoveLiquidity = async (args: {
     amountInput: string;
     maxRemovableAmount: BigNumber;
+    convertUnderlyingToLP: ConverterFnType;
   }) => {
     if (!tokenSymbol || !signer || !account) {
       return;
@@ -112,7 +113,7 @@ export function useRemoveLiquidity(
     const hubPoolContract = config.getHubPool(signer);
     const txResponse = await hubPoolContract.removeLiquidity(
       tokenInfo.l1TokenAddress,
-      parsedAndValidAmount,
+      args.convertUnderlyingToLP(parsedAndValidAmount),
       isEth
     );
     await waitOnTransaction(txResponse, notify);


### PR DESCRIPTION
Remove liquidity didn't work for max. values because we passed in the L1 token amount instead of the converted LP token amount.

