### PR TITLE
feat: required api endpoints for dodo

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -486,34 +486,23 @@ export const getProvider = (_chainId: number): providers.Provider => {
  * @returns The corresponding SpokePool for the given `_chainId`
  */
 export const getSpokePool = (_chainId: number): SpokePool => {
+  const spokePoolAddress = getSpokePoolAddress(_chainId);
+  return SpokePool__factory.connect(spokePoolAddress, getProvider(_chainId));
+};
+
+export const getSpokePoolAddress = (_chainId: number): string => {
   const chainId = _chainId.toString();
-  const provider = getProvider(_chainId);
   switch (chainId.toString()) {
     case "1":
-      return SpokePool__factory.connect(
-        "0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5",
-        provider
-      );
+      return "0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5";
     case "10":
-      return SpokePool__factory.connect(
-        "0x6f26Bf09B1C792e3228e5467807a900A503c0281",
-        provider
-      );
+      return "0x6f26Bf09B1C792e3228e5467807a900A503c0281";
     case "137":
-      return SpokePool__factory.connect(
-        "0x9295ee1d8C5b022Be115A2AD3c30C72E34e7F096",
-        provider
-      );
+      return "0x9295ee1d8C5b022Be115A2AD3c30C72E34e7F096";
     case "288":
-      return SpokePool__factory.connect(
-        "0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58",
-        provider
-      );
+      return "0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58";
     case "42161":
-      return SpokePool__factory.connect(
-        "0xe35e9842fceaCA96570B734083f4a58e8F7C5f2A",
-        provider
-      );
+      return "0xe35e9842fceaCA96570B734083f4a58e8F7C5f2A";
     default:
       throw new Error("Invalid chainId provided");
   }
@@ -725,4 +714,31 @@ export function getLpCushion(
       .map((key) => process.env[key])
       .find((value) => value !== undefined) ?? "0"
   );
+}
+
+export function tagReferrer(dataHex: string, referrerAddress: string) {
+  if (!ethers.utils.isAddress(referrerAddress)) {
+    throw new Error("Data must be a valid address");
+  }
+
+  if (!ethers.utils.isHexString(dataHex)) {
+    throw new Error("Data must be a valid hex string");
+  }
+
+  return ethers.utils.hexConcat([
+    dataHex,
+    "0xd00dfeeddeadbeef",
+    referrerAddress,
+  ]);
+}
+
+export function getFallbackTokenLogoURI(l1TokenAddress: string) {
+  const isACX =
+    sdk.constants.TOKEN_SYMBOLS_MAP.ACX.addresses[1] === l1TokenAddress;
+
+  if (isACX) {
+    return "https://across.to/logo-small.png";
+  }
+
+  return `https://github.com/trustwallet/assets/blob/master/blockchains/ethereum/assets/${l1TokenAddress}/logo.png?raw=true`;
 }

--- a/api/build-deposit-tx.ts
+++ b/api/build-deposit-tx.ts
@@ -1,0 +1,109 @@
+import { VercelResponse } from "@vercel/node";
+import { ethers } from "ethers";
+import { type, assert, Infer, optional, string } from "superstruct";
+import { TypedVercelRequest } from "./_types";
+import {
+  getLogger,
+  InputError,
+  handleErrorCondition,
+  parsableBigNumberString,
+  validAddress,
+  positiveIntStr,
+  boolStr,
+  getSpokePool,
+  tagReferrer,
+} from "./_utils";
+
+const BuildDepositTxQueryParamsSchema = type({
+  amount: parsableBigNumberString(),
+  token: validAddress(),
+  isNative: boolStr(),
+  destinationChainId: positiveIntStr(),
+  originChainId: positiveIntStr(),
+  recipient: validAddress(),
+  relayerFeePct: parsableBigNumberString(),
+  quoteTimestamp: positiveIntStr(),
+  message: optional(string()),
+  maxCount: optional(boolStr()),
+  referrer: optional(validAddress()),
+});
+
+type BuildDepositTxQueryParams = Infer<typeof BuildDepositTxQueryParamsSchema>;
+
+const handler = async (
+  { query }: TypedVercelRequest<BuildDepositTxQueryParams>,
+  response: VercelResponse
+) => {
+  const logger = getLogger();
+  logger.debug({
+    at: "BuildDepositTx",
+    message: "Query data",
+    query,
+  });
+  try {
+    assert(query, BuildDepositTxQueryParamsSchema);
+
+    let {
+      amount: amountInput,
+      token,
+      destinationChainId: destinationChainIdInput,
+      originChainId: originChainIdInput,
+      recipient,
+      relayerFeePct: relayerFeePctInput,
+      quoteTimestamp,
+      message = "0x",
+      maxCount = ethers.constants.MaxUint256.toString(),
+      referrer,
+    } = query;
+
+    recipient = ethers.utils.getAddress(recipient);
+    token = ethers.utils.getAddress(token);
+    const destinationChainId = parseInt(destinationChainIdInput);
+    const originChainId = parseInt(originChainIdInput);
+    const amount = ethers.BigNumber.from(amountInput);
+    const relayerFeePct = ethers.BigNumber.from(relayerFeePctInput);
+
+    if (originChainId === destinationChainId) {
+      throw new InputError("Origin and destination chains cannot be the same");
+    }
+
+    const spokePool = getSpokePool(originChainId);
+
+    const value =
+      token === ethers.constants.AddressZero ? amount : ethers.constants.Zero;
+    const tx = await spokePool.populateTransaction.deposit(
+      recipient,
+      token,
+      amount,
+      destinationChainId,
+      relayerFeePct,
+      quoteTimestamp,
+      message,
+      maxCount,
+      { value }
+    );
+
+    // do not tag a referrer if data is not provided as a hex string.
+    tx.data =
+      referrer && ethers.utils.isAddress(referrer)
+        ? tagReferrer(tx.data!, referrer)
+        : tx.data;
+
+    const responseJson = {
+      data: tx.data,
+      value: tx.value?.toString(),
+    };
+
+    logger.debug({
+      at: "BuildDepositTx",
+      message: "Response data",
+      responseJson,
+    });
+
+    response.status(200).json(responseJson);
+  } catch (error) {
+    return handleErrorCondition("build-deposit-tx", response, logger, error);
+  }
+};
+
+export default handler;

--- a/api/build-deposit-tx.ts
+++ b/api/build-deposit-tx.ts
@@ -26,6 +26,7 @@ const BuildDepositTxQueryParamsSchema = type({
   message: optional(string()),
   maxCount: optional(boolStr()),
   referrer: optional(validAddressOrENS()),
+  isNative: optional(boolStr()),
 });
 
 type BuildDepositTxQueryParams = Infer<typeof BuildDepositTxQueryParamsSchema>;
@@ -56,6 +57,7 @@ const handler = async (
       message = "0x",
       maxCount = ethers.constants.MaxUint256.toString(),
       referrer,
+      isNative: isNativeBoolStr,
     } = query;
 
     recipient = ethers.utils.getAddress(recipient);
@@ -64,6 +66,7 @@ const handler = async (
     const originChainId = parseInt(originChainIdInput);
     const amount = ethers.BigNumber.from(amountInput);
     const relayerFeePct = ethers.BigNumber.from(relayerFeePctInput);
+    const isNative = isNativeBoolStr === "true";
 
     if (originChainId === destinationChainId) {
       throw new InputError("Origin and destination chains cannot be the same");
@@ -71,8 +74,7 @@ const handler = async (
 
     const spokePool = getSpokePool(originChainId);
 
-    const value =
-      token === ethers.constants.AddressZero ? amount : ethers.constants.Zero;
+    const value = isNative ? amount : ethers.constants.Zero;
     const tx = await spokePool.populateTransaction.deposit(
       recipient,
       token,

--- a/api/build-deposit-tx.ts
+++ b/api/build-deposit-tx.ts
@@ -99,7 +99,7 @@ const handler = async (
       message: "Response data",
       responseJson,
     });
-
+    response.setHeader("Cache-Control", "s-maxage=300");
     response.status(200).json(responseJson);
   } catch (error) {
     return handleErrorCondition("build-deposit-tx", response, logger, error);

--- a/api/build-deposit-tx.ts
+++ b/api/build-deposit-tx.ts
@@ -12,12 +12,12 @@ import {
   boolStr,
   getSpokePool,
   tagReferrer,
+  validAddressOrENS,
 } from "./_utils";
 
 const BuildDepositTxQueryParamsSchema = type({
   amount: parsableBigNumberString(),
   token: validAddress(),
-  isNative: boolStr(),
   destinationChainId: positiveIntStr(),
   originChainId: positiveIntStr(),
   recipient: validAddress(),
@@ -25,7 +25,7 @@ const BuildDepositTxQueryParamsSchema = type({
   quoteTimestamp: positiveIntStr(),
   message: optional(string()),
   maxCount: optional(boolStr()),
-  referrer: optional(validAddress()),
+  referrer: optional(validAddressOrENS()),
 });
 
 type BuildDepositTxQueryParams = Infer<typeof BuildDepositTxQueryParamsSchema>;
@@ -86,10 +86,7 @@ const handler = async (
     );
 
     // do not tag a referrer if data is not provided as a hex string.
-    tx.data =
-      referrer && ethers.utils.isAddress(referrer)
-        ? tagReferrer(tx.data!, referrer)
-        : tx.data;
+    tx.data = referrer ? await tagReferrer(tx.data!, referrer) : tx.data;
 
     const responseJson = {
       data: tx.data,

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -168,7 +168,7 @@ const handler = async (
       timestamp: parsedTimestamp.toString(),
       isAmountTooLow: relayerFeeDetails.isAmountTooLow,
       quoteBlock: blockTag.toString(),
-      spokePoolAddress: getSpokePoolAddress(Number(originChainId)),
+      spokePoolAddress: getSpokePoolAddress(Number(computedOriginChainId)),
     };
 
     logger.debug({

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -23,6 +23,7 @@ import {
   boolStr,
   HUP_POOL_CHAIN_ID,
   ENABLED_ROUTES,
+  getSpokePoolAddress,
 } from "./_utils";
 
 const SuggestedFeesQueryParamsSchema = type({
@@ -167,6 +168,7 @@ const handler = async (
       timestamp: parsedTimestamp.toString(),
       isAmountTooLow: relayerFeeDetails.isAmountTooLow,
       quoteBlock: blockTag.toString(),
+      spokePoolAddress: getSpokePoolAddress(Number(originChainId)),
     };
 
     logger.debug({

--- a/api/token-list.ts
+++ b/api/token-list.ts
@@ -55,15 +55,15 @@ const handler = async (_: TypedVercelRequest<{}>, response: VercelResponse) => {
     // Two different explanations for how `stale-while-revalidate` works:
 
     // https://vercel.com/docs/concepts/edge-network/caching#stale-while-revalidate
-    // This tells our CDN the value is fresh for 6 hours. If a request is repeated within the next 6 hours,
+    // This tells our CDN the value is fresh for 7 days. If a request is repeated within the next 7 days,
     // the previously cached value is still fresh. The header x-vercel-cache present in the response will show the
-    // value HIT. If the request is repeated up to 6 hours later, the cached value will be stale but
+    // value HIT. If the request is repeated up to 7 days later, the cached value will be stale but
     // still render. In the background, a revalidation request will be made to populate the cache with a fresh value.
     // x-vercel-cache will have the value STALE until the cache is refreshed.
 
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
-    // The response is fresh for 6 hours. After 6 hours it becomes stale, but the cache is allowed to reuse it
-    // for any requests that are made in the following 6 hours, provided that they revalidate the response in the background.
+    // The response is fresh for 7 days. After 7 days it becomes stale, but the cache is allowed to reuse it
+    // for any requests that are made in the following 7 days, provided that they revalidate the response in the background.
     // Revalidation will make the cache be fresh again, so it appears to clients that it was always fresh during
     // that period — effectively hiding the latency penalty of revalidation from them.
     // If no request happened during that period, the cache became stale and the next request will revalidate normally.
@@ -74,7 +74,7 @@ const handler = async (_: TypedVercelRequest<{}>, response: VercelResponse) => {
     });
     response.setHeader(
       "Cache-Control",
-      "s-maxage=21600, stale-while-revalidate=21600"
+      "s-maxage=604800, stale-while-revalidate=604800"
     );
     response.status(200).json(enrichedTokensPerChain);
   } catch (error: unknown) {

--- a/api/token-list.ts
+++ b/api/token-list.ts
@@ -1,0 +1,85 @@
+import { VercelResponse } from "@vercel/node";
+import { constants } from "@across-protocol/sdk-v2";
+import {
+  getLogger,
+  handleErrorCondition,
+  getFallbackTokenLogoURI,
+  ENABLED_ROUTES,
+} from "./_utils";
+import { TypedVercelRequest } from "./_types";
+
+const handler = async (_: TypedVercelRequest<{}>, response: VercelResponse) => {
+  const logger = getLogger();
+
+  try {
+    const tokensPerChain = ENABLED_ROUTES.routes.reduce(
+      (acc, route) => {
+        return {
+          ...acc,
+          [`${route.fromTokenSymbol}-${route.fromChain}`]: {
+            symbol: route.fromTokenSymbol,
+            chainId: route.fromChain,
+            address: route.fromTokenAddress,
+            isNative: route.isNative,
+            l1TokenAddress: route.l1TokenAddress,
+          },
+        };
+      },
+      {} as Record<
+        string,
+        {
+          symbol: string;
+          chainId: number;
+          address: string;
+          isNative: boolean;
+          l1TokenAddress: string;
+        }
+      >
+    );
+
+    const enrichedTokensPerChain = Object.values(tokensPerChain).map(
+      (token) => {
+        const tokenInfo =
+          constants.TOKEN_SYMBOLS_MAP[
+            token.symbol as keyof typeof constants.TOKEN_SYMBOLS_MAP
+          ];
+        return {
+          ...token,
+          name: tokenInfo.name,
+          decimals: tokenInfo.decimals,
+          logoURI: getFallbackTokenLogoURI(token.l1TokenAddress),
+        };
+      }
+    );
+
+    // Two different explanations for how `stale-while-revalidate` works:
+
+    // https://vercel.com/docs/concepts/edge-network/caching#stale-while-revalidate
+    // This tells our CDN the value is fresh for 6 hours. If a request is repeated within the next 6 hours,
+    // the previously cached value is still fresh. The header x-vercel-cache present in the response will show the
+    // value HIT. If the request is repeated up to 6 hours later, the cached value will be stale but
+    // still render. In the background, a revalidation request will be made to populate the cache with a fresh value.
+    // x-vercel-cache will have the value STALE until the cache is refreshed.
+
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+    // The response is fresh for 6 hours. After 6 hours it becomes stale, but the cache is allowed to reuse it
+    // for any requests that are made in the following 6 hours, provided that they revalidate the response in the background.
+    // Revalidation will make the cache be fresh again, so it appears to clients that it was always fresh during
+    // that period — effectively hiding the latency penalty of revalidation from them.
+    // If no request happened during that period, the cache became stale and the next request will revalidate normally.
+    logger.debug({
+      at: "TokenList",
+      message: "Response data",
+      responseJson: enrichedTokensPerChain,
+    });
+    response.setHeader(
+      "Cache-Control",
+      "s-maxage=21600, stale-while-revalidate=21600"
+    );
+    response.status(200).json(enrichedTokensPerChain);
+  } catch (error: unknown) {
+    return handleErrorCondition("token-list", response, logger, error);
+  }
+};
+
+export default handler;


### PR DESCRIPTION
This PR adds some helper endpoints in an effort to be included in the DODO aggregator:

- `GET /api/build-deposit-tx`
  - Populates a raw deposit tx that can be signed. See https://github.com/DODOEX/dodo-bridge-aggregator#iv-buildtransactiondata
- `GET /api/token-list`
  - Returns a list of enabled tokens per enabled chain. See https://github.com/DODOEX/dodo-bridge-aggregator#iii-tokenlist

