### PR TITLE
fix: ens name display

### DIFF
--- a/src/hooks/useConnection.ts
+++ b/src/hooks/useConnection.ts
@@ -36,7 +36,7 @@ export function useConnection() {
 
   return {
     account: account ? ethers.utils.getAddress(account.address) : undefined,
-    ensName: account?.ens,
+    ensName: account?.ens?.name,
     chainId,
     provider,
     signer,


### PR DESCRIPTION
Sentry uncovered a bug that occurred for accounts with ENS