### PR TITLE
fix: app crash on transactions page

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -428,7 +428,6 @@ export function getConfigStoreAddress(
 }
 
 export function getChainInfo(chainId: number): ChainInfo {
-  assert(isSupportedChainId(chainId), "Unsupported chain id " + chainId);
   return chainInfoTable[chainId];
 }
 


### PR DESCRIPTION
The transactions page was crashing if the history contains deposits from/to BOBA, which was removed. Instead of filtering out the deposits, I decided to remove the assert from the helper. 

Example issue on Sentry https://risk-labs-m6.sentry.io/issues/4053538768/events/5e0353ebbcd44910ba0744423db4ea4f/