### PR TITLE
fix: make max. removable amount more robust to volatile exchange rates

### DIFF
--- a/src/views/LiquidityPool/components/ActionInputBlock.tsx
+++ b/src/views/LiquidityPool/components/ActionInputBlock.tsx
@@ -62,7 +62,8 @@ export function ActionInputBlock({ action, selectedToken }: Props) {
       return;
     }
 
-    const { maxAddableAmount, maxRemovableAmount } = maxAmountsQuery.data;
+    const { maxAddableAmount, maxRemovableAmount, maxRemovableAmountInLP } =
+      maxAmountsQuery.data;
 
     if (action === "add") {
       addLiquidityMutation.mutate(
@@ -82,7 +83,7 @@ export function ActionInputBlock({ action, selectedToken }: Props) {
         {
           amountInput: amount,
           maxRemovableAmount,
-          convertUnderlyingToLP: stakingPoolQuery.data.convertUnderlyingToLP,
+          maxRemovableAmountInLP,
         },
         {
           onSuccess: () => {

--- a/src/views/LiquidityPool/hooks/useMaxAmounts.ts
+++ b/src/views/LiquidityPool/hooks/useMaxAmounts.ts
@@ -24,6 +24,7 @@ export function useMaxAmounts(
     async () => {
       let maxAddableAmount: BigNumber;
       let maxRemovableAmount: BigNumber;
+      let maxRemovableAmountInLP: BigNumber;
 
       if (
         selectedTokenAddress &&
@@ -52,14 +53,22 @@ export function useMaxAmounts(
           ),
           0
         );
+        maxRemovableAmountInLP = max(
+          BigNumber.from(userLiquidityPoolQuery.data.lpTokens).sub(
+            stakingPoolQuery.data.userAmountOfLPStaked
+          ),
+          0
+        );
       } else {
         maxAddableAmount = BigNumber.from(0);
         maxRemovableAmount = BigNumber.from(0);
+        maxRemovableAmountInLP = BigNumber.from(0);
       }
 
       return {
         maxAddableAmount,
         maxRemovableAmount,
+        maxRemovableAmountInLP,
       };
     },
     {


### PR DESCRIPTION
Instead of converting the max. removable amount to LP when calling `removeLiquidity`, we instead calculate the ratio of `amountInput / maxRemovableAmount (both denominated in tokens)` and take that percentage from the `maxRemovableAmountLP`. This should mitigate the risk of stale exchange rate values that prevented the user from previously executing the action.

Fixes ACX-694