### PR TITLE
fix: :ambulance: remove gas fee from bridge fees

### DIFF
--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -21,14 +21,11 @@ export function receiveAmount(
   deductionsSansRelayerGas: BigNumber;
   receivable: BigNumber;
 } {
-  const deductions = fees.relayerFee.total
-    .add(fees.lpFee.total)
-    .add(fees.relayerGasFee.total);
-
+  const deductions = fees.relayerFee.total.add(fees.lpFee.total);
   return {
     receivable: max(amount.sub(deductions), 0),
     deductions,
-    deductionsSansRelayerGas: deductions.sub(fees.relayerGasFee.total.mul(2)),
+    deductionsSansRelayerGas: deductions.sub(fees.relayerGasFee.total),
   };
 }
 

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -28,7 +28,7 @@ export function receiveAmount(
   return {
     receivable: max(amount.sub(deductions), 0),
     deductions,
-    deductionsSansRelayerGas: deductions.sub(fees.relayerGasFee.total),
+    deductionsSansRelayerGas: deductions.sub(fees.relayerGasFee.total.mul(2)),
   };
 }
 


### PR DESCRIPTION
## Motivation
Currently, the `fees.relayerGasFee` is included in the calculation of the true bridge fee. However, this approach doesn't accurately represent the actual fee charged to users. 

## Result
After removing the inclusion of `fees.relayerGasFee` from the calculation of the true bridge fee, users will have a more accurate representation of the actual fee charged. This will improve transparency and provide a better user experience. 