### PR TITLE
fix: `getChainInfo` helper unknown networks

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { ethers } from "ethers";
+import { ethers, providers } from "ethers";
 import { relayFeeCalculator, constants } from "@across-protocol/sdk-v2";
 import { across } from "@uma/sdk";
 import * as superstruct from "superstruct";
@@ -378,7 +378,31 @@ export function getConfigStoreAddress(
 }
 
 export function getChainInfo(chainId: number): ChainInfo {
-  return chainInfoTable[chainId];
+  let chainInfo = chainInfoTable[chainId];
+
+  if (!chainInfo) {
+    let unknownNetworkName = `Unknown Network (${chainId})`;
+    try {
+      const { name } = providers.getNetwork(chainId);
+      unknownNetworkName = name;
+    } catch (error) {}
+
+    chainInfo = {
+      name: unknownNetworkName,
+      fullName: unknownNetworkName,
+      chainId,
+      logoURI: ethereumLogo,
+      grayscaleLogoURI: ethereumLogoGrayscale,
+      explorerUrl: "https://blockscan.com/",
+      constructExplorerLink: (txHash: string) =>
+        `https://blockscan.com/tx/${txHash}`,
+      nativeCurrencySymbol: "ETH",
+      pollingInterval: defaultBlockPollingInterval,
+      earliestBlock: 1,
+    };
+  }
+
+  return chainInfo;
 }
 
 export const tokenTable = Object.fromEntries(

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,6 +20,7 @@ import umaLogo from "assets/uma.svg";
 import acxLogo from "assets/across.svg";
 import balLogo from "assets/bal.svg";
 import usdtLogo from "assets/usdt-logo.svg";
+import unknownLogo from "assets/icons/question-24.svg";
 
 import ethereumLogoGrayscale from "assets/grayscale-logos/eth.svg";
 import optimismLogoGrayscale from "assets/grayscale-logos/optimism.svg";
@@ -381,18 +382,15 @@ export function getChainInfo(chainId: number): ChainInfo {
   let chainInfo = chainInfoTable[chainId];
 
   if (!chainInfo) {
-    let unknownNetworkName = `Unknown Network (${chainId})`;
-    try {
-      const { name } = providers.getNetwork(chainId);
-      unknownNetworkName = name;
-    } catch (error) {}
+    let { name } = providers.getNetwork(chainId);
+    name = name === "unknown" ? `Unknown (${chainId})` : name;
 
     chainInfo = {
-      name: unknownNetworkName,
-      fullName: unknownNetworkName,
+      name,
+      fullName: name,
       chainId,
-      logoURI: ethereumLogo,
-      grayscaleLogoURI: ethereumLogoGrayscale,
+      logoURI: unknownLogo,
+      grayscaleLogoURI: unknownLogo,
       explorerUrl: "https://blockscan.com/",
       constructExplorerLink: (txHash: string) =>
         `https://blockscan.com/tx/${txHash}`,


### PR DESCRIPTION
The fix https://github.com/across-protocol/frontend-v2/pull/708 led to another bug that causes the transactions page to crash if there is a deposit from an unknown chain. 

This PR fixes this by making sure to always return a chain info object in the helper `getChainInfo`.