### PR TITLE
fix(ampli): ensure resolved referralProgramAddress before page view tracking

### DIFF
--- a/src/components/RouteTrace/useRouteTrace.ts
+++ b/src/components/RouteTrace/useRouteTrace.ts
@@ -6,7 +6,8 @@ import { ampli } from "../../ampli";
 
 export function useRouteTrace() {
   const location = useLocation();
-  const { referrer: referralAddress } = useReferrer();
+  const { referrer: referralAddress, isResolved: isReferralAddressResolved } =
+    useReferrer();
   const [initialPage, setInitialPage] = useState(true);
   const [path, setPath] = useState("");
 
@@ -17,7 +18,7 @@ export function useRouteTrace() {
   }, [location, path]);
 
   useEffect(() => {
-    if (path) {
+    if (path && isReferralAddressResolved) {
       const referrer = document.referrer;
       const origin = window.location.origin;
       const page = pageLookup[path] ?? "404Page";
@@ -30,10 +31,13 @@ export function useRouteTrace() {
         gitCommitHash: currentGitCommitHash,
         referralProgramAddress: referralAddress,
       });
-      setInitialPage(false);
+
+      if (initialPage) {
+        setInitialPage(false);
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [path]);
+  }, [path, isReferralAddressResolved]);
 }
 
 export const pageLookup: Record<

--- a/src/hooks/useReferrer.ts
+++ b/src/hooks/useReferrer.ts
@@ -11,11 +11,13 @@ export default function useReferrer() {
   const r = refParam || referrer;
 
   const [address, setAddress] = useState<string>("");
+  const [isResolved, setIsResolved] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
   useEffect(() => {
     setError("");
     if (provider && r) {
       if (ethers.utils.isAddress(r)) {
+        setIsResolved(true);
         return setAddress(r);
       }
 
@@ -23,6 +25,7 @@ export default function useReferrer() {
         .resolveName(r)
         .then((ra) => {
           setAddress(ra || "");
+          setIsResolved(true);
           if (!ra) {
             setError("Invalid referral ENS name");
           }
@@ -41,5 +44,5 @@ export default function useReferrer() {
   // If ref and referrer params exist, prefer referrer param.
   // Not likely to happen but should have a catch if we get a bad link.
   // TODO? Test which of these is a good value?
-  return { referrer: address, error };
+  return { referrer: address, error, isResolved };
 }


### PR DESCRIPTION
The `PageViewed` event property `referralProgramAddress` wasn't correctly tracked for the initial page.