### PR TITLE
fix: fee query 400 code due to same origin + dest

### DIFF
--- a/src/views/Bridge/hooks/useBridge.ts
+++ b/src/views/Bridge/hooks/useBridge.ts
@@ -296,8 +296,8 @@ export function useBridge() {
 
   const { fees: rawFees, isLoading: areRawFeesLoading } = useBridgeFees(
     amountToBridge ?? BigNumber.from(0),
-    currentFromRoute,
-    currentToRoute,
+    currentRoute?.fromChain,
+    currentRoute?.toChain,
     currentToken
   );
 


### PR DESCRIPTION
Similar to #707 but related to the fees query. Example issue on Sentry https://risk-labs-m6.sentry.io/issues/3938438386/events/bbf1a146109f4ea1ac878ffdfa36f24c/