### PR TITLE
improve: properly set AllAssetsAllNetworksWalletCurrentBalanceUsd

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,6 @@ if (amplitudeAPIKey) {
   });
   ampli.load({
     client: { instance },
-    environment: isProductionBuild ? "production" : "development",
   });
 }
 // Record an event when the application is loaded

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ if (amplitudeAPIKey) {
   });
   ampli.load({
     client: { instance },
+    environment: isProductionBuild ? "production" : "development",
   });
 }
 // Record an event when the application is loaded

--- a/src/components/WalletBalanceTrace/useWalletBalanceTrace.ts
+++ b/src/components/WalletBalanceTrace/useWalletBalanceTrace.ts
@@ -1,6 +1,6 @@
 import { BigNumber, utils } from "ethers";
 import { useConnection } from "hooks";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import {
   ChainId,
   fixedPointAdjustment,
@@ -17,96 +17,112 @@ import Sentry from "utils/sentry";
 
 export function useWalletBalanceTrace() {
   const { account, isConnected } = useConnection();
+  const [recordingSuccessful, setRecordingSuccessful] = useState(false);
+
+  // While setRecordingSuccessful is false, attempt to record the wallet balance every 30 seconds
   useEffect(() => {
-    if (account && isConnected) {
-      calculateUsdBalances(account)
-        .then((balance) => {
-          reportTotalWalletUsdBalance(balance);
-        })
-        .catch((e) => {
-          console.error("Failed to fetch balances:", e);
-          Sentry.captureException(e);
-        });
-    }
+    const interval =
+      account && isConnected && !recordingSuccessful
+        ? setInterval(() => {
+            calculateUsdBalances(account)
+              .then((balance) => {
+                reportTotalWalletUsdBalance(balance);
+                setRecordingSuccessful(true);
+              })
+              .catch((e) => {
+                console.error("Failed to fetch balances:", e);
+                Sentry.captureException(e);
+              });
+          }, 30000)
+        : undefined;
+    return () => clearInterval(interval);
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [account, recordingSuccessful]);
+
+  // Reset the recordingSuccessful state whenever the account changes
+  useEffect(() => {
+    setRecordingSuccessful(false);
   }, [account]);
-}
 
-type TokenSymbolAddressType = {
-  fromTokenSymbol: string;
-  fromTokenAddress: string;
-};
-const availableTokens: Record<number, TokenSymbolAddressType[]> = getRoutes(
-  getConfig().getHubPoolChainId()
-).routes.reduce((acc, route) => {
-  const { fromChain, fromTokenSymbol, fromTokenAddress } = route;
-  const payload = { fromTokenSymbol, fromTokenAddress };
+  type TokenSymbolAddressType = {
+    fromTokenSymbol: string;
+    fromTokenAddress: string;
+  };
+  const availableTokens: Record<number, TokenSymbolAddressType[]> = getRoutes(
+    getConfig().getHubPoolChainId()
+  ).routes.reduce((acc, route) => {
+    const { fromChain, fromTokenSymbol, fromTokenAddress } = route;
+    const payload = { fromTokenSymbol, fromTokenAddress };
 
-  if (!acc[fromChain]?.some((t) => t.fromTokenAddress === fromTokenAddress)) {
-    acc[fromChain] = [...(acc[fromChain] ?? []), payload];
-  }
-  return acc;
-}, {} as Record<number, TokenSymbolAddressType[]>);
+    if (!acc[fromChain]?.some((t) => t.fromTokenAddress === fromTokenAddress)) {
+      acc[fromChain] = [...(acc[fromChain] ?? []), payload];
+    }
+    return acc;
+  }, {} as Record<number, TokenSymbolAddressType[]>);
 
-const availableSymbols = [
-  ...new Set(getRoutes(ChainId.MAINNET).routes.map((r) => r.fromTokenSymbol)),
-];
+  const availableSymbols = [
+    ...new Set(getRoutes(ChainId.MAINNET).routes.map((r) => r.fromTokenSymbol)),
+  ];
 
-const calculateUsdBalances = async (account: string) => {
-  const coingeckoPrices = await Promise.all(
-    availableSymbols.map((symbol) =>
-      getApiEndpoint().coingecko(getToken(symbol).mainnetAddress!, "usd")
-    )
-  );
-  const usdPrices: Record<string, BigNumber> = coingeckoPrices.reduce(
-    (acc, { price }, i) => {
-      return { ...acc, [availableSymbols[i]]: price };
-    },
-    {}
-  );
-
-  const balances = (
-    await Promise.all(
-      Object.entries(availableTokens).flatMap(async ([chainId, tokens]) => {
-        const promises = tokens.map(
-          async ({ fromTokenSymbol, fromTokenAddress }) => ({
-            fromTokenSymbol,
-            fromTokenAddress,
-            balance: await getBalance(
-              Number(chainId),
-              account,
-              fromTokenAddress
-            ),
-          })
-        );
-        if (chainId !== "137") {
-          const fn = async () => {
-            return {
-              fromTokenSymbol: "ETH",
-              fromTokenAddress: "0x0000000000000000000000000000000000000000",
-              balance: await getNativeBalance(Number(chainId), account),
-            };
-          };
-          promises.push(fn());
-        }
-        return await Promise.all(promises);
-      })
-    )
-  ).flat(2);
-
-  const totalBalance = balances.reduce((acc, { fromTokenSymbol, balance }) => {
-    const token = getToken(fromTokenSymbol);
-    const usdPrice = usdPrices[fromTokenSymbol];
-    const usdBalance = Number(
-      utils.formatUnits(
-        usdPrice
-          .mul(ConvertDecimals(token.decimals, 18)(balance))
-          .div(fixedPointAdjustment),
-        18
+  const calculateUsdBalances = async (account: string) => {
+    const coingeckoPrices = await Promise.all(
+      availableSymbols.map((symbol) =>
+        getApiEndpoint().coingecko(getToken(symbol).mainnetAddress!, "usd")
       )
     );
-    return acc + usdBalance;
-  }, 0);
+    const usdPrices: Record<string, BigNumber> = coingeckoPrices.reduce(
+      (acc, { price }, i) => {
+        return { ...acc, [availableSymbols[i]]: price };
+      },
+      {}
+    );
 
-  return totalBalance;
-};
+    const balances = (
+      await Promise.all(
+        Object.entries(availableTokens).flatMap(async ([chainId, tokens]) => {
+          const promises = tokens.map(
+            async ({ fromTokenSymbol, fromTokenAddress }) => ({
+              fromTokenSymbol,
+              fromTokenAddress,
+              balance: await getBalance(
+                Number(chainId),
+                account,
+                fromTokenAddress
+              ),
+            })
+          );
+          if (chainId !== "137") {
+            const fn = async () => {
+              return {
+                fromTokenSymbol: "ETH",
+                fromTokenAddress: "0x0000000000000000000000000000000000000000",
+                balance: await getNativeBalance(Number(chainId), account),
+              };
+            };
+            promises.push(fn());
+          }
+          return await Promise.all(promises);
+        })
+      )
+    ).flat(2);
+
+    const totalBalance = balances.reduce(
+      (acc, { fromTokenSymbol, balance }) => {
+        const token = getToken(fromTokenSymbol);
+        const usdPrice = usdPrices[fromTokenSymbol];
+        const usdBalance = Number(
+          utils.formatUnits(
+            usdPrice
+              .mul(ConvertDecimals(token.decimals, 18)(balance))
+              .div(fixedPointAdjustment),
+            18
+          )
+        );
+        return acc + usdBalance;
+      },
+      0
+    );
+
+    return totalBalance;
+  };
+}

--- a/src/components/WalletBalanceTrace/useWalletBalanceTrace.ts
+++ b/src/components/WalletBalanceTrace/useWalletBalanceTrace.ts
@@ -12,7 +12,6 @@ import {
 } from "utils";
 import { ConvertDecimals } from "utils/convertdecimals";
 import getApiEndpoint from "utils/serverless-api";
-import Sentry from "utils/sentry";
 import { useQuery } from "react-query";
 
 export function useWalletBalanceTrace() {
@@ -22,15 +21,9 @@ export function useWalletBalanceTrace() {
     ["wallet-balance", account ?? "loading"],
     async () => {
       if (!account) return;
-      try {
-        const balance = await calculateUsdBalances(account);
-        reportTotalWalletUsdBalance(balance);
-        return balance;
-      } catch (e) {
-        console.error("Failed to fetch balances:", e);
-        Sentry.captureException(e);
-        throw e; // Throw the error so that react-query can retry
-      }
+      const balance = await calculateUsdBalances(account);
+      reportTotalWalletUsdBalance(balance);
+      return balance;
     },
     {
       refetchOnWindowFocus: false,


### PR DESCRIPTION
## Motivation
During regular FE execution, the `AllAssetsAllNetworksWalletCurrentBalanceUsd` user property was not being correctly set. This error was caused by commit [`3c21999`](https://github.com/across-protocol/frontend-v2/commit/3c2199935fed0ea9f2d13d61a3aef0c7b21ca9fe), which removed the environment attribute for amplitude, leading to the incorrect setting of the user property.

Additionally, this PR also contains logic to retry the `AllAssetsAllNetworksWalletCurrentBalanceUsd` instrumentation every 30 seconds during a user's session until uploaded.