### PR TITLE
perf: improve tree-shaking typechain

### DIFF
--- a/src/hooks/useApprove.ts
+++ b/src/hooks/useApprove.ts
@@ -1,9 +1,9 @@
 import { useConnection } from "hooks";
 import { useMutation } from "react-query";
 import { BigNumberish } from "ethers";
-import { ERC20__factory } from "@across-protocol/contracts-v2";
 
 import { hubPoolChainId, MAX_APPROVAL_AMOUNT, waitOnTransaction } from "utils";
+import { ERC20__factory } from "utils/typechain";
 import { useIsWrongNetwork } from "hooks";
 
 export function useApprove(requiredChainId = hubPoolChainId) {

--- a/src/hooks/useStakingPool.ts
+++ b/src/hooks/useStakingPool.ts
@@ -16,11 +16,11 @@ import {
   defaultRefetchInterval,
 } from "utils";
 import { BigNumber, BigNumberish } from "ethers";
-import { ERC20__factory } from "@across-protocol/contracts-v2";
 import axios from "axios";
 import { ConvertDecimals } from "utils/convertdecimals";
 import { useCoingeckoPrice } from "./useCoingeckoPrice";
 import getApiEndpoint from "utils/serverless-api";
+import { ERC20__factory } from "utils/typechain";
 
 const config = getConfig();
 

--- a/src/hooks/useWalletTokenImport.ts
+++ b/src/hooks/useWalletTokenImport.ts
@@ -1,6 +1,8 @@
-import { ERC20__factory } from "@across-protocol/contracts-v2";
 import { providers } from "ethers";
 import { useCallback } from "react";
+
+import { ERC20__factory } from "utils/typechain";
+
 import { useConnection } from "./useConnection";
 
 export function useWalletTokenImport() {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -2,6 +2,9 @@ import assert from "assert";
 import { Signer } from "./ethers";
 import * as constants from "./constants";
 import * as providerUtils from "./providers";
+import filter from "lodash/filter";
+import sortBy from "lodash/sortBy";
+
 import {
   HubPool,
   HubPool__factory,
@@ -9,15 +12,11 @@ import {
   SpokePool__factory,
   AcrossMerkleDistributor,
   AcrossMerkleDistributor__factory,
-} from "@across-protocol/contracts-v2";
-import filter from "lodash/filter";
-import sortBy from "lodash/sortBy";
-import {
   AcceleratingDistributor,
   AcceleratingDistributor__factory,
   ClaimAndStake,
   ClaimAndStake__factory,
-} from "@across-protocol/across-token";
+} from "utils/typechain";
 
 export type Token = constants.TokenInfo & {
   l1TokenAddress: string;

--- a/src/utils/pool.ts
+++ b/src/utils/pool.ts
@@ -1,5 +1,5 @@
 import { ethers, Signer, BigNumberish, BigNumber } from "ethers";
-import * as acrossSdk from "@across-protocol/sdk-v2";
+import { pool } from "@across-protocol/sdk-v2";
 
 import {
   getConfigStoreAddress,
@@ -75,7 +75,7 @@ export async function estimateGasForAddEthLiquidity(
   return estimateGas(gas, gasPrice, GAS_PRICE_BUFFER);
 }
 
-export function makePoolClientConfig(chainId: ChainId): acrossSdk.pool.Config {
+export function makePoolClientConfig(chainId: ChainId): pool.Config {
   const config = getConfig();
   const configStoreAddress = ethers.utils.getAddress(
     getConfigStoreAddress(chainId)
@@ -90,12 +90,12 @@ export function makePoolClientConfig(chainId: ChainId): acrossSdk.pool.Config {
   };
 }
 
-export let poolClient: undefined | acrossSdk.pool.Client;
+export let poolClient: undefined | pool.Client;
 
-export function getPoolClient(): acrossSdk.pool.Client {
+export function getPoolClient(): pool.Client {
   if (poolClient) return poolClient;
   const hubPoolConfig = makePoolClientConfig(hubPoolChainId);
-  poolClient = new acrossSdk.pool.Client(
+  poolClient = new pool.Client(
     hubPoolConfig,
     {
       provider: getProvider(hubPoolChainId),

--- a/src/utils/tokenRoutes.ts
+++ b/src/utils/tokenRoutes.ts
@@ -13,7 +13,7 @@ import {
   HubPool__factory,
   SpokePool,
   SpokePool__factory,
-} from "@across-protocol/contracts-v2";
+} from "utils/typechain";
 
 // event types
 type L1TokenEnabledForLiquidityProvision = GetEventType<

--- a/src/utils/typechain.ts
+++ b/src/utils/typechain.ts
@@ -1,0 +1,17 @@
+/**
+ * This file re-exports some of the typechain factories so that they can be tree-shaken in the final frontend bundle.
+ * Currently, the packages `@across-protocol/contracts-v2` and `@across-protocol/across-token` are not optimized for tree-shaking.
+ * This is a temporary solution until we can fix the issue upstream.
+ */
+export { AcrossMerkleDistributor__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/AcrossMerkleDistributor__factory";
+export { HubPool__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/HubPool__factory";
+export { SpokePool__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/SpokePool__factory";
+export { ERC20__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/ERC20__factory";
+export { AcceleratingDistributor__factory } from "@across-protocol/across-token/dist/typechain/factories/AcceleratingDistributor__factory";
+export { ClaimAndStake__factory } from "@across-protocol/across-token/dist/typechain/factories/ClaimAndStake__factory";
+
+export type { AcrossMerkleDistributor } from "@across-protocol/contracts-v2/dist/typechain/AcrossMerkleDistributor";
+export type { HubPool } from "@across-protocol/contracts-v2/dist/typechain/HubPool";
+export type { SpokePool } from "@across-protocol/contracts-v2/dist/typechain/SpokePool";
+export type { AcceleratingDistributor } from "@across-protocol/across-token/dist/typechain/AcceleratingDistributor";
+export type { ClaimAndStake } from "@across-protocol/across-token/dist/typechain/ClaimAndStake";

--- a/src/views/Staking/hooks/useStakingAction.ts
+++ b/src/views/Staking/hooks/useStakingAction.ts
@@ -1,6 +1,5 @@
 import { useMutation } from "react-query";
 import { BigNumber, Signer } from "ethers";
-import { ERC20__factory } from "@across-protocol/contracts-v2";
 import { API } from "bnc-notify";
 
 import { useConnection, useStakingPool } from "hooks";
@@ -11,6 +10,7 @@ import {
   waitOnTransaction,
 } from "utils";
 import { sendWithPaddedGas } from "utils/transactions";
+import { ERC20__factory } from "utils/typechain";
 
 export type StakingActionFunctionArgs = { amount: BigNumber };
 export type StakingActionFunctionType = (


### PR DESCRIPTION
While updating to `@across-protocol/contracts-v2@2.1.0-beta.1`, I had to circumvent some issues with the latest `@uma/common` package, which currently is not really compatible with a browser environment. The workaround is to import the typechain bindings via an explicit path. 

Then I noticed that our bundle size got smaller. It seems that the packages `@across-protocol/contracts-v2` and `@across-protocol/across-token` can not be tree-shaken if we import stuff directly from the main entry file. Until we fix this upstream, I decided to add a wrapper module `utils/typechain.ts` that re-exports the respective bindings. This results in a **300 kB (gzipped)** decrease in the bundle size. 