### PR TITLE
fix: remove old google site verification

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,11 +29,6 @@
     />
     <meta name="twitter:creator" content="@UMAprotocol" />
     <meta name="twitter:image" content="%PUBLIC_URL%/logo-small.png" />
-    <!-- For Google console search tools: https://search.google.com/ -->
-    <meta
-      name="google-site-verification"
-      content="xs1HS4-nzd-a2ROd3-pQsn35pCc1WwMnlE4uK032IJ0"
-    />
     <meta name="robots" content="index, follow" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 


### PR DESCRIPTION
Leaving this here is a security risk because it could allow users who previously had access to regain access.