### PR TITLE
test: enable per-route capital fee config

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -7,8 +7,8 @@ export const disabledL1Tokens = [
   constants.TOKEN_SYMBOLS_MAP.BADGER.addresses[constants.CHAIN_IDs.MAINNET],
 ].map((x) => x.toLowerCase());
 
-export const relayerFeeCapitalCostConfig: {
-  [token: string]: relayFeeCalculator.RelayCapitalCostConfig;
+const defaultRelayerFeeCapitalCostConfig: {
+  [token: string]: relayFeeCalculator.CapitalCostConfig;
 } = {
   ETH: {
     lowerBound: ethers.utils.parseUnits("0.0001").toString(),
@@ -35,30 +35,10 @@ export const relayerFeeCapitalCostConfig: {
     decimals: 18,
   },
   USDC: {
-    default: {
-      lowerBound: ethers.utils.parseUnits("0.0001").toString(),
-      upperBound: ethers.utils.parseUnits("0.0001").toString(),
-      cutoff: ethers.utils.parseUnits("1500000").toString(),
-      decimals: 6,
-    },
-    routeOverrides: {
-      "10": {
-        "42161": {
-          lowerBound: ethers.utils.parseUnits("0").toString(),
-          upperBound: ethers.utils.parseUnits("0").toString(),
-          cutoff: ethers.utils.parseUnits("0").toString(),
-          decimals: 6,
-        },
-      },
-      "42161": {
-        "10": {
-          lowerBound: ethers.utils.parseUnits("0").toString(),
-          upperBound: ethers.utils.parseUnits("0").toString(),
-          cutoff: ethers.utils.parseUnits("0").toString(),
-          decimals: 6,
-        },
-      },
-    },
+    lowerBound: ethers.utils.parseUnits("0.0001").toString(),
+    upperBound: ethers.utils.parseUnits("0.0001").toString(),
+    cutoff: ethers.utils.parseUnits("1500000").toString(),
+    decimals: 6,
   },
   UMA: {
     lowerBound: ethers.utils.parseUnits("0.0003").toString(),
@@ -79,6 +59,29 @@ export const relayerFeeCapitalCostConfig: {
     decimals: 18,
   },
 };
+
+const relayerFeeCapitalCostOverrides: Record<
+  string,
+  Record<string, Record<string, relayFeeCalculator.CapitalCostConfig>>
+> = process.env.RELAYER_FEE_CAPITAL_COST_OVERRIDES
+  ? JSON.parse(process.env.RELAYER_FEE_CAPITAL_COST_OVERRIDES)
+  : {};
+
+export const relayerFeeCapitalCostConfig: {
+  [token: string]: relayFeeCalculator.RelayCapitalCostConfig;
+} = Object.fromEntries(
+  Object.keys(defaultRelayerFeeCapitalCostConfig).map(
+    (token): [string, relayFeeCalculator.CapitalCostConfigOverride] => {
+      return [
+        token,
+        {
+          default: defaultRelayerFeeCapitalCostConfig[token],
+          routeOverrides: relayerFeeCapitalCostOverrides[token] || {},
+        },
+      ];
+    }
+  )
+);
 
 // If `timestamp` is not passed into a suggested-fees query, then return the latest mainnet timestamp minus this buffer.
 export const DEFAULT_QUOTE_TIMESTAMP_BUFFER = 12 * 25; // ~25 blocks on mainnet (12s/block), ~= 5 minutes.

--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import { constants } from "@across-protocol/sdk-v2";
+import { constants, relayFeeCalculator } from "@across-protocol/sdk-v2";
 
 export const maxRelayFeePct = 0.25;
 
@@ -7,7 +7,9 @@ export const disabledL1Tokens = [
   constants.TOKEN_SYMBOLS_MAP.BADGER.addresses[constants.CHAIN_IDs.MAINNET],
 ].map((x) => x.toLowerCase());
 
-export const relayerFeeCapitalCostConfig = {
+export const relayerFeeCapitalCostConfig: {
+  [token: string]: relayFeeCalculator.RelayCapitalCostConfig;
+} = {
   ETH: {
     lowerBound: ethers.utils.parseUnits("0.0001").toString(),
     upperBound: ethers.utils.parseUnits("0.0001").toString(),
@@ -33,10 +35,30 @@ export const relayerFeeCapitalCostConfig = {
     decimals: 18,
   },
   USDC: {
-    lowerBound: ethers.utils.parseUnits("0.0001").toString(),
-    upperBound: ethers.utils.parseUnits("0.0001").toString(),
-    cutoff: ethers.utils.parseUnits("1500000").toString(),
-    decimals: 6,
+    default: {
+      lowerBound: ethers.utils.parseUnits("0.0001").toString(),
+      upperBound: ethers.utils.parseUnits("0.0001").toString(),
+      cutoff: ethers.utils.parseUnits("1500000").toString(),
+      decimals: 6,
+    },
+    routeOverrides: {
+      "10": {
+        "42161": {
+          lowerBound: ethers.utils.parseUnits("0").toString(),
+          upperBound: ethers.utils.parseUnits("0").toString(),
+          cutoff: ethers.utils.parseUnits("0").toString(),
+          decimals: 6,
+        },
+      },
+      "42161": {
+        "10": {
+          lowerBound: ethers.utils.parseUnits("0").toString(),
+          upperBound: ethers.utils.parseUnits("0").toString(),
+          cutoff: ethers.utils.parseUnits("0").toString(),
+          decimals: 6,
+        },
+      },
+    },
   },
   UMA: {
     lowerBound: ethers.utils.parseUnits("0.0003").toString(),

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -420,12 +420,19 @@ export const getTokenSymbol = (tokenAddress: string): string => {
 export const getRelayerFeeDetails = (
   l1Token: string,
   amount: sdk.utils.BigNumberish,
+  originChainId: number,
   destinationChainId: number,
   tokenPrice?: number
 ): Promise<sdk.relayFeeCalculator.RelayerFeeDetails> => {
   const tokenSymbol = getTokenSymbol(l1Token);
   const relayFeeCalculator = getRelayerFeeCalculator(destinationChainId);
-  return relayFeeCalculator.relayerFeeDetails(amount, tokenSymbol, tokenPrice);
+  return relayFeeCalculator.relayerFeeDetails(
+    amount,
+    tokenSymbol,
+    tokenPrice,
+    originChainId?.toString(),
+    destinationChainId.toString()
+  );
 };
 
 /**

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -147,6 +147,7 @@ const handler = async (
         l1Token,
         ethers.BigNumber.from("10").pow(18),
         Number(destinationChainId),
+        computedOriginChainId,
         tokenPriceNative
       ),
       hubPool.callStatic.multicall(multicallInput, { blockTag: BLOCK_TAG_LAG }),

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -128,6 +128,7 @@ const handler = async (
     const relayerFeeDetails = await getRelayerFeeDetails(
       l1Token,
       amount,
+      computedOriginChainId,
       Number(destinationChainId),
       tokenPrice
     );

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@across-protocol/across-token": "^0.0.2",
     "@across-protocol/contracts-v2": "^1.0.7",
-    "@across-protocol/sdk-v2": "^0.3.7",
+    "@across-protocol/sdk-v2": "^0.4.1",
     "@amplitude/analytics-browser": "^1.6.6",
     "@amplitude/marketing-analytics-browser": "^0.3.6",
     "@datapunt/matomo-tracker-js": "^0.5.1",

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -1,22 +1,14 @@
 import assert from "assert";
 import { clients, utils, BlockFinder } from "@uma/sdk";
-import {
-  relayFeeCalculator,
-  lpFeeCalculator,
-  contracts,
-  constants,
-} from "@across-protocol/sdk-v2";
+import { lpFeeCalculator, contracts, constants } from "@across-protocol/sdk-v2";
 import { Provider, Block } from "@ethersproject/providers";
 import { ethers, BigNumber } from "ethers";
 
 import {
-  MAX_RELAY_FEE_PERCENT,
   ChainId,
   hubPoolChainId,
   hubPoolAddress,
   getConfigStoreAddress,
-  queriesTable,
-  FLAT_RELAY_CAPITAL_FEE,
   referrerDelimiterHex,
   usdcLpCushion,
   wethLpCushion,
@@ -456,23 +448,4 @@ export default class LpFeeCalculator {
     ]);
     return calculateRealizedLpFeePct(rateModel, currentUt, nextUt);
   }
-}
-
-export function relayFeeCalculatorConfig(
-  chainId: ChainId
-): relayFeeCalculator.RelayFeeCalculatorConfig {
-  const config = getConfig();
-  const provider = getProvider(chainId);
-  const token = config.getNativeTokenInfo(chainId);
-
-  if (!queriesTable[chainId])
-    throw new Error(`No queries in queriesTable for chainId ${chainId}!`);
-
-  const queries = queriesTable[chainId](provider);
-  return {
-    nativeTokenDecimals: token.decimals,
-    feeLimitPercent: MAX_RELAY_FEE_PERCENT,
-    capitalCostsPercent: FLAT_RELAY_CAPITAL_FEE,
-    queries,
-  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,10 +58,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@^0.3.7":
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.3.7.tgz#69d648a199cf7e3f5af24ee8fed03f53d739bbce"
-  integrity sha512-Y6hlQH9u54I5XX4Tc7us6IEeq+vvyGG/KNF/kjOFSBhfSrBaPk8H18fcRlGeID64905rScWyTWmN3ZuIWpt+WQ==
+"@across-protocol/sdk-v2@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.4.1.tgz#41daf7342d887b4923915857c6c8e80cad7f3a36"
+  integrity sha512-wkghEVdsBKW1t+RBsUhoPD99TtkyR19LmNqXGpKh7e+rnlDojaYuzdMcp8wOrKli+RfRex/pYozDhOQYZ4KWzA==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/contracts-v2" "^2.0.1"


### PR DESCRIPTION
This test enables a capital fee override for USDC between its Optimism <> Arbitrum route.