### PR TITLE
feat: include greyed-out selectors for all routes/tokens

### DIFF
--- a/src/components/Selector/Selector.tsx
+++ b/src/components/Selector/Selector.tsx
@@ -104,7 +104,9 @@ const Selector = <ElementValue,>({
                       }
                       placement="bottom-start"
                     >
-                      <InfoIcon />
+                      <InfoIconWrapper>
+                        <InfoIcon />
+                      </InfoIconWrapper>
                     </PopperTooltip>
                   ) : idx === selectedIndex ? (
                     <ActiveIcon>
@@ -262,4 +264,16 @@ const ElementSuffixWrapper = styled.div<{ largeGap?: boolean }>`
   gap: ${({ largeGap }) => (largeGap ? "16px" : "4px")};
 `;
 
-const InfoIcon = styled(II)``;
+const InfoIcon = styled(II)`
+  height: 16px;
+  width: 16px;
+`;
+
+const InfoIconWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  height: 24px;
+  width: 24px;
+`;

--- a/src/components/Selector/Selector.tsx
+++ b/src/components/Selector/Selector.tsx
@@ -2,13 +2,20 @@ import styled from "@emotion/styled";
 import { ReactComponent as Arrow } from "assets/icons/arrow-16.svg";
 import Modal from "components/Modal";
 import { Text } from "components/Text";
+import { PopperTooltip } from "components/Tooltip";
 import { QUERIESV2 } from "utils";
+import { ReactComponent as II } from "assets/icons/info-16.svg";
 import { useSelector } from "./useSelector";
 
 export type SelectorElementType<Value> = {
   value: Value;
   element: JSX.Element;
   suffix?: JSX.Element;
+  disabled?: boolean;
+  disabledTooltip?: {
+    title: string;
+    description: string;
+  };
 };
 
 export type SelectorPropType<Value> = {
@@ -69,16 +76,37 @@ const Selector = <ElementValue,>({
             <ElementRow
               key={idx}
               onClick={() => {
+                if (element.disabled) return;
                 setSelectedValue(element.value);
                 setDisplayModal(false);
               }}
-              active={selectedIndex === idx}
+              active={!element.disabled && selectedIndex === idx}
+              disabled={element.disabled}
             >
-              <ElementSection> {element.element}</ElementSection>
+              <ElementSection disabled={element.disabled}>
+                {element.element}
+              </ElementSection>
               <ElementSection>
-                <ElementSuffixWrapper>
-                  {element.suffix}
-                  {idx === selectedIndex ? (
+                <ElementSuffixWrapper largeGap={element.disabled}>
+                  {element.disabled ? (
+                    <Text size="sm" color="grey-400">
+                      Not supported
+                    </Text>
+                  ) : (
+                    element.suffix
+                  )}
+                  {element.disabled ? (
+                    <PopperTooltip
+                      title={element.disabledTooltip?.title ?? "Not supported."}
+                      body={
+                        element.disabledTooltip?.description ??
+                        "This asset is not supported within this context."
+                      }
+                      placement="bottom-start"
+                    >
+                      <InfoIcon />
+                    </PopperTooltip>
+                  ) : idx === selectedIndex ? (
                     <ActiveIcon>
                       <ActiveSelectedIcon />
                     </ActiveIcon>
@@ -159,23 +187,26 @@ const ElementRowDivider = styled.div`
   width: calc(100% + 32px);
 `;
 
-const ElementRow = styled.div<{ active: boolean }>`
+const ElementRow = styled.div<{ active: boolean; disabled?: boolean }>`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
   padding: 14px 12px 14px 16px;
-  cursor: pointer;
+  cursor: ${({ disabled }) => (disabled ? "default" : "pointer")};
   width: 100%;
 
-  background: ${({ active }) => (active ? "#2d2e33" : "transparent")};
+  background: ${({ active, disabled }) =>
+    active && !disabled ? "#2d2e33" : "transparent"};
 
   &:hover {
-    background: #2d2e33;
+    background: ${({ disabled }) => (!disabled ? "#2d2e33" : "transparent")};
   }
 `;
 
-const ElementSection = styled.div``;
+const ElementSection = styled.div<{ disabled?: boolean }>`
+  opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
+`;
 
 const InactiveIcon = styled.div`
   display: flex;
@@ -222,11 +253,13 @@ const ActiveSelectedIcon = styled.div`
   background: #44d2ff;
 `;
 
-const ElementSuffixWrapper = styled.div`
+const ElementSuffixWrapper = styled.div<{ largeGap?: boolean }>`
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
   align-items: center;
   padding: 0px;
-  gap: 4px;
+  gap: ${({ largeGap }) => (largeGap ? "16px" : "4px")};
 `;
+
+const InfoIcon = styled(II)``;

--- a/src/views/Bridge/Bridge.tsx
+++ b/src/views/Bridge/Bridge.tsx
@@ -42,6 +42,8 @@ const Bridge = () => {
     walletAccount,
     disableQuickSwap,
     setIsBridgeAmountValid,
+    allFromRoutes,
+    allToRoutes,
   } = useBridge();
   return (
     <>
@@ -83,7 +85,9 @@ const Bridge = () => {
               currentFromRoute={currentFromRoute}
               setCurrentFromRoute={setCurrentFromRoute}
               availableFromRoutes={availableFromRoutes}
+              allFromRoutes={allFromRoutes}
               availableToRoutes={availableToRoutes}
+              allToRoutes={allToRoutes}
               currentToRoute={currentToRoute}
               setCurrentToRoute={setCurrentToRoute}
               handleQuickSwap={handleQuickSwap}

--- a/src/views/Bridge/components/BridgeForm.tsx
+++ b/src/views/Bridge/components/BridgeForm.tsx
@@ -28,7 +28,9 @@ type BridgeFormProps = {
   currentFromRoute: number | undefined;
   setCurrentFromRoute: (chainId: number) => void;
   availableFromRoutes: ChainInfo[];
+  allFromRoutes: ChainInfo[];
   availableToRoutes: ChainInfo[];
+  allToRoutes: ChainInfo[];
   currentToRoute: number | undefined;
   setCurrentToRoute: (chainId: number) => void;
   handleQuickSwap: () => void;
@@ -78,6 +80,8 @@ const BridgeForm = ({
   walletAccount,
   disableQuickSwap,
   setIsBridgeAmountValid,
+  allToRoutes,
+  allFromRoutes,
 }: BridgeFormProps) => {
   const mapChainInfoToRoute = (
     c?: ChainInfo,
@@ -124,9 +128,16 @@ const BridgeForm = ({
             From
           </Text>
           <Selector<number>
-            elements={availableFromRoutes.map((r) => ({
+            elements={allFromRoutes.map((r) => ({
               value: r.chainId,
               element: mapChainInfoToRoute(r)!,
+              disabled: availableFromRoutes.every(
+                (c) => c.chainId !== r.chainId
+              ),
+              disabledTooltip: {
+                title: `Asset not supported on ${r.name}.`,
+                description: `${currentToken} is not supported on ${r.name}. Please select another asset or change this chain.`,
+              },
             }))}
             selectedValue={currentFromRoute ?? 1}
             setSelectedValue={(v) => setCurrentFromRoute(v)}
@@ -145,9 +156,16 @@ const BridgeForm = ({
           </QuickSwapWrapper>
           <FromSelectionStack>
             <Selector<number>
-              elements={availableToRoutes.map((r) => ({
+              elements={allToRoutes.map((r) => ({
                 value: r.chainId,
                 element: mapChainInfoToRoute(r)!,
+                disabled: availableToRoutes.every(
+                  (c) => c.chainId !== r.chainId
+                ),
+                disabledTooltip: {
+                  title: `Asset not supported on ${r.name}.`,
+                  description: `${currentToken} is not supported on ${r.name}. Please select another asset or change this chain.`,
+                },
               }))}
               displayElement={mapChainInfoToRoute(
                 availableToRoutes.filter(

--- a/src/views/Bridge/components/CoinSelector.tsx
+++ b/src/views/Bridge/components/CoinSelector.tsx
@@ -5,6 +5,7 @@ import { SecondaryButtonWithoutShadow as UnstyledButton } from "components/Butto
 import { BigNumber, utils } from "ethers";
 import {
   formatUnits,
+  getChainInfo,
   getConfig,
   isNumberEthersParseable,
   parseUnitsFnBuilder,
@@ -220,8 +221,20 @@ const CoinSelector = ({
         </AmountInnerWrapper>
       </AmountWrapper>
       <TokenSelection
-        elements={tokenChoices.map((t, idx) => ({
+        elements={tokenChoices.map((t) => ({
           value: t.symbol,
+          disabled: !getConfig().routes.some(
+            (r) =>
+              toChain === r.toChain &&
+              fromChain === r.fromChain &&
+              r.fromTokenSymbol === t.symbol
+          ),
+          disabledTooltip: {
+            title: "Asset not supported.",
+            description: `${t.symbol.toUpperCase()} is not supported on ${
+              getChainInfo(fromChain).name
+            }. Pick a different asset or change the destination chain.`,
+          },
           element: (
             <CoinIconTextWrapper>
               <CoinIcon src={t.logoURI} />

--- a/src/views/Bridge/hooks/useBridge.ts
+++ b/src/views/Bridge/hooks/useBridge.ts
@@ -33,14 +33,28 @@ const enabledRoutes = getConfig().getRoutes();
 export function useBridge() {
   // Get all available tokens from the enabled routes and use useMemo to avoid
   // recalculating this every time the component re-renders
-  const availableTokens = useMemo(() => {
+  const { availableTokens, allFromRoutes, allToRoutes } = useMemo(() => {
     // Map the enabled routes to an array of token symbols and filter for duplicates
-    return enabledRoutes
-      .map((route) => getToken(route.fromTokenSymbol))
-      .filter(
-        (token, index, self) =>
-          index === self.findIndex((t) => t.symbol === token.symbol)
-      );
+    return {
+      availableTokens: enabledRoutes
+        .map((route) => getToken(route.fromTokenSymbol))
+        .filter(
+          (token, index, self) =>
+            index === self.findIndex((t) => t.symbol === token.symbol)
+        ),
+      allFromRoutes: enabledRoutes
+        .map((route) => getChainInfo(route.fromChain))
+        .filter(
+          (chain, index, self) =>
+            index === self.findIndex((t) => t.chainId === chain.chainId)
+        ),
+      allToRoutes: enabledRoutes
+        .map((route) => getChainInfo(route.toChain))
+        .filter(
+          (chain, index, self) =>
+            index === self.findIndex((t) => t.chainId === chain.chainId)
+        ),
+    };
   }, []);
 
   const [currentToken, setCurrentToken] = useState(availableTokens[0].symbol);
@@ -486,5 +500,7 @@ export function useBridge() {
     transactionElapsedTimeAsFormattedString,
     disableQuickSwap,
     setIsBridgeAmountValid,
+    allFromRoutes,
+    allToRoutes,
   };
 }


### PR DESCRIPTION
This PR allows all chains/assets to be visible to the user when a user clicks a dropdown. However, the selectors now `disable` inconsistent/unavailable route combinations. 
![image](https://user-images.githubusercontent.com/96435344/218784843-2443e322-f1a9-476a-ab56-3dc99c9291a7.png)
