### PR TITLE
fix: :bug: correct error readout in bridge tab

### DIFF
--- a/src/views/Bridge/components/BridgeForm.tsx
+++ b/src/views/Bridge/components/BridgeForm.tsx
@@ -122,6 +122,7 @@ const BridgeForm = ({
             tokenSelected={currentToken}
             onTokenSelected={setCurrentToken}
             onAmountToBridgeChanged={setAmountToBridge}
+            amountToBridge={amountToBridge}
             currentSelectedBalance={currentBalance}
             walletAccount={walletAccount}
             setIsBridgeAmountValid={setIsBridgeAmountValid}


### PR DESCRIPTION
This change modifies the error readouts to produce the correct alert to the user depending on the number of funds they request to bridge.