### PR TITLE
feat: :sparkles: add per-route lp cushions

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -83,6 +83,25 @@ export const relayerFeeCapitalCostConfig: {
   )
 );
 
+/**
+ * The cushion applied to the total available liquidity when calculating the max amount of a token to relay.
+ * This is to account for slippage and other factors that may cause the relay to fail.
+ * This map takes the following format:
+ * {
+ *    "DAI": "100000",
+ *    "DAI:1:10": "100001",
+ * }
+ * The key is the token symbol, and the value is the cushion in wei. If the key is a token symbol followed by a colon,
+ * followed by an origin chain ID, followed by a colon, followed by a destination chain ID, then the cushion will only
+ * apply to that specific route. For example, the key "DAI:1:10" will only apply to the DAI route from mainnet to
+ * optimism.
+ */
+export const lpCushionMap: {
+  [symbol: string]: string;
+} = process.env.REACT_APP_LP_CUSHION_MAP
+  ? JSON.parse(process.env.REACT_APP_LP_CUSHION_MAP)
+  : {};
+
 // If `timestamp` is not passed into a suggested-fees query, then return the latest mainnet timestamp minus this buffer.
 export const DEFAULT_QUOTE_TIMESTAMP_BUFFER = 12 * 25; // ~25 blocks on mainnet (12s/block), ~= 5 minutes.
 

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -12,7 +12,11 @@ import { define, StructError } from "superstruct";
 import enabledMainnetRoutesAsJson from "../src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json";
 import enabledGoerliRoutesAsJson from "../src/data/routes_5_0xA44A832B994f796452e4FaF191a041F791AD8A0A.json";
 
-import { maxRelayFeePct, relayerFeeCapitalCostConfig } from "./_constants";
+import {
+  lpCushionMap,
+  maxRelayFeePct,
+  relayerFeeCapitalCostConfig,
+} from "./_constants";
 import { StaticJsonRpcProvider } from "@ethersproject/providers";
 import QueryBase from "@across-protocol/sdk-v2/dist/relayFeeCalculator/chain-queries/baseQuery";
 import { VercelResponse } from "@vercel/node";
@@ -667,4 +671,21 @@ export function boolStr() {
   return define<string>("boolStr", (value) => {
     return value === "true" || value === "false";
   });
+}
+
+/**
+ * Returns the cushion for a given token symbol and route. If no route is specified, the cushion for the token symbol
+ * @param symbol The token symbol
+ * @param fromChainId The origin chain ID
+ * @param toChainId The destination chain ID
+ * @returns The cushion in wei
+ */
+export function getLpCushion(
+  symbol: string,
+  fromChainId?: number,
+  toChainId?: number
+) {
+  const key = `${symbol}:${fromChainId}:${toChainId}`;
+  if (lpCushionMap[key]) return lpCushionMap[key];
+  return lpCushionMap[symbol] ?? "0";
 }

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -23,6 +23,7 @@ import {
   handleErrorCondition,
   validAddress,
   positiveIntStr,
+  getLpCushion,
 } from "./_utils";
 
 const LimitsQueryParamsSchema = object({
@@ -191,7 +192,7 @@ const handler = async (
     );
 
     const lpCushion = ethers.utils.parseUnits(
-      process.env[`REACT_APP_${symbol}_LP_CUSHION`] ?? "0",
+      getLpCushion(symbol, computedOriginChainId, Number(destinationChainId)),
       tokenDetails.decimals
     );
     liquidReserves = liquidReserves.sub(lpCushion);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -272,7 +272,6 @@ export class ConfigClient {
         ];
       }
     );
-    console.log(exclusivePools);
     return [...this.getTokenList(chainId), ...exclusivePools];
   }
   // this has a chance to mix up eth/weth which can be a problem. prefer token by symbol.

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -444,6 +444,19 @@ export const getToken = (symbol: string): TokenInfo => {
   return token;
 };
 
+/**
+ * Resolves a token by address. This is useful for tokens that have multiple addresses on different chains.
+ * @param address An address of a token
+ * @returns The token info for the token with the given address
+ */
+export const getTokenByAddress = (address: string): TokenInfo => {
+  const token = Object.values(constants.TOKEN_SYMBOLS_MAP).find((token) =>
+    Object.values(token.addresses).includes(address)
+  );
+  assert(token, "No token found for address: " + address);
+  return getToken(token.symbol);
+};
+
 const RouteSS = superstruct.object({
   fromChain: superstruct.number(),
   toChain: superstruct.number(),
@@ -583,13 +596,24 @@ export const queriesTable = getQueriesTable();
 
 export const referrerDelimiterHex = "0xd00dfeeddeadbeef";
 
-export const usdcLpCushion = process.env.REACT_APP_USDC_LP_CUSHION || "0";
-export const wethLpCushion = process.env.REACT_APP_WETH_LP_CUSHION || "0";
-export const wbtcLpCushion = process.env.REACT_APP_WBTC_LP_CUSHION || "0";
-export const daiLpCushion = process.env.REACT_APP_DAI_LP_CUSHION || "0";
-export const balLpCushion = process.env.REACT_APP_BAL_LP_CUSHION || "0";
-export const umaLpCushion = process.env.REACT_APP_UMA_LP_CUSHION || "0";
-export const bobaLpCushion = process.env.REACT_APP_BOBA_LP_CUSHION || "0";
+/**
+ * The cushion applied to the total available liquidity when calculating the max amount of a token to relay.
+ * This is to account for slippage and other factors that may cause the relay to fail.
+ * This map takes the following format:
+ * {
+ *    "DAI": "100000",
+ *    "DAI:1:10": "100001",
+ * }
+ * The key is the token symbol, and the value is the cushion in wei. If the key is a token symbol followed by a colon,
+ * followed by an origin chain ID, followed by a colon, followed by a destination chain ID, then the cushion will only
+ * apply to that specific route. For example, the key "DAI:1:10" will only apply to the DAI route from mainnet to
+ * optimism.
+ */
+export const lpCushionMap: {
+  [symbol: string]: string;
+} = process.env.REACT_APP_LP_CUSHION_MAP
+  ? JSON.parse(process.env.REACT_APP_LP_CUSHION_MAP)
+  : {};
 
 export function stringValueInArray(value: string, arr: string[]) {
   return arr.indexOf(value) !== -1;

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,6 +1,7 @@
 import type { BridgeFees } from "./bridge";
 import { BigNumber, BigNumberish } from "ethers";
 import { isNumberEthersParseable } from "./format";
+import { lpCushionMap } from "./constants";
 
 export function max(a: BigNumberish, b: BigNumberish) {
   if (BigNumber.from(a).gte(b)) return BigNumber.from(a);
@@ -94,4 +95,21 @@ export function categorizeNumberInRange(
     }
   }
   return `>${boundry[boundry.length - 1]}`;
+}
+
+/**
+ * Returns the cushion for a given token symbol and route. If no route is specified, the cushion for the token symbol
+ * @param symbol The token symbol
+ * @param fromChainId The origin chain ID
+ * @param toChainId The destination chain ID
+ * @returns The cushion in wei
+ */
+export function getLpCushion(
+  symbol: string,
+  fromChainId?: number,
+  toChainId?: number
+) {
+  const key = `${symbol}:${fromChainId}:${toChainId}`;
+  if (lpCushionMap[key]) return lpCushionMap[key];
+  return lpCushionMap[symbol] ?? "0";
 }


### PR DESCRIPTION
This change adds per-route LP cushions. Additionally, this PR simplifies the logic in how we resolve, compute, and act on any given LP cushion.

Breaking Changes: The ENV variables will need to be modified to include a single `REACT_APP_LP_CUSHION_MAP` variable which replaces all other LP Cushion variables.