### PR TITLE
feat(vercel): add env var to disable tokens in API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,3 +113,6 @@ REACT_APP_ENABLE_SENTRY=
 
 # Comma-separated list of tokens to disable bridging for in the UI, e.g. "BOBA,DAI"
 REACT_APP_DISABLED_BRIDGE_TOKENS=
+
+# Comma-separated list of tokens to disable in the API, e.g. "BOBA,DAI"
+DISABLED_ROUTE_TOKENS=

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -45,6 +45,11 @@ export const FLAT_RELAY_CAPITAL_FEE = Number(
   process.env.REACT_APP_FLAT_RELAY_CAPITAL_FEE ?? 0.03
 ); // 0.03%
 
+// Tokens that should be disabled in the routes
+export const DISABLED_ROUTE_TOKENS = (
+  process.env.DISABLED_ROUTE_TOKENS || ""
+).split(",");
+
 export const ENABLED_ROUTES =
   HUP_POOL_CHAIN_ID === 1
     ? enabledMainnetRoutesAsJson
@@ -532,7 +537,8 @@ export const isRouteEnabled = (
   fromToken: string
 ): boolean => {
   const enabled = ENABLED_ROUTES.routes.some(
-    ({ fromTokenAddress, fromChain, toChain }) =>
+    ({ fromTokenAddress, fromChain, toChain, fromTokenSymbol }) =>
+      !DISABLED_ROUTE_TOKENS.includes(fromTokenSymbol) &&
       fromChainId === fromChain &&
       toChainId === toChain &&
       fromToken.toLowerCase() === fromTokenAddress.toLowerCase()

--- a/api/available-routes.ts
+++ b/api/available-routes.ts
@@ -7,6 +7,7 @@ import {
   positiveIntStr,
   ENABLED_ROUTES,
   handleErrorCondition,
+  DISABLED_ROUTE_TOKENS,
 } from "./_utils";
 import { TypedVercelRequest } from "./_types";
 
@@ -39,6 +40,11 @@ const handler = async (
     const { originToken, destinationToken, originChainId, destinationChainId } =
       query;
 
+    // Filter out disabled routes
+    const availableRoutes = ENABLED_ROUTES.routes.filter(
+      (route) => !DISABLED_ROUTE_TOKENS.includes(route.fromTokenSymbol)
+    );
+
     // Generate a mapping that contains similar tokens on each chain
     // Note:  The key in this dictionary represents an l1Token address, and
     //        the corresponding value is a nested hashmap containing a key
@@ -48,7 +54,7 @@ const handler = async (
       l1TokenAddress,
       fromChain,
       fromTokenAddress,
-    } of ENABLED_ROUTES.routes) {
+    } of availableRoutes) {
       l1TokensToDestinationTokens[l1TokenAddress] = {
         ...l1TokensToDestinationTokens[l1TokenAddress],
         [fromChain]: fromTokenAddress,
@@ -56,7 +62,7 @@ const handler = async (
     }
 
     const enabledRoutes = applyMapFilter(
-      ENABLED_ROUTES.routes,
+      availableRoutes,
       // Filter out elements from the request query parameters
       (route: {
         originToken: string;


### PR DESCRIPTION
I decided to add a separate env var for disabling tokens in the API because for testing purposes it was handy to have new tokens enabled in the API but disabled in the UI.