### PR TITLE
improve(api): Set quoteTimestamps equal to nearest minute

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -86,6 +86,10 @@ export const relayerFeeCapitalCostConfig: {
 // If `timestamp` is not passed into a suggested-fees query, then return the latest mainnet timestamp minus this buffer.
 export const DEFAULT_QUOTE_TIMESTAMP_BUFFER = 12 * 25; // ~25 blocks on mainnet (12s/block), ~= 5 minutes.
 
+// If `timestamp` is not passed into a suggested-fees query, then return the latest price rounded to
+// the nearest multiple of this value.
+export const DEFAULT_QUOTE_TIMESTAMP_PRECISION = 5 * 60; // 5 minutes
+
 export const BLOCK_TAG_LAG = -1;
 
 // Note: this is a small subset of all the supported base currencies, but since we don't expect to use the others,

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -77,14 +77,14 @@ const handler = async (
       ? Number(timestamp)
       : (await provider.getBlock("latest")).timestamp - quoteTimeBuffer;
 
-    // Round timestamp to nearest minute. Assuming that depositors use this timestamp as the `quoteTimestamp` will allow relayers
+    // Round timestamp. Assuming that depositors use this timestamp as the `quoteTimestamp` will allow relayers
     // to take advantage of cached block-for-timestamp values when computing LP fee %'s. Currently the relayer is assumed
     // to first find the block for deposit's `quoteTimestamp` and then call `HubPool#liquidityUtilization` at that block
     // height to derive the LP fee. The expensive operation is finding a block for a timestamp and involves a binary search.
     // We can use rounding here to increase the chance that a deposit's quote timestamp is re-used, thereby
     // allowing relayers hit the cache more often when fetching a block for a timestamp.
-    // Divide by 60 seconds, round down to nearest integer, multiply by 60 seconds.
-    const parsedTimestamp = Math.floor(_parsedTimestamp / 60) * 60;
+    // Divide by intended precision in seconds, round down to nearest integer, multiply by precision in seconds.
+    const parsedTimestamp = Math.floor(_parsedTimestamp / 300) * 300;
 
     const amount = ethers.BigNumber.from(amountInput);
 

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -73,9 +73,18 @@ const handler = async (
     // older than HEAD. This is to improve relayer UX who have heightened risk of sending inadvertent invalid
     // fills for quote times right at HEAD (or worst, in the future of HEAD). If timestamp is supplied as a query param,
     // then no need to apply buffer.
-    const parsedTimestamp = timestamp
+    const _parsedTimestamp = timestamp
       ? Number(timestamp)
       : (await provider.getBlock("latest")).timestamp - quoteTimeBuffer;
+    
+    // Round timestamp to nearest minute. Assuming that depositors use this timestamp as the `quoteTimestamp` will allow relayers
+    // to take advantage of cached block-for-timestamp values when computing LP fee %'s. Currently the relayer is assumed
+    // to first find the block for deposit's `quoteTimestamp` and then call `HubPool#liquidityUtilization` at that block
+    // height to derive the LP fee. The expensive operation is finding a block for a timestamp and involves a binary search.
+    // We can use rounding here to increase the chance that a deposit's quote timestamp is re-used, thereby
+    // allowing relayers hit the cache more often when fetching a block for a timestamp.
+    // Divide by 60 seconds, round down to nearest integer, multiply by 60 seconds.
+    const parsedTimestamp = Math.floor(_parsedTimestamp / (60 * 1000)) * 60 * 1000;
 
     const amount = ethers.BigNumber.from(amountInput);
 

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -45,7 +45,7 @@ const handler = async (
     query,
   });
   try {
-    const { QUOTE_TIMESTAMP_BUFFER } = process.env;
+    const { QUOTE_TIMESTAMP_BUFFER, QUOTE_TIMESTAMP_PRECISION } = process.env;
     const quoteTimeBuffer = QUOTE_TIMESTAMP_BUFFER
       ? Number(QUOTE_TIMESTAMP_BUFFER)
       : DEFAULT_QUOTE_TIMESTAMP_BUFFER;
@@ -84,7 +84,11 @@ const handler = async (
     // We can use rounding here to increase the chance that a deposit's quote timestamp is re-used, thereby
     // allowing relayers hit the cache more often when fetching a block for a timestamp.
     // Divide by intended precision in seconds, round down to nearest integer, multiply by precision in seconds.
-    const parsedTimestamp = Math.floor(_parsedTimestamp / 300) * 300;
+    const precision = QUOTE_TIMESTAMP_PRECISION
+      ? Number(QUOTE_TIMESTAMP_PRECISION)
+      : DEFAULT_QUOTE_TIMESTAMP_BUFFER;
+    const parsedTimestamp =
+      Math.floor(_parsedTimestamp / precision) * precision;
 
     const amount = ethers.BigNumber.from(amountInput);
 

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -84,8 +84,7 @@ const handler = async (
     // We can use rounding here to increase the chance that a deposit's quote timestamp is re-used, thereby
     // allowing relayers hit the cache more often when fetching a block for a timestamp.
     // Divide by 60 seconds, round down to nearest integer, multiply by 60 seconds.
-    const parsedTimestamp =
-      Math.floor(_parsedTimestamp / (60 * 1000)) * 60 * 1000;
+    const parsedTimestamp = Math.floor(_parsedTimestamp / 60) * 60;
 
     const amount = ethers.BigNumber.from(amountInput);
 

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -76,7 +76,7 @@ const handler = async (
     const _parsedTimestamp = timestamp
       ? Number(timestamp)
       : (await provider.getBlock("latest")).timestamp - quoteTimeBuffer;
-    
+
     // Round timestamp to nearest minute. Assuming that depositors use this timestamp as the `quoteTimestamp` will allow relayers
     // to take advantage of cached block-for-timestamp values when computing LP fee %'s. Currently the relayer is assumed
     // to first find the block for deposit's `quoteTimestamp` and then call `HubPool#liquidityUtilization` at that block
@@ -84,7 +84,8 @@ const handler = async (
     // We can use rounding here to increase the chance that a deposit's quote timestamp is re-used, thereby
     // allowing relayers hit the cache more often when fetching a block for a timestamp.
     // Divide by 60 seconds, round down to nearest integer, multiply by 60 seconds.
-    const parsedTimestamp = Math.floor(_parsedTimestamp / (60 * 1000)) * 60 * 1000;
+    const parsedTimestamp =
+      Math.floor(_parsedTimestamp / (60 * 1000)) * 60 * 1000;
 
     const amount = ethers.BigNumber.from(amountInput);
 


### PR DESCRIPTION
This should allow relayers to hit the cache more often when computing realized LP fees

1 minute of error in quote time also seems like it would have zero impact on realized LP fees charged to deposits

UPDATE: We may want to decrease the precision and use something like every 5 minutes, every 2 minutes