### PR TITLE
fix: limits query same origin and dest chain

### DIFF
--- a/src/views/Bridge/hooks/useBridge.ts
+++ b/src/views/Bridge/hooks/useBridge.ts
@@ -303,8 +303,8 @@ export function useBridge() {
 
   const { limits: rawLimits, isLoading: areRawLimitsLoading } = useBridgeLimits(
     currentRoute?.fromTokenAddress,
-    currentFromRoute,
-    currentToRoute
+    currentRoute?.fromChain,
+    currentRoute?.toChain
   );
 
   const [fees, setFees] = useState<GetBridgeFeesResult | undefined>();
@@ -474,8 +474,8 @@ export function useBridge() {
     currentToken,
     setCurrentToken: setCurrentTokenExternal,
     setAmountToBridge,
-    currentFromRoute,
-    currentToRoute,
+    currentFromRoute: currentRoute?.fromChain,
+    currentToRoute: currentRoute?.toChain,
     setCurrentFromRoute: setCurrentFromRouteExternal,
     setCurrentToRoute: setCurrentToRouteExternal,
     currentBalance,


### PR DESCRIPTION
I noticed on Sentry that many 400s were thrown for the limits query https://risk-labs-m6.sentry.io/issues/3938438386/events/5b7507855bf047e9b210bbcd7990c11d/. The query fails because somewhere in the code, we try to fetch limits with `originChainId == destChainId`. 

I found the cause while working on the v2.5 update. In `useBridge.ts`, we have a lot of state-changing effects that get fired when from/to chains change, leading to an invalid state of `currentFromRoute/currentToRoute` for a short period. I fix this for now by using the memoized `currentRoute` as the source of truth. It might be worth though to consider refactoring and reducing the usage of `useEffect` in the future because the code is a bit hard to reason about.