### PR TITLE
fix: explicitly pass required chain to waitOnTx helper

### DIFF
--- a/src/hooks/useApprove.ts
+++ b/src/hooks/useApprove.ts
@@ -3,12 +3,13 @@ import { useMutation } from "react-query";
 import { BigNumberish } from "ethers";
 import { ERC20__factory } from "@across-protocol/contracts-v2";
 
-import { MAX_APPROVAL_AMOUNT, waitOnTransaction } from "utils";
+import { hubPoolChainId, MAX_APPROVAL_AMOUNT, waitOnTransaction } from "utils";
 import { useIsWrongNetwork } from "hooks";
 
-export function useApprove() {
+export function useApprove(requiredChainId = hubPoolChainId) {
   const { account, signer, notify } = useConnection();
-  const { isWrongNetwork, isWrongNetworkHandler } = useIsWrongNetwork();
+  const { isWrongNetwork, isWrongNetworkHandler } =
+    useIsWrongNetwork(requiredChainId);
 
   const handleApprove = async (args: {
     erc20Address: string;
@@ -39,7 +40,7 @@ export function useApprove() {
         args.allowedContractAddress,
         MAX_APPROVAL_AMOUNT
       );
-      await waitOnTransaction(txResponse, notify);
+      await waitOnTransaction(requiredChainId, txResponse, notify);
     }
   };
 

--- a/src/utils/notify.ts
+++ b/src/utils/notify.ts
@@ -50,12 +50,13 @@ export const notificationEmitter = async (
  * @param ignoreErrors An optional parameter to ignore tx failure and return successful
  **/
 export const waitOnTransaction = async (
+  requiredChainId: number,
   tx: ContractTransaction,
   notify: NotifyAPI,
   timingBuffer?: number,
   ignoreErrors?: boolean
 ): Promise<void> => {
-  if (supportedNotifyChainIds.includes(tx.chainId)) {
+  if (supportedNotifyChainIds.includes(requiredChainId)) {
     await notificationEmitter(tx.hash, notify, timingBuffer, ignoreErrors);
   } else {
     try {

--- a/src/views/Airdrop/hooks/useClaimAndStake.tsx
+++ b/src/views/Airdrop/hooks/useClaimAndStake.tsx
@@ -3,10 +3,11 @@ import { useMutation } from "react-query";
 import { getConfig } from "utils/config";
 import { waitOnTransaction } from "utils/notify";
 import { useConnection, useIsWrongNetwork } from "hooks";
+import { sendWithPaddedGas } from "utils/transactions";
+import { hubPoolChainId } from "utils";
 
 import { useAirdropRecipient } from "./useAirdropRecipient";
 import { useIsAirdropClaimed } from "./useIsAirdropClaimed";
-import { sendWithPaddedGas } from "utils/transactions";
 
 const config = getConfig();
 
@@ -43,7 +44,7 @@ export function useClaimAndStake() {
       "claimAndStake"
     )(parameters);
 
-    await waitOnTransaction(claimAndStakeTx, notify, 0);
+    await waitOnTransaction(hubPoolChainId, claimAndStakeTx, notify, 0);
   };
 
   return useMutation(handleClaimAndStake, {

--- a/src/views/Bridge/hooks/useBridgeAction.ts
+++ b/src/views/Bridge/hooks/useBridgeAction.ts
@@ -38,7 +38,7 @@ export function useBridgeAction(
               signer,
             });
             if (tx) {
-              await waitOnTransaction(tx, notify);
+              await waitOnTransaction(payload.fromChain, tx, notify);
             }
           } catch (e) {
             console.error(e);
@@ -63,7 +63,7 @@ export function useBridgeAction(
             if (onTransactionComplete) {
               onTransactionComplete(tx.hash);
             }
-            await waitOnTransaction(tx, notify);
+            await waitOnTransaction(payload.fromChain, tx, notify);
             if (onDepositResolved) {
               onDepositResolved(true);
             }

--- a/src/views/LiquidityPool/hooks/useLiquidityAction.ts
+++ b/src/views/LiquidityPool/hooks/useLiquidityAction.ts
@@ -66,7 +66,7 @@ export function useAddLiquidity(tokenSymbol?: string, l1TokenAddress?: string) {
         value: isEth ? parsedAndValidAmount : undefined,
       }
     );
-    await waitOnTransaction(txResponse, notify);
+    await waitOnTransaction(hubPoolChainId, txResponse, notify);
   };
 
   return useMutation(handleAddLiquidity, {
@@ -115,7 +115,7 @@ export function useRemoveLiquidity(
       parsedAndValidAmount,
       isEth
     );
-    await waitOnTransaction(txResponse, notify);
+    await waitOnTransaction(hubPoolChainId, txResponse, notify);
   };
 
   return useMutation(handleRemoveLiquidity, {

--- a/src/views/Referrals/hooks/useClaimReferralRewards.tsx
+++ b/src/views/Referrals/hooks/useClaimReferralRewards.tsx
@@ -4,7 +4,7 @@ import { getConfig } from "utils/config";
 import { useConnection, useIsWrongNetwork } from "hooks";
 import { useUnclaimedReferralProofs } from "./useUnclaimedReferralProofs";
 import { sendWithPaddedGas } from "utils/transactions";
-import { waitOnTransaction } from "utils";
+import { hubPoolChainId, waitOnTransaction } from "utils";
 
 const config = getConfig();
 
@@ -36,7 +36,7 @@ export function useClaimReferralRewards() {
         account,
       }))
     );
-    await waitOnTransaction(claimMultiTx, notify);
+    await waitOnTransaction(hubPoolChainId, claimMultiTx, notify);
   };
 
   return useMutation(handleClaim, {

--- a/src/views/Staking/hooks/useClaimStakeRewardAction.ts
+++ b/src/views/Staking/hooks/useClaimStakeRewardAction.ts
@@ -2,7 +2,7 @@ import { API } from "bnc-notify";
 import { Signer } from "ethers";
 import { useConnection, useStakingPool } from "hooks";
 import { useMutation } from "react-query";
-import { getConfig, waitOnTransaction } from "utils";
+import { getConfig, hubPoolChainId, waitOnTransaction } from "utils";
 import { sendWithPaddedGas } from "utils/transactions";
 
 export function useClaimStakeRewardAction(tokenAddress?: string) {
@@ -42,7 +42,7 @@ const performClaimingAction = async (
       "withdrawReward"
     )(lpTokenAddress);
     // Send this to onboard's notify API to track the TX
-    await waitOnTransaction(resultingTx, notify, 0, true);
+    await waitOnTransaction(hubPoolChainId, resultingTx, notify, 0, true);
   } catch (_e) {
     // We currently don't handle the error case other than to exit gracefully.
   }

--- a/src/views/Staking/hooks/useStakingAction.ts
+++ b/src/views/Staking/hooks/useStakingAction.ts
@@ -4,7 +4,12 @@ import { ERC20__factory } from "@across-protocol/contracts-v2";
 import { API } from "bnc-notify";
 
 import { useConnection, useStakingPool } from "hooks";
-import { getConfig, MAX_APPROVAL_AMOUNT, waitOnTransaction } from "utils";
+import {
+  getConfig,
+  hubPoolChainId,
+  MAX_APPROVAL_AMOUNT,
+  waitOnTransaction,
+} from "utils";
 import { sendWithPaddedGas } from "utils/transactions";
 
 export type StakingActionFunctionArgs = { amount: BigNumber };
@@ -104,7 +109,7 @@ const performStakingActionBuilderFn = (
           MAX_APPROVAL_AMOUNT
         );
         // Wait for the transaction to return successful
-        await waitOnTransaction(approvalResult, notify);
+        await waitOnTransaction(hubPoolChainId, approvalResult, notify);
         innerApprovalRequired = false;
       } catch (_e) {
         // If this function fails to resolve (or the user rejects), we don't proceed.
@@ -118,7 +123,7 @@ const performStakingActionBuilderFn = (
     // wait until the tx has been resolved
     try {
       const result = await callingFn(lpTokenAddress, amountAsBigNumber);
-      await waitOnTransaction(result, notify, 5000, true);
+      await waitOnTransaction(hubPoolChainId, result, notify, 5000, true);
     } catch (_e) {
       // We currently don't handle the error case other than to exit gracefully.
     }


### PR DESCRIPTION
For some reason, `txResponse.chainId` returns always `0`. So the `waitOnTransaction` helper falls back to `tx.wait` event for supported chains.
