### PR TITLE
improve: change copy on reward/staking page

### DIFF
--- a/src/views/Rewards/components/GenericStakingPoolTable/GenericStakingPoolFormatter.tsx
+++ b/src/views/Rewards/components/GenericStakingPoolTable/GenericStakingPoolFormatter.tsx
@@ -69,7 +69,7 @@ const rawHeader: (
     tooltip: {
       title: "APY",
       description:
-        "Your total APY for the pool, including the pool APY plus rewards APY times your multiplier. Max APY is the maximum APY after you have staked your LP tokens for 100 days.",
+        "Your total APY for the pool, including the pool APY plus rewards APR times your multiplier. Max APY is the maximum APY after you have staked your LP tokens for 100 days.",
     },
   },
   {

--- a/src/views/Staking/components/StakingForm/StakingForm.tsx
+++ b/src/views/Staking/components/StakingForm/StakingForm.tsx
@@ -251,10 +251,10 @@ export const StakingForm = ({
             <Divider />
             <StakeInfoRow>
               <StakeInfoItem>
-                Rewards APY{" "}
+                Rewards APY
                 <PopperTooltip
                   title="Rewards APY"
-                  body="The base reward APY times your multiplier."
+                  body="The base reward APR times your multiplier."
                   placement="bottom-start"
                 >
                   <InfoIcon />

--- a/src/views/Staking/components/StakingForm/StakingForm.tsx
+++ b/src/views/Staking/components/StakingForm/StakingForm.tsx
@@ -231,8 +231,8 @@ export const StakingForm = ({
                 <ArrowIcon />
                 APY
                 <PopperTooltip
-                  title="APY"
-                  body="Your total APY for the pool, including the pool APY plus rewards APY times your multiplier. Max APY is the maximum APY after you have staked your LP tokens for 100 days."
+                  title="Rewards APR"
+                  body="Your total APY for the pool, including the pool APY plus rewards APR times your multiplier. Max APY is the maximum APY after you have staked your LP tokens for 100 days."
                   placement="bottom-start"
                 >
                   <InfoIcon />


### PR DESCRIPTION
This change introduces the following change: 

- On the rewards page, pools table(s) on APY column
    - In the tool tip, update to "…including the pool APY plus rewards APR times…"

- On the staking page
    - Update label to "Rewards APR"
    - In the APY tooltip, update to "…plus rewards APR…"
    - In the rewards apy tooltip, update to "…base reward APR times…"

