### PR TITLE
fix: disable lp action if no amount or data

### DIFF
--- a/src/views/LiquidityPool/components/ActionInputBlock.tsx
+++ b/src/views/LiquidityPool/components/ActionInputBlock.tsx
@@ -100,6 +100,14 @@ export function ActionInputBlock({ action, selectedToken }: Props) {
     addLiquidityMutation.isLoading ||
     removeLiquidityMutation.isLoading;
 
+  const disableAction = Boolean(
+    disableInputs ||
+      amountValidationError ||
+      !amount ||
+      !maxAmountsQuery.data ||
+      !stakingPoolQuery.data
+  );
+
   const maxAmount =
     selectedToken.decimals && maxAmountsQuery.data
       ? utils.formatUnits(
@@ -135,7 +143,7 @@ export function ActionInputBlock({ action, selectedToken }: Props) {
             size="lg"
             onClick={handleAction}
             isRemove={action === "remove"}
-            disabled={Boolean(disableInputs || amountValidationError)}
+            disabled={disableAction}
           >
             <Text color="dark-grey" weight={500}>
               {action === "add"


### PR DESCRIPTION
The action button for adding/removing liquidity wasn't correctly disable if amount input was empty.