### PR TITLE
fix(ampli): reset user props on account change

### DIFF
--- a/src/hooks/useAmpliTracking.ts
+++ b/src/hooks/useAmpliTracking.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { useQueue } from "hooks/useQueue";
 
-type TrackingRequest = () => Promise<void>;
+export type TrackingRequest = () => Promise<void> | void;
 
 export function useAmpliTracking(areInitialPropsSet: boolean) {
   const { addToQueue, queue, processNext } = useQueue<TrackingRequest>();

--- a/src/hooks/useAmplitude.tsx
+++ b/src/hooks/useAmplitude.tsx
@@ -4,7 +4,7 @@ import { amplitudeAPIKey } from "utils";
 
 import { useLoadAmpli } from "./useLoadAmpli";
 import { useInitialUserPropTraces } from "./useInitialUserPropTraces";
-import { useAmpliTracking } from "./useAmpliTracking";
+import { useAmpliTracking, TrackingRequest } from "./useAmpliTracking";
 
 const isAmpliDisabled = Boolean(amplitudeAPIKey);
 
@@ -12,7 +12,7 @@ export const AmpliContext = createContext<{
   isAmpliLoaded: boolean;
   isAmpliDisabled: boolean;
   areInitialUserPropsSet: boolean;
-  addToAmpliQueue: (request: () => Promise<void>) => void;
+  addToAmpliQueue: (request: TrackingRequest) => void;
 }>({
   isAmpliLoaded: false,
   isAmpliDisabled,

--- a/src/hooks/useInitialUserPropTraces.ts
+++ b/src/hooks/useInitialUserPropTraces.ts
@@ -14,13 +14,14 @@ export function useInitialUserPropTraces(isAmpliLoaded: boolean) {
   const [prevTrackedAccount, setPrevTrackedAccount] = useState<
     string | undefined
   >();
+  const [didApplicationLoad, setDidApplicationLoad] = useState(false);
 
   const { didAttemptAutoSelect, wallet, account, chainId } = useConnection();
   const walletBalanceTraceQuery = useWalletBalanceTrace();
 
   // Re-triggers the initial user props when the account changes
   useEffect(() => {
-    if (!prevTrackedAccount || prevTrackedAccount === account) {
+    if (prevTrackedAccount === account) {
       return;
     }
 
@@ -51,11 +52,6 @@ export function useInitialUserPropTraces(isAmpliLoaded: boolean) {
       // Always enforce referring_domain
       await identifyReferrer()?.promise;
 
-      // Ensures that this event is triggered once per session
-      if (!prevTrackedAccount) {
-        await ampli.applicationLoaded().promise;
-      }
-
       setAreInitialUserPropsSet(true);
       setPrevTrackedAccount(account);
     })();
@@ -70,6 +66,14 @@ export function useInitialUserPropTraces(isAmpliLoaded: boolean) {
     walletBalanceTraceQuery.status,
     walletBalanceTraceQuery.failureCount,
   ]);
+
+  useEffect(() => {
+    // Ensures that this event is triggered once per session
+    if (!didApplicationLoad && areInitialUserPropsSet) {
+      ampli.applicationLoaded();
+      setDidApplicationLoad(true);
+    }
+  }, [didApplicationLoad, areInitialUserPropsSet]);
 
   return { areInitialUserPropsSet };
 }

--- a/src/hooks/useOnboard.tsx
+++ b/src/hooks/useOnboard.tsx
@@ -29,7 +29,7 @@ import { Account } from "@web3-onboard/core/dist/types";
 
 import { useConnectWallet, useSetChain } from "@web3-onboard/react";
 import { Chain } from "@web3-onboard/common";
-import { ethers, utils } from "ethers";
+import { ethers } from "ethers";
 import Notify, { API as NotifyAPI, ConfigOptions } from "bnc-notify";
 import {
   ampli,

--- a/src/hooks/useOnboard.tsx
+++ b/src/hooks/useOnboard.tsx
@@ -15,7 +15,7 @@ import {
   trackConnectWalletButtonClicked,
   trackDisconnectWalletButtonClicked,
   CACHED_WALLET_KEY,
-  setUserId,
+  identifyUserWallet,
 } from "utils";
 import { onboardInit } from "utils/onboard";
 import {
@@ -197,8 +197,8 @@ export function useOnboardManager() {
       const walletStates = await connect(
         connectOptions?.autoSelect ? connectOptions : undefined
       );
-      if (walletStates[0]?.accounts[0]?.address) {
-        setUserId(utils.getAddress(walletStates[0]?.accounts[0]?.address));
+      if (walletStates[0]) {
+        identifyUserWallet(walletStates[0]);
       }
       if (trackSection) {
         trackConnectWalletButtonClicked(trackSection);

--- a/src/hooks/useRouteTrace.ts
+++ b/src/hooks/useRouteTrace.ts
@@ -24,8 +24,8 @@ export function useRouteTrace() {
       const referrer = document.referrer;
       const origin = window.location.origin;
       const page = getPageValue();
-      addToAmpliQueue(async () => {
-        await ampli.pageViewed({
+      addToAmpliQueue(() => {
+        ampli.pageViewed({
           path,
           referrer,
           origin,
@@ -33,7 +33,7 @@ export function useRouteTrace() {
           page,
           gitCommitHash: currentGitCommitHash,
           referralProgramAddress: referralAddress,
-        }).promise;
+        });
       });
 
       if (initialPage) {

--- a/src/hooks/useWalletBalanceTrace.ts
+++ b/src/hooks/useWalletBalanceTrace.ts
@@ -9,6 +9,7 @@ import {
   getRoutes,
   getToken,
   reportTotalWalletUsdBalance,
+  setUserId,
 } from "utils";
 import { ConvertDecimals } from "utils/convertdecimals";
 import getApiEndpoint from "utils/serverless-api";
@@ -21,6 +22,7 @@ export function useWalletBalanceTrace() {
     ["wallet-balance", account ?? "loading"],
     async () => {
       if (!account) return;
+      setUserId(account);
       const balance = await calculateUsdBalances(account);
       reportTotalWalletUsdBalance(balance);
       return balance;

--- a/src/hooks/useWalletTrace.ts
+++ b/src/hooks/useWalletTrace.ts
@@ -33,11 +33,11 @@ export function useWalletNetworkTrace() {
     }
 
     const chainInfo = chainInfoTable[Number(chainId)];
-    addToAmpliQueue(async () => {
-      await ampli.walletNetworkSelected({
+    addToAmpliQueue(() => {
+      ampli.walletNetworkSelected({
         chainId: String(chainId),
         chainName: chainInfo?.name || "unknown",
-      }).promise;
+      });
     });
     setPrevTracked({ account, chainId });
   }, [chainId, account]);
@@ -63,9 +63,8 @@ export function useWalletChangeTrace() {
     }
 
     const previousConnection = window.localStorage.getItem(CACHED_WALLET_KEY);
-    addToAmpliQueue(async () => {
-      await trackWalletConnectTransactionCompleted(wallet, previousConnection)
-        .promise;
+    addToAmpliQueue(() => {
+      trackWalletConnectTransactionCompleted(wallet, previousConnection);
     });
 
     setPrevTrackedWallet(connectedWalletAddress);

--- a/src/views/Bridge/components/ChangeAccountModal.tsx
+++ b/src/views/Bridge/components/ChangeAccountModal.tsx
@@ -6,6 +6,7 @@ import { ReactComponent as CrossIcon } from "assets/icons/cross-16.svg";
 import { SecondaryButtonWithoutShadow as UnstyledButton } from "components/Buttons";
 import { ethers } from "ethers";
 import { ampli } from "ampli";
+import { useAmplitude } from "hooks";
 
 type ChangeAccountModalProps = {
   displayModal: boolean;
@@ -23,6 +24,8 @@ const ChangeAccountModal = ({
   const [userInput, setUserInput] = useState(currentAccount);
   const [validInput, setValidInput] = useState(false);
 
+  const { addToAmpliQueue } = useAmplitude();
+
   useEffect(() => {
     if (displayModal) {
       setUserInput(currentAccount);
@@ -38,8 +41,10 @@ const ChangeAccountModal = ({
   const onSaveHandler = () => {
     if (validInput) {
       changeAccountHandler(userInput);
-      ampli.toAccountChanged({
-        toWalletAddress: userInput,
+      addToAmpliQueue(async () => {
+        ampli.toAccountChanged({
+          toWalletAddress: userInput,
+        });
       });
       displayModalCloseHandler();
     }

--- a/src/views/Bridge/components/ChangeAccountModal.tsx
+++ b/src/views/Bridge/components/ChangeAccountModal.tsx
@@ -41,7 +41,7 @@ const ChangeAccountModal = ({
   const onSaveHandler = () => {
     if (validInput) {
       changeAccountHandler(userInput);
-      addToAmpliQueue(async () => {
+      addToAmpliQueue(() => {
         ampli.toAccountChanged({
           toWalletAddress: userInput,
         });

--- a/src/views/Bridge/components/CoinSelector.tsx
+++ b/src/views/Bridge/components/CoinSelector.tsx
@@ -49,7 +49,7 @@ function useCoinSelector(
   const maxBalanceOnClick = () => {
     if (currentBalance) {
       setUserAmountInput(tokenFormatterFn(currentBalance));
-      addToAmpliQueue(async () => {
+      addToAmpliQueue(() => {
         trackMaxButtonClicked("bridgeForm");
       });
     }

--- a/src/views/Bridge/components/CoinSelector.tsx
+++ b/src/views/Bridge/components/CoinSelector.tsx
@@ -16,7 +16,12 @@ import {
 import { useCallback, useEffect, useState } from "react";
 import { Theme } from "@emotion/react";
 import { SelectorPropType } from "components/Selector/Selector";
-import { useBalancesBySymbols, useBridgeLimits, useConnection } from "hooks";
+import {
+  useBalancesBySymbols,
+  useBridgeLimits,
+  useConnection,
+  useAmplitude,
+} from "hooks";
 import BridgeInputErrorAlert from "./BridgeAlert";
 
 function useCoinSelector(
@@ -33,6 +38,8 @@ function useCoinSelector(
   const [userAmountInput, setUserAmountInput] = useState("");
   const [validInput, setValidInput] = useState(true);
   const { isConnected } = useConnection();
+  const { addToAmpliQueue } = useAmplitude();
+
   const token =
     tokens.find((t) => t.symbol.toLowerCase() === currentToken.toLowerCase()) ??
     tokens[0];
@@ -42,7 +49,9 @@ function useCoinSelector(
   const maxBalanceOnClick = () => {
     if (currentBalance) {
       setUserAmountInput(tokenFormatterFn(currentBalance));
-      trackMaxButtonClicked("bridgeForm");
+      addToAmpliQueue(async () => {
+        trackMaxButtonClicked("bridgeForm");
+      });
     }
   };
 

--- a/src/views/Bridge/components/SlippageAlert.tsx
+++ b/src/views/Bridge/components/SlippageAlert.tsx
@@ -12,7 +12,7 @@ const SlippageAlert = () => {
 
   const displayModalHandler = () => {
     setDisplayModal(true);
-    addToAmpliQueue(async () => {
+    addToAmpliQueue(() => {
       ampli.feesInfoExpanded();
     });
   };

--- a/src/views/Bridge/components/SlippageAlert.tsx
+++ b/src/views/Bridge/components/SlippageAlert.tsx
@@ -4,12 +4,17 @@ import { Alert } from "components";
 import { Text } from "components/Text";
 import { useState } from "react";
 import FeeInformationModal from "./FeeInformationModal";
+import { useAmplitude } from "hooks";
 
 const SlippageAlert = () => {
   const [displayModal, setDisplayModal] = useState(false);
+  const { addToAmpliQueue } = useAmplitude();
+
   const displayModalHandler = () => {
     setDisplayModal(true);
-    ampli.feesInfoExpanded();
+    addToAmpliQueue(async () => {
+      ampli.feesInfoExpanded();
+    });
   };
   return (
     <>

--- a/src/views/Bridge/hooks/useBridge.ts
+++ b/src/views/Bridge/hooks/useBridge.ts
@@ -71,7 +71,7 @@ export function useBridge() {
 
   useEffect(() => {
     if (isDefaultToken) {
-      addToAmpliQueue(async () => {
+      addToAmpliQueue(() => {
         trackTokenChanged(currentToken, true);
       });
     }
@@ -100,7 +100,7 @@ export function useBridge() {
   useEffect(() => {
     if (currentToRoute) {
       if (isDefaultToRoute) {
-        addToAmpliQueue(async () => {
+        addToAmpliQueue(() => {
           trackToChainChanged(currentToRoute, true);
         });
       }
@@ -112,7 +112,7 @@ export function useBridge() {
   useEffect(() => {
     if (currentFromRoute) {
       if (isDefaultFromRoute) {
-        addToAmpliQueue(async () => {
+        addToAmpliQueue(() => {
           trackFromChainChanged(currentFromRoute, true);
         });
       }
@@ -211,7 +211,7 @@ export function useBridge() {
             );
           if (!toRouteStillAvailable) {
             setCurrentToRoute(availableToRoutesForCurrentFromRoute[0]);
-            addToAmpliQueue(async () => {
+            addToAmpliQueue(() => {
               trackToChainChanged(
                 availableToRoutesForCurrentFromRoute[0],
                 true
@@ -239,7 +239,7 @@ export function useBridge() {
             );
           if (!fromRouteStillAvailable) {
             setCurrentFromRoute(availableFromRoutesForCurrentToRoute[0]);
-            addToAmpliQueue(async () => {
+            addToAmpliQueue(() => {
               trackFromChainChanged(
                 availableFromRoutesForCurrentToRoute[0],
                 true
@@ -271,7 +271,7 @@ export function useBridge() {
       // Set the current to route to the current from route
       setCurrentToRoute(currentFromRouteTemp);
       setAmountToBridge(undefined);
-      addToAmpliQueue(async () => {
+      addToAmpliQueue(() => {
         trackFromChainChanged(currentToRouteTemp, false);
         trackToChainChanged(currentFromRouteTemp, false);
         trackQuickSwap("bridgeForm");
@@ -417,7 +417,7 @@ export function useBridge() {
         estimatedTimeToRelayObject,
         amountToBridge
       );
-      addToAmpliQueue(async () => {
+      addToAmpliQueue(() => {
         ampli.transferQuoteReceived(quote);
       });
       setQuote(quote);
@@ -464,7 +464,7 @@ export function useBridge() {
       setCurrentToRoute(firstAvailableRoute?.toChain);
     }
     setCurrentToken(token);
-    addToAmpliQueue(async () => {
+    addToAmpliQueue(() => {
       trackTokenChanged(token);
     });
   };
@@ -472,7 +472,7 @@ export function useBridge() {
   const setCurrentFromRouteExternal = (chainId?: number) => {
     setCurrentFromRoute(chainId);
     if (chainId) {
-      addToAmpliQueue(async () => {
+      addToAmpliQueue(() => {
         trackFromChainChanged(chainId, false);
       });
     }
@@ -481,7 +481,7 @@ export function useBridge() {
   const setCurrentToRouteExternal = (chainId?: number) => {
     setCurrentToRoute(chainId);
     if (chainId) {
-      addToAmpliQueue(async () => {
+      addToAmpliQueue(() => {
         trackToChainChanged(chainId, false);
       });
     }

--- a/src/views/Bridge/hooks/useBridge.ts
+++ b/src/views/Bridge/hooks/useBridge.ts
@@ -6,6 +6,7 @@ import {
   useBridgeLimits,
   useConnection,
   useIsWrongNetwork,
+  useAmplitude,
 } from "hooks";
 import { useCoingeckoPrice } from "hooks/useCoingeckoPrice";
 import useReferrer from "hooks/useReferrer";
@@ -66,9 +67,13 @@ export function useBridge() {
   const [isLiquidityFromAountExceeded, setIsLiquidityFromAountExceeded] =
     useState(false);
 
+  const { addToAmpliQueue } = useAmplitude();
+
   useEffect(() => {
     if (isDefaultToken) {
-      trackTokenChanged(currentToken, true);
+      addToAmpliQueue(async () => {
+        trackTokenChanged(currentToken, true);
+      });
     }
     setIsDefaultToken(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -95,7 +100,9 @@ export function useBridge() {
   useEffect(() => {
     if (currentToRoute) {
       if (isDefaultToRoute) {
-        trackToChainChanged(currentToRoute, true);
+        addToAmpliQueue(async () => {
+          trackToChainChanged(currentToRoute, true);
+        });
       }
       setIsDefaultToRoute(false);
     }
@@ -105,7 +112,9 @@ export function useBridge() {
   useEffect(() => {
     if (currentFromRoute) {
       if (isDefaultFromRoute) {
-        trackFromChainChanged(currentFromRoute, true);
+        addToAmpliQueue(async () => {
+          trackFromChainChanged(currentFromRoute, true);
+        });
       }
       setIsDefaultFromRoute(false);
     }
@@ -202,7 +211,12 @@ export function useBridge() {
             );
           if (!toRouteStillAvailable) {
             setCurrentToRoute(availableToRoutesForCurrentFromRoute[0]);
-            trackToChainChanged(availableToRoutesForCurrentFromRoute[0], true);
+            addToAmpliQueue(async () => {
+              trackToChainChanged(
+                availableToRoutesForCurrentFromRoute[0],
+                true
+              );
+            });
           }
         }
       }
@@ -225,10 +239,12 @@ export function useBridge() {
             );
           if (!fromRouteStillAvailable) {
             setCurrentFromRoute(availableFromRoutesForCurrentToRoute[0]);
-            trackFromChainChanged(
-              availableFromRoutesForCurrentToRoute[0],
-              true
-            );
+            addToAmpliQueue(async () => {
+              trackFromChainChanged(
+                availableFromRoutesForCurrentToRoute[0],
+                true
+              );
+            });
           }
         }
       }
@@ -252,14 +268,16 @@ export function useBridge() {
 
       // Set the current from route to the current to route
       setCurrentFromRoute(currentToRouteTemp);
-      trackFromChainChanged(currentToRouteTemp, false);
       // Set the current to route to the current from route
       setCurrentToRoute(currentFromRouteTemp);
       setAmountToBridge(undefined);
-      trackToChainChanged(currentFromRouteTemp, false);
-      trackQuickSwap("bridgeForm");
+      addToAmpliQueue(async () => {
+        trackFromChainChanged(currentToRouteTemp, false);
+        trackToChainChanged(currentFromRouteTemp, false);
+        trackQuickSwap("bridgeForm");
+      });
     }
-  }, [currentFromRoute, currentToRoute, disableQuickSwap]);
+  }, [currentFromRoute, currentToRoute, disableQuickSwap, addToAmpliQueue]);
 
   useEffect(() => {
     // Resolve the from and to route as temporary variables
@@ -399,7 +417,9 @@ export function useBridge() {
         estimatedTimeToRelayObject,
         amountToBridge
       );
-      ampli.transferQuoteReceived(quote);
+      addToAmpliQueue(async () => {
+        ampli.transferQuoteReceived(quote);
+      });
       setQuote(quote);
       setInitialQuoteTime((s) => s ?? Date.now());
     }
@@ -444,20 +464,26 @@ export function useBridge() {
       setCurrentToRoute(firstAvailableRoute?.toChain);
     }
     setCurrentToken(token);
-    trackTokenChanged(token);
+    addToAmpliQueue(async () => {
+      trackTokenChanged(token);
+    });
   };
 
   const setCurrentFromRouteExternal = (chainId?: number) => {
     setCurrentFromRoute(chainId);
     if (chainId) {
-      trackFromChainChanged(chainId, false);
+      addToAmpliQueue(async () => {
+        trackFromChainChanged(chainId, false);
+      });
     }
   };
 
   const setCurrentToRouteExternal = (chainId?: number) => {
     setCurrentToRoute(chainId);
     if (chainId) {
-      trackToChainChanged(chainId, false);
+      addToAmpliQueue(async () => {
+        trackToChainChanged(chainId, false);
+      });
     }
   };
 

--- a/src/views/Bridge/hooks/useBridgeAction.ts
+++ b/src/views/Bridge/hooks/useBridgeAction.ts
@@ -90,7 +90,7 @@ export function useBridgeAction(
     let timeSigned: number | undefined = undefined;
     let tx: ContractTransaction | undefined = undefined;
     try {
-      addToAmpliQueue(async () => {
+      addToAmpliQueue(() => {
         // Instrument amplitude before sending the transaction for the submit button.
         ampli.transferSubmitted(
           generateTransferSubmitted(
@@ -106,7 +106,7 @@ export function useBridgeAction(
 
       // Instrument amplitude after signing the transaction for the submit button.
       timeSigned = Date.now();
-      addToAmpliQueue(async () => {
+      addToAmpliQueue(() => {
         ampli.transferSigned(
           generateTransferSigned(frozenQuote, referrer, timeSubmitted, tx!.hash)
         );
@@ -148,7 +148,7 @@ export function useBridgeAction(
       }
     }
     if (timeSigned && tx) {
-      addToAmpliQueue(async () => {
+      addToAmpliQueue(() => {
         ampli.transferDepositCompleted(
           generateDepositConfirmed(
             frozenQuote,

--- a/src/views/Bridge/hooks/useBridgeAction.ts
+++ b/src/views/Bridge/hooks/useBridgeAction.ts
@@ -1,7 +1,12 @@
 import { ampli, TransferQuoteReceivedProperties } from "ampli";
 import { BigNumber, ContractTransaction, utils } from "ethers";
 import { DateTime } from "luxon";
-import { useConnection, useApprove, useIsWrongNetwork } from "hooks";
+import {
+  useConnection,
+  useApprove,
+  useIsWrongNetwork,
+  useAmplitude,
+} from "hooks";
 import { useLocalPendingDeposits } from "hooks/useLocalPendingDeposits";
 import { cloneDeep } from "lodash";
 import { useMutation } from "react-query";
@@ -37,6 +42,7 @@ export function useBridgeAction(
 
   const { addLocalPendingDeposit } = useLocalPendingDeposits();
   const approveHandler = useApprove(payload?.fromChain);
+  const { addToAmpliQueue } = useAmplitude();
 
   const buttonActionHandler = useMutation(async () => {
     const frozenQuote = cloneDeep(recentQuote);
@@ -84,19 +90,27 @@ export function useBridgeAction(
     let timeSigned: number | undefined = undefined;
     let tx: ContractTransaction | undefined = undefined;
     try {
-      // Instrument amplitude before sending the transaction for the submit button.
-      ampli.transferSubmitted(
-        generateTransferSubmitted(frozenQuote, referrer, frozenInitialQuoteTime)
-      );
+      addToAmpliQueue(async () => {
+        // Instrument amplitude before sending the transaction for the submit button.
+        ampli.transferSubmitted(
+          generateTransferSubmitted(
+            frozenQuote,
+            referrer,
+            frozenInitialQuoteTime
+          )
+        );
+      });
       const timeSubmitted = Date.now();
 
       tx = await sendAcrossDeposit(signer, frozenPayload);
 
       // Instrument amplitude after signing the transaction for the submit button.
       timeSigned = Date.now();
-      ampli.transferSigned(
-        generateTransferSigned(frozenQuote, referrer, timeSubmitted, tx.hash)
-      );
+      addToAmpliQueue(async () => {
+        ampli.transferSigned(
+          generateTransferSigned(frozenQuote, referrer, timeSubmitted, tx!.hash)
+        );
+      });
 
       if (onTransactionComplete) {
         onTransactionComplete(tx.hash);
@@ -134,16 +148,18 @@ export function useBridgeAction(
       }
     }
     if (timeSigned && tx) {
-      ampli.transferDepositCompleted(
-        generateDepositConfirmed(
-          frozenQuote,
-          referrer,
-          timeSigned,
-          tx.hash,
-          succeeded,
-          tx.timestamp!
-        )
-      );
+      addToAmpliQueue(async () => {
+        ampli.transferDepositCompleted(
+          generateDepositConfirmed(
+            frozenQuote,
+            referrer,
+            timeSigned!,
+            tx!.hash,
+            succeeded,
+            tx!.timestamp!
+          )
+        );
+      });
     }
     // Call recordTransferUserProperties to update the user's properties in Amplitude.
     recordTransferUserProperties(

--- a/src/views/LiquidityPool/components/ActionInputBlock.tsx
+++ b/src/views/LiquidityPool/components/ActionInputBlock.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { utils } from "ethers";
 
 import { QUERIESV2, trackMaxButtonClicked } from "utils";
-import { useStakingPool } from "hooks";
+import { useStakingPool, useAmplitude } from "hooks";
 import { InputWithMaxButton, Text } from "components";
 
 import {
@@ -48,6 +48,8 @@ export function ActionInputBlock({ action, selectedToken }: Props) {
     selectedToken.decimals,
     maxAmountsQuery.data
   );
+
+  const { addToAmpliQueue } = useAmplitude();
 
   // Reset amount input and mutation state when switching actions or tokens
   useEffect(() => {
@@ -130,9 +132,11 @@ export function ActionInputBlock({ action, selectedToken }: Props) {
           onEnterKeyDown={handleAction}
           onClickMaxButton={() => {
             setAmount(maxAmount);
-            trackMaxButtonClicked(
-              action === "add" ? "addLiquidityForm" : "removeLiquidityForm"
-            );
+            addToAmpliQueue(async () => {
+              trackMaxButtonClicked(
+                action === "add" ? "addLiquidityForm" : "removeLiquidityForm"
+              );
+            });
           }}
           maxValue={maxAmountsQuery.isLoading ? "" : maxAmount}
           disableTokenIcon

--- a/src/views/LiquidityPool/components/ActionInputBlock.tsx
+++ b/src/views/LiquidityPool/components/ActionInputBlock.tsx
@@ -132,7 +132,7 @@ export function ActionInputBlock({ action, selectedToken }: Props) {
           onEnterKeyDown={handleAction}
           onClickMaxButton={() => {
             setAmount(maxAmount);
-            addToAmpliQueue(async () => {
+            addToAmpliQueue(() => {
               trackMaxButtonClicked(
                 action === "add" ? "addLiquidityForm" : "removeLiquidityForm"
               );

--- a/src/views/Staking/components/StakingInputBlock/StakingInputBlock.tsx
+++ b/src/views/Staking/components/StakingInputBlock/StakingInputBlock.tsx
@@ -13,6 +13,7 @@ import {
 import { capitalizeFirstLetter } from "utils/format";
 import BouncingDotsLoader from "components/BouncingDotsLoader";
 import { trackMaxButtonClicked } from "utils";
+import { useAmplitude } from "hooks";
 
 interface Props {
   value: string;
@@ -42,53 +43,58 @@ const StakingInputBlock: React.FC<Props> = ({
   warningButtonColor,
   disableInput,
   stakingAction,
-}) => (
-  <Wrapper>
-    <InputRow>
-      <InputWrapper valid={valid} invalid={invalid}>
-        <TokenIcon src={logoURI} />
-        <Input
-          valid={valid}
-          invalid={invalid}
-          placeholder="Enter amount"
-          value={value}
-          type="text"
-          onChange={(e) => setValue(e.target.value)}
-          disabled={displayLoader || disableInput}
-          onKeyDown={(e) => e.key === "Enter" && valid && onClickHandler()}
-        />
-        <MaxButton
-          disabled={displayLoader || disableInput || !maxValue}
-          onClick={() => {
-            setValue(maxValue ?? "");
-            trackMaxButtonClicked(
-              stakingAction === "stake" ? "stakeForm" : "unstakeForm"
-            );
-          }}
-        >
-          Max
-        </MaxButton>
-      </InputWrapper>
+}) => {
+  const { addToAmpliQueue } = useAmplitude();
+  return (
+    <Wrapper>
+      <InputRow>
+        <InputWrapper valid={valid} invalid={invalid}>
+          <TokenIcon src={logoURI} />
+          <Input
+            valid={valid}
+            invalid={invalid}
+            placeholder="Enter amount"
+            value={value}
+            type="text"
+            onChange={(e) => setValue(e.target.value)}
+            disabled={displayLoader || disableInput}
+            onKeyDown={(e) => e.key === "Enter" && valid && onClickHandler()}
+          />
+          <MaxButton
+            disabled={displayLoader || disableInput || !maxValue}
+            onClick={() => {
+              setValue(maxValue ?? "");
+              addToAmpliQueue(async () => {
+                trackMaxButtonClicked(
+                  stakingAction === "stake" ? "stakeForm" : "unstakeForm"
+                );
+              });
+            }}
+          >
+            Max
+          </MaxButton>
+        </InputWrapper>
 
-      <ButtonWrapper>
-        <StakeButton
-          valid={valid}
-          onClick={onClickHandler}
-          disabled={!valid || invalid}
-          warningButtonColor={warningButtonColor}
-        >
-          <StakeButtonContentWrapper>
-            <span>{capitalizeFirstLetter(buttonText)}</span>
-            {displayLoader && (
-              <LoaderWrapper>
-                <BouncingDotsLoader />
-              </LoaderWrapper>
-            )}
-          </StakeButtonContentWrapper>
-        </StakeButton>
-      </ButtonWrapper>
-    </InputRow>
-  </Wrapper>
-);
+        <ButtonWrapper>
+          <StakeButton
+            valid={valid}
+            onClick={onClickHandler}
+            disabled={!valid || invalid}
+            warningButtonColor={warningButtonColor}
+          >
+            <StakeButtonContentWrapper>
+              <span>{capitalizeFirstLetter(buttonText)}</span>
+              {displayLoader && (
+                <LoaderWrapper>
+                  <BouncingDotsLoader />
+                </LoaderWrapper>
+              )}
+            </StakeButtonContentWrapper>
+          </StakeButton>
+        </ButtonWrapper>
+      </InputRow>
+    </Wrapper>
+  );
+};
 
 export default StakingInputBlock;

--- a/src/views/Staking/components/StakingInputBlock/StakingInputBlock.tsx
+++ b/src/views/Staking/components/StakingInputBlock/StakingInputBlock.tsx
@@ -64,7 +64,7 @@ const StakingInputBlock: React.FC<Props> = ({
             disabled={displayLoader || disableInput || !maxValue}
             onClick={() => {
               setValue(maxValue ?? "");
-              addToAmpliQueue(async () => {
+              addToAmpliQueue(() => {
                 trackMaxButtonClicked(
                   stakingAction === "stake" ? "stakeForm" : "unstakeForm"
                 );


### PR DESCRIPTION
Fixes ACX-1044

The initial user props were not reset when the user connected a wallet by clicking the `Connect wallet` button or changed the account in the wallet directly.

This PR fixes the issue by re-running the `src/hooks/useInitialUserPropTraces.ts` hook if the connected account changes. We also make sure to wrap every tracking call with the `addToAmpliQueue` function, to avoid missing updated user properties.