### PR TITLE
refactor: bridge enforce network

### DIFF
--- a/src/hooks/useIsWrongNetwork.ts
+++ b/src/hooks/useIsWrongNetwork.ts
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
-import { providers } from "ethers";
 
 import { useConnection } from "hooks";
-import { hubPoolChainId } from "utils";
+import { hubPoolChainId, chainInfoTable } from "utils";
 
 export function useIsWrongNetwork(baseChain?: number) {
   const correctChainId = baseChain ?? hubPoolChainId;
@@ -29,9 +28,7 @@ export function useIsWrongNetwork(baseChain?: number) {
 
     if (!didSetChain) {
       throw new Error(
-        `Wrong network. Please switch to network ${
-          providers.getNetwork(correctChainId).name
-        }`
+        `Wrong network. Please switch to network ${chainInfoTable[correctChainId]?.name}`
       );
     }
   };
@@ -41,9 +38,7 @@ export function useIsWrongNetwork(baseChain?: number) {
       await isWrongNetworkHandler();
     } catch (_e) {
       console.error(
-        `Wrong network. Please switch to network ${
-          providers.getNetwork(correctChainId).name
-        }`
+        `Wrong network. Please switch to network ${chainInfoTable[correctChainId]?.name}`
       );
     }
   };

--- a/src/views/Bridge/Bridge.tsx
+++ b/src/views/Bridge/Bridge.tsx
@@ -21,6 +21,8 @@ const Bridge = () => {
     setCurrentToRoute,
     handleQuickSwap,
     isConnected,
+    isWrongChain,
+    handleChainSwitch,
     buttonActionHandler,
     buttonLabel,
     isBridgeDisabled,
@@ -82,6 +84,8 @@ const Bridge = () => {
               currentToRoute={currentToRoute}
               setCurrentToRoute={setCurrentToRoute}
               handleQuickSwap={handleQuickSwap}
+              isWrongChain={isWrongChain}
+              handleChainSwitch={handleChainSwitch}
               isConnected={isConnected}
               buttonActionHandler={buttonActionHandler}
               buttonLabel={buttonLabel}

--- a/src/views/Bridge/components/BridgeForm.tsx
+++ b/src/views/Bridge/components/BridgeForm.tsx
@@ -32,7 +32,7 @@ type BridgeFormProps = {
   setCurrentToRoute: (chainId: number) => void;
   handleQuickSwap: () => void;
   isConnected: boolean;
-  buttonActionHandler: () => Promise<void>;
+  buttonActionHandler: () => void;
   buttonLabel: string;
   isBridgeDisabled: boolean;
   fees: GetBridgeFeesResult | undefined;

--- a/src/views/Bridge/components/BridgeForm.tsx
+++ b/src/views/Bridge/components/BridgeForm.tsx
@@ -32,6 +32,8 @@ type BridgeFormProps = {
   setCurrentToRoute: (chainId: number) => void;
   handleQuickSwap: () => void;
   isConnected: boolean;
+  isWrongChain: boolean;
+  handleChainSwitch: () => void;
   buttonActionHandler: () => void;
   buttonLabel: string;
   isBridgeDisabled: boolean;
@@ -57,6 +59,8 @@ const BridgeForm = ({
   currentToRoute,
   setCurrentToRoute,
   handleQuickSwap,
+  isWrongChain,
+  handleChainSwitch,
   isConnected,
   buttonActionHandler,
   buttonLabel,
@@ -175,16 +179,24 @@ const BridgeForm = ({
           />
         )}
         <Divider />
-        <Button
-          disabled={isBridgeDisabled}
-          onClick={() => {
-            buttonActionHandler();
-          }}
-        >
-          <Text color="dark-grey" weight={500}>
-            {buttonLabel}
-          </Text>
-        </Button>
+        {isWrongChain ? (
+          <Button onClick={() => handleChainSwitch()}>
+            <Text color="dark-grey" weight={500}>
+              Switch Network
+            </Text>
+          </Button>
+        ) : (
+          <Button
+            disabled={isBridgeDisabled}
+            onClick={() => {
+              buttonActionHandler();
+            }}
+          >
+            <Text color="dark-grey" weight={500}>
+              {buttonLabel}
+            </Text>
+          </Button>
+        )}
       </CardWrapper>{" "}
     </>
   );

--- a/src/views/Bridge/hooks/useBridge.ts
+++ b/src/views/Bridge/hooks/useBridge.ts
@@ -231,6 +231,7 @@ export function useBridge() {
       trackFromChainChanged(currentToRouteTemp, false);
       // Set the current to route to the current from route
       setCurrentToRoute(currentFromRouteTemp);
+      setAmountToBridge(undefined);
       trackToChainChanged(currentFromRouteTemp, false);
       trackQuickSwap("bridgeForm");
     }
@@ -254,14 +255,14 @@ export function useBridge() {
   const isBridgeDisabled =
     isConnected && (!amountToBridge || amountToBridge.eq(0));
 
-  const { fees: rawFees } = useBridgeFees(
+  const { fees: rawFees, isLoading: areRawFeesLoading } = useBridgeFees(
     amountToBridge ?? BigNumber.from(0),
     currentFromRoute,
     currentToRoute,
     currentToken
   );
 
-  const { limits: rawLimits } = useBridgeLimits(
+  const { limits: rawLimits, isLoading: areRawLimitsLoading } = useBridgeLimits(
     currentRoute?.fromTokenAddress,
     currentFromRoute,
     currentToRoute
@@ -294,8 +295,10 @@ export function useBridge() {
         : undefined
       : undefined;
   }, [amountToBridge, currentFromRoute, currentToRoute, limits]);
-  const estimatedTime = limits
-    ? estimatedTimeToRelayObject?.formattedString ?? "loading..."
+  const estimatedTime = areRawLimitsLoading
+    ? "loading..."
+    : limits
+    ? estimatedTimeToRelayObject?.formattedString
     : undefined;
 
   const { referrer } = useReferrer();
@@ -370,7 +373,7 @@ export function useBridge() {
   }, [fees, currentRoute]);
 
   const bridgeAction = useBridgeAction(
-    limits === undefined || fees === undefined,
+    areRawFeesLoading || areRawLimitsLoading,
     bridgePayload,
     currentToken,
     onTxHashChange,

--- a/src/views/Bridge/hooks/useBridge.ts
+++ b/src/views/Bridge/hooks/useBridge.ts
@@ -437,8 +437,7 @@ export function useBridge() {
     isConnected,
     isBridgeDisabled:
       isConnected &&
-      (isWrongNetwork ||
-        isBridgeDisabled ||
+      (isBridgeDisabled ||
         bridgeAction.buttonDisabled ||
         (!!fees && fees.isAmountTooLow)),
     amountTooLow: isConnected && (fees?.isAmountTooLow ?? false),

--- a/src/views/Bridge/hooks/useBridgeAction.ts
+++ b/src/views/Bridge/hooks/useBridgeAction.ts
@@ -1,7 +1,6 @@
 import { ampli, TransferQuoteReceivedProperties } from "ampli";
 import { BigNumber, ContractTransaction } from "ethers";
-import { useConnection, useERC20 } from "hooks";
-import { useAllowance } from "hooks/useAllowance";
+import { useConnection, useApprove, useIsWrongNetwork } from "hooks";
 import { cloneDeep } from "lodash";
 import { useMutation } from "react-query";
 import {
@@ -11,11 +10,12 @@ import {
   generateTransferSubmitted,
   getConfig,
   getToken,
-  MAX_APPROVAL_AMOUNT,
   recordTransferUserProperties,
   sendAcrossDeposit,
   waitOnTransaction,
 } from "utils";
+
+const config = getConfig();
 
 export function useBridgeAction(
   dataLoading: boolean,
@@ -27,38 +27,13 @@ export function useBridgeAction(
   recentInitialQuoteTime?: number,
   tokenPrice?: BigNumber
 ) {
-  const { isConnected, connect, account, chainId, signer, notify } =
-    useConnection();
-  const { approve } = useERC20(tokenSymbol ?? "");
-  const { allowance } = useAllowance(
-    tokenSymbol,
-    payload?.fromChain,
-    account,
-    payload ? getConfig().getSpokePoolAddress(payload.fromChain) : undefined
+  const { isConnected, connect, signer, notify } = useConnection();
+
+  const { isWrongNetwork, isWrongNetworkHandler } = useIsWrongNetwork(
+    payload?.fromChain
   );
 
-  const approvalHandler = async () => {
-    if (allowance !== undefined && payload && signer) {
-      const spokePool = getConfig().getSpokePool(payload.fromChain, signer);
-      if (chainId === payload.fromChain) {
-        if (allowance.lt(payload.amount)) {
-          try {
-            const tx = await approve({
-              spender: spokePool.address,
-              amount: MAX_APPROVAL_AMOUNT,
-              signer,
-            });
-            if (tx) {
-              await waitOnTransaction(payload.fromChain, tx, notify);
-            }
-          } catch (e) {
-            console.error(e);
-            return;
-          }
-        }
-      }
-    }
-  };
+  const approveHandler = useApprove(payload?.fromChain);
 
   const buttonActionHandler = useMutation(async () => {
     const frozenQuote = cloneDeep(recentQuote);
@@ -69,110 +44,122 @@ export function useBridgeAction(
 
     if (!isConnected) {
       connect();
-    } else {
-      if (
-        allowance !== undefined &&
-        frozenPayload &&
-        signer &&
-        chainId === frozenPayload.fromChain &&
-        frozenQuote &&
-        frozenInitialQuoteTime &&
-        frozenTokenPrice
-      ) {
-        if (allowance.lt(frozenPayload.amount)) {
-          await approvalHandler();
-        }
-        let succeeded = false;
-        let timeSigned: number | undefined = undefined;
-        let tx: ContractTransaction | undefined = undefined;
-        try {
-          // Instrument amplitude before sending the transaction for the submit button.
-          ampli.transferSubmitted(
-            generateTransferSubmitted(
-              frozenQuote,
-              referrer,
-              frozenInitialQuoteTime
-            )
-          );
-          const timeSubmitted = Date.now();
+      return;
+    }
 
-          tx = await sendAcrossDeposit(signer, frozenPayload);
+    if (
+      !frozenPayload ||
+      !signer ||
+      !frozenQuote ||
+      !frozenInitialQuoteTime ||
+      !frozenTokenPrice ||
+      !tokenSymbol
+    ) {
+      return;
+    }
 
-          // Instrument amplitude after signing the transaction for the submit button.
-          timeSigned = Date.now();
-          ampli.transferSigned(
-            generateTransferSigned(
-              frozenQuote,
-              referrer,
-              timeSubmitted,
-              tx.hash
-            )
-          );
+    if (isWrongNetwork) {
+      await isWrongNetworkHandler();
+    }
 
-          if (onTransactionComplete) {
-            onTransactionComplete(tx.hash);
-          }
-          await waitOnTransaction(frozenPayload.fromChain, tx, notify);
-          if (onDepositResolved) {
-            onDepositResolved(true);
-          }
-          succeeded = true;
-        } catch (e) {
-          console.error(e);
-          if (onDepositResolved) {
-            onDepositResolved(false);
-          }
-        }
-        if (timeSigned && tx) {
-          ampli.transferDepositCompleted(
-            generateDepositConfirmed(
-              frozenQuote,
-              referrer,
-              timeSigned,
-              tx.hash,
-              succeeded,
-              tx.timestamp!
-            )
-          );
-        }
-        // Call recordTransferUserProperties to update the user's properties in Amplitude.
-        recordTransferUserProperties(
-          frozenPayload.amount,
-          frozenTokenPrice,
-          getToken(frozenQuote.tokenSymbol).decimals,
-          frozenQuote.tokenSymbol.toLowerCase(),
-          Number(frozenQuote.fromChainId),
-          Number(frozenQuote.toChainId),
-          frozenQuote.fromChainName
-        );
+    if (tokenSymbol !== "ETH") {
+      await approveHandler.mutateAsync({
+        erc20Address: config.getTokenInfoBySymbol(
+          frozenPayload.fromChain,
+          tokenSymbol
+        ).address,
+        approvalAmount: frozenPayload.amount,
+        allowedContractAddress: config.getSpokePoolAddress(
+          frozenPayload.fromChain
+        ),
+      });
+    }
+
+    let succeeded = false;
+    let timeSigned: number | undefined = undefined;
+    let tx: ContractTransaction | undefined = undefined;
+    try {
+      // Instrument amplitude before sending the transaction for the submit button.
+      ampli.transferSubmitted(
+        generateTransferSubmitted(frozenQuote, referrer, frozenInitialQuoteTime)
+      );
+      const timeSubmitted = Date.now();
+
+      tx = await sendAcrossDeposit(signer, frozenPayload);
+
+      // Instrument amplitude after signing the transaction for the submit button.
+      timeSigned = Date.now();
+      ampli.transferSigned(
+        generateTransferSigned(frozenQuote, referrer, timeSubmitted, tx.hash)
+      );
+
+      if (onTransactionComplete) {
+        onTransactionComplete(tx.hash);
+      }
+      await waitOnTransaction(frozenPayload.fromChain, tx, notify);
+      if (onDepositResolved) {
+        onDepositResolved(true);
+      }
+      succeeded = true;
+    } catch (e) {
+      console.error(e);
+      if (onDepositResolved) {
+        onDepositResolved(false);
       }
     }
+    if (timeSigned && tx) {
+      ampli.transferDepositCompleted(
+        generateDepositConfirmed(
+          frozenQuote,
+          referrer,
+          timeSigned,
+          tx.hash,
+          succeeded,
+          tx.timestamp!
+        )
+      );
+    }
+    // Call recordTransferUserProperties to update the user's properties in Amplitude.
+    recordTransferUserProperties(
+      frozenPayload.amount,
+      frozenTokenPrice,
+      getToken(frozenQuote.tokenSymbol).decimals,
+      frozenQuote.tokenSymbol.toLowerCase(),
+      Number(frozenQuote.fromChainId),
+      Number(frozenQuote.toChainId),
+      frozenQuote.fromChainName
+    );
   });
 
-  let buttonLabel = "";
-  if (!isConnected) {
-    buttonLabel = "Connect wallet";
-  } else if (payload) {
-    if (dataLoading || !allowance) {
-      buttonLabel = "Loading...";
-    } else {
-      if (buttonActionHandler.isLoading) {
-        buttonLabel = "Confirming...";
-      } else {
-        buttonLabel = "Confirm transaction";
-      }
-    }
-  } else {
-    buttonLabel = "Confirm transaction";
-  }
   const buttonDisabled =
     !payload || (isConnected && dataLoading) || buttonActionHandler.isLoading;
 
   return {
     isConnected,
-    buttonActionHandler: buttonActionHandler.mutateAsync,
+    buttonActionHandler: buttonActionHandler.mutate,
     isButtonActionLoading: buttonActionHandler.isLoading,
-    buttonLabel,
+    buttonLabel: getButtonLabel({
+      isConnected,
+      isDataLoading: dataLoading,
+      isMutating: buttonActionHandler.isLoading,
+    }),
     buttonDisabled,
   };
+}
+
+function getButtonLabel(args: {
+  isConnected: boolean;
+  isDataLoading: boolean;
+  isMutating: boolean;
+}) {
+  if (!args.isConnected) {
+    return "Connect wallet";
+  }
+  if (args.isMutating) {
+    return "Confirming...";
+  }
+  if (args.isDataLoading) {
+    return "Loading...";
+  }
+  return "Confirm transaction";
 }

--- a/src/views/LiquidityPool/LiquidityPool.tsx
+++ b/src/views/LiquidityPool/LiquidityPool.tsx
@@ -13,7 +13,12 @@ import {
   hubPoolChainId,
 } from "utils";
 import { repeatableTernaryBuilder } from "utils/ternary";
-import { useConnection, useQueryParams, useStakingPool } from "hooks";
+import {
+  useConnection,
+  useIsWrongNetwork,
+  useQueryParams,
+  useStakingPool,
+} from "hooks";
 
 import Breadcrumb from "./components/Breadcrumb";
 import PoolSelector from "./components/PoolSelector";
@@ -36,6 +41,8 @@ export default function LiquidityPool() {
   const [selectedToken, setSelectedToken] = useState(tokenList[0]);
 
   const { isConnected, connect } = useConnection();
+  const { isWrongNetwork, isWrongNetworkHandlerWithoutError } =
+    useIsWrongNetwork();
 
   const userLiquidityPoolQuery = useUserLiquidityPool(selectedToken.symbol);
   const allLiquidityPoolQueries = useAllLiquidityPools();
@@ -178,6 +185,13 @@ export default function LiquidityPool() {
                 }
               >
                 Connect Wallet
+              </Button>
+            ) : isWrongNetwork ? (
+              <Button
+                size="lg"
+                onClick={() => isWrongNetworkHandlerWithoutError()}
+              >
+                Switch Network
               </Button>
             ) : (
               <ActionInputBlock action={action} selectedToken={selectedToken} />

--- a/src/views/LiquidityPool/components/ActionInputBlock.tsx
+++ b/src/views/LiquidityPool/components/ActionInputBlock.tsx
@@ -2,8 +2,8 @@ import styled from "@emotion/styled";
 import { useEffect, useState } from "react";
 import { utils } from "ethers";
 
-import { QUERIESV2, trackMaxButtonClicked } from "utils";
-import { useStakingPool } from "hooks";
+import { hubPoolChainId, QUERIESV2, trackMaxButtonClicked } from "utils";
+import { useIsWrongNetwork, useStakingPool } from "hooks";
 import { InputWithMaxButton, Text } from "components";
 
 import {


### PR DESCRIPTION
This adds a new button at the same place as the main action of the pool or bridge page to switch networks. Similar to the old designs.

The PR also contains smaller fixes:
- Local handling of pending deposits (was accidentally removed while refactoring)
- Input reset and loading indicator fix