### PR TITLE
feat: display weth info when bridging eth mainnet -> polygon or contract

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -23,13 +23,13 @@ export type TooltipIcon =
   | "clock";
 export interface TooltipProps {
   icon?: TooltipIcon;
-  title: string;
+  title?: string;
   titleSecondary?: string;
   body: string;
 }
 
 export const PopperTooltip: React.FC<{
-  title: string;
+  title?: string;
   body: string;
   icon?: TooltipIcon;
   placement?: Placement;
@@ -99,16 +99,18 @@ export const Tooltip: React.FC<TooltipProps> = ({
 }) => {
   return (
     <Wrapper>
-      <TitleRow>
-        {icon === "green-checkmark" && <RoundedCheckmark16 />}
-        {icon === "grey-checkmark" && <GreyRoundedCheckmark16 />}
-        {icon === "self-referral" && <SelfReferralIcon />}
-        {icon === "referral" && <ReferrerIcon />}
-        {icon === "referee" && <RefereeIcon />}
-        {icon === "clock" && <ClockIcon />}
-        {title}
-        {titleSecondary && <TitleSecondary>{titleSecondary}</TitleSecondary>}
-      </TitleRow>
+      {title && (
+        <TitleRow>
+          {icon === "green-checkmark" && <RoundedCheckmark16 />}
+          {icon === "grey-checkmark" && <GreyRoundedCheckmark16 />}
+          {icon === "self-referral" && <SelfReferralIcon />}
+          {icon === "referral" && <ReferrerIcon />}
+          {icon === "referee" && <RefereeIcon />}
+          {icon === "clock" && <ClockIcon />}
+          {title}
+          {titleSecondary && <TitleSecondary>{titleSecondary}</TitleSecondary>}
+        </TitleRow>
+      )}
       <Body>{body}</Body>
     </Wrapper>
   );

--- a/src/hooks/useConnection.ts
+++ b/src/hooks/useConnection.ts
@@ -1,10 +1,9 @@
-import { useState, useEffect } from "react";
-import { useOnboard } from "hooks/useOnboard";
 import { ethers } from "ethers";
-import { getCode, noContractCode } from "utils";
+
+import { useOnboard } from "hooks/useOnboard";
+import { useIsContractAddress } from "hooks/useIsContractAddress";
 
 export function useConnection() {
-  const [isContractAddress, setIsContractAddress] = useState(false);
   const {
     provider,
     signer,
@@ -21,19 +20,7 @@ export function useConnection() {
     didAttemptAutoSelect,
   } = useOnboard();
 
-  useEffect(() => {
-    setIsContractAddress(false);
-    if (account && chainId) {
-      const addr = ethers.utils.getAddress(account.address);
-      getCode(addr, chainId)
-        .then((res) => {
-          setIsContractAddress(res !== noContractCode);
-        })
-        .catch((err) => {
-          console.log("err in getCode call", err);
-        });
-    }
-  }, [account, chainId]);
+  const isContractAddress = useIsContractAddress(account?.address, chainId);
 
   return {
     account: account ? ethers.utils.getAddress(account.address) : undefined,

--- a/src/hooks/useIsContractAddress.ts
+++ b/src/hooks/useIsContractAddress.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from "react";
+
+import { getCode, noContractCode } from "utils";
+
+export function useIsContractAddress(address?: string, chainId = 1) {
+  const [isContractAddress, setIsContractAddress] = useState(false);
+
+  useEffect(() => {
+    setIsContractAddress(false);
+    if (address && chainId) {
+      getCode(address, chainId)
+        .then((res) => {
+          setIsContractAddress(res !== noContractCode);
+        })
+        .catch((err) => {
+          console.log("err in getCode call", err);
+        });
+    }
+  }, [address, chainId]);
+
+  return isContractAddress;
+}

--- a/src/hooks/useIsContractAddress.ts
+++ b/src/hooks/useIsContractAddress.ts
@@ -6,7 +6,6 @@ export function useIsContractAddress(address?: string, chainId = 1) {
   const [isContractAddress, setIsContractAddress] = useState(false);
 
   useEffect(() => {
-    setIsContractAddress(false);
     if (address && chainId) {
       getCode(address, chainId)
         .then((res) => {

--- a/src/hooks/useIsContractAddress.ts
+++ b/src/hooks/useIsContractAddress.ts
@@ -14,6 +14,8 @@ export function useIsContractAddress(address?: string, chainId = 1) {
         .catch((err) => {
           console.log("err in getCode call", err);
         });
+    } else {
+      setIsContractAddress(false);
     }
   }, [address, chainId]);
 

--- a/src/views/Bridge/Bridge.tsx
+++ b/src/views/Bridge/Bridge.tsx
@@ -32,7 +32,7 @@ const Bridge = () => {
     displayChangeAccount,
     setDisplayChangeAccount,
     toAccount,
-    setToAccount,
+    setCustomToAddress,
     trackingTxHash,
     transactionPending,
     onTxHashChange,
@@ -56,8 +56,8 @@ const Bridge = () => {
         <ChangeAccountModal
           displayModal={displayChangeAccount}
           displayModalCloseHandler={() => setDisplayChangeAccount(false)}
-          currentAccount={toAccount}
-          changeAccountHandler={setToAccount}
+          currentAccount={toAccount?.address}
+          changeAccountHandler={setCustomToAddress}
         />
       )}
       <LayoutV2 maxWidth={600}>

--- a/src/views/Bridge/components/BridgeForm.tsx
+++ b/src/views/Bridge/components/BridgeForm.tsx
@@ -19,6 +19,7 @@ import EstimatedTable from "./EstimatedTable";
 import QuickSwap from "./QuickSwap";
 import SlippageAlert from "./SlippageAlert";
 import { BigNumber } from "ethers";
+import { ToAccount } from "../hooks/useToAccount";
 
 type BridgeFormProps = {
   availableTokens: TokenInfo[];
@@ -46,7 +47,7 @@ type BridgeFormProps = {
   estimatedTime: string | undefined;
   displayChangeAccount: boolean;
   setDisplayChangeAccount: (display: boolean) => void;
-  toAccount?: string;
+  toAccount?: ToAccount;
   amountTooLow: boolean;
   walletAccount?: string;
   disableQuickSwap?: boolean;
@@ -107,6 +108,9 @@ const BridgeForm = ({
         </ChainIconSuperTextWrapper>
       </ChainIconTextWrapper>
     ) : undefined;
+
+  const isRouteMainnetToPolygon =
+    currentFromRoute === 1 && currentToRoute === 137;
 
   return (
     <>
@@ -180,7 +184,7 @@ const BridgeForm = ({
                   (r) => r.chainId === currentToRoute
                 )[0],
                 toAccount
-                  ? `Address: ${shortenAddress(toAccount, "...", 4)}`
+                  ? `Address: ${shortenAddress(toAccount.address, "...", 4)}`
                   : undefined
               )}
               selectedValue={currentToRoute ?? 1}
@@ -218,6 +222,7 @@ const BridgeForm = ({
             }
             token={getToken(currentToken)}
             dataLoaded={isConnected}
+            willReceiveWETH={isRouteMainnetToPolygon || toAccount?.isContract}
           />
         )}
         <Divider />

--- a/src/views/Bridge/components/ChangeAccountModal.tsx
+++ b/src/views/Bridge/components/ChangeAccountModal.tsx
@@ -39,7 +39,7 @@ const ChangeAccountModal = ({
   }, [currentAccount, userInput]);
 
   const onSaveHandler = () => {
-    if (validInput) {
+    if (validInput || userInput === "") {
       changeAccountHandler(userInput);
       addToAmpliQueue(() => {
         ampli.toAccountChanged({
@@ -84,7 +84,10 @@ const ChangeAccountModal = ({
                 Cancel
               </Text>
             </CancelButton>
-            <SaveButton disabled={!validInput} onClick={onSaveHandler}>
+            <SaveButton
+              disabled={!validInput && !!userInput}
+              onClick={onSaveHandler}
+            >
               <Text size="lg" weight={500} color="dark-grey">
                 Save
               </Text>

--- a/src/views/Bridge/components/EstimatedTable.tsx
+++ b/src/views/Bridge/components/EstimatedTable.tsx
@@ -1,7 +1,17 @@
 import styled from "@emotion/styled";
-import { Text } from "components/Text";
 import { BigNumber } from "ethers";
-import { capitalizeFirstLetter, getChainInfo, TokenInfo } from "utils";
+
+import { Text } from "components/Text";
+import { PopperTooltip } from "components/Tooltip";
+import { ReactComponent as InfoIcon } from "assets/icons/info-16.svg";
+
+import {
+  capitalizeFirstLetter,
+  getChainInfo,
+  TokenInfo,
+  getToken,
+} from "utils";
+
 import TokenFee from "./TokenFee";
 
 type EstimatedTableProps = {
@@ -12,6 +22,7 @@ type EstimatedTableProps = {
   totalReceived?: BigNumber;
   token: TokenInfo;
   dataLoaded: boolean;
+  willReceiveWETH?: boolean;
 };
 
 const EstimatedTable = ({
@@ -21,6 +32,7 @@ const EstimatedTable = ({
   bridgeFee,
   token,
   totalReceived,
+  willReceiveWETH,
 }: EstimatedTableProps) => (
   <Wrapper>
     <Row>
@@ -56,7 +68,11 @@ const EstimatedTable = ({
       </Text>
       <Text size="md" color="grey-400">
         {totalReceived ? (
-          <TokenFee amount={totalReceived} token={token} />
+          <TotalReceive
+            totalReceived={totalReceived}
+            token={token}
+            willReceiveWETH={willReceiveWETH}
+          />
         ) : (
           "-"
         )}
@@ -64,6 +80,35 @@ const EstimatedTable = ({
     </Row>
   </Wrapper>
 );
+
+function TotalReceive({
+  totalReceived,
+  token,
+  willReceiveWETH,
+}: {
+  totalReceived: BigNumber;
+  willReceiveWETH?: boolean;
+  token: TokenInfo;
+}) {
+  if (!willReceiveWETH) {
+    return <TokenFee amount={totalReceived} token={token} />;
+  }
+  return (
+    <TotalReceiveRow>
+      <PopperTooltip
+        body="When bridging ETH and recipient address is a smart contract, or destination is Polygon, you will receive WETH."
+        placement="bottom-start"
+      >
+        <WarningInfoIcon />
+      </PopperTooltip>
+      <TokenFee
+        amount={totalReceived}
+        token={getToken("WETH")}
+        textColor="warning"
+      />
+    </TotalReceiveRow>
+  );
+}
 
 export default EstimatedTable;
 
@@ -90,4 +135,17 @@ const Row = styled.div`
 
 const WhiteText = styled.span`
   color: #e0f3ff;
+`;
+
+const TotalReceiveRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+`;
+
+const WarningInfoIcon = styled(InfoIcon)`
+  path {
+    stroke: #f9d26c;
+  }
 `;

--- a/src/views/Bridge/components/TokenFee.tsx
+++ b/src/views/Bridge/components/TokenFee.tsx
@@ -6,11 +6,12 @@ import { formatUnits, TokenInfo } from "utils";
 type TokenFeeProps = {
   token: TokenInfo;
   amount: BigNumber;
+  textColor?: string;
 };
 
-const TokenFee = ({ token, amount }: TokenFeeProps) => (
+const TokenFee = ({ token, amount, textColor = "grey-400" }: TokenFeeProps) => (
   <Wrapper>
-    <NumericText size="md" color="grey-400">
+    <NumericText size="md" color={textColor}>
       {formatUnits(amount, token.decimals)} {token.symbol.toUpperCase()}{" "}
     </NumericText>
     <TokenSymbol src={token.logoURI} />

--- a/src/views/Bridge/hooks/useBridge.ts
+++ b/src/views/Bridge/hooks/useBridge.ts
@@ -28,6 +28,7 @@ import {
 import { BridgeLimitInterface } from "utils/serverless-api/types";
 import { useBridgeAction } from "./useBridgeAction";
 import { useBridgeDepositTracking } from "./useBridgeDepositTracking";
+import { useToAccount } from "./useToAccount";
 
 const enabledRoutes = getConfig().getEnabledRoutes();
 
@@ -361,11 +362,7 @@ export function useBridge() {
   const { referrer } = useReferrer();
 
   const [displayChangeAccount, setDisplayChangeAccount] = useState(false);
-  const [toAccount, setToAccount] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    setToAccount(account);
-  }, [account]);
+  const { toAccount, setCustomToAddress } = useToAccount(currentToRoute);
 
   const bridgePayload: AcrossDepositArgs | undefined =
     amountToBridge && currentRoute && fees
@@ -378,7 +375,7 @@ export function useBridge() {
           relayerFeePct: fees.relayerFee.pct,
           tokenAddress: currentRoute.fromTokenAddress,
           isNative: currentRoute.isNative,
-          toAddress: toAccount ?? "",
+          toAddress: toAccount?.address ?? "",
         }
       : undefined;
 
@@ -411,7 +408,7 @@ export function useBridge() {
         tokenInfo,
         fromChainInfo,
         toChainInfo,
-        toAccount,
+        toAccount?.address,
         account,
         tokenPriceInUSD,
         estimatedTimeToRelayObject,
@@ -491,7 +488,7 @@ export function useBridge() {
     ...bridgeAction,
     displayChangeAccount,
     setDisplayChangeAccount,
-    setToAccount,
+    setCustomToAddress,
     toAccount,
     walletAccount: account,
     fees,

--- a/src/views/Bridge/hooks/useToAccount.ts
+++ b/src/views/Bridge/hooks/useToAccount.ts
@@ -1,0 +1,59 @@
+import { useState, useEffect } from "react";
+
+import { useConnection } from "hooks";
+import { getCode } from "utils";
+
+export type ToAccount = {
+  address: string;
+  isContract: boolean;
+};
+
+export function useToAccount(toChainId?: number) {
+  const [customToAddress, setCustomToAddress] = useState<string | undefined>();
+  const [toAccount, setToAccount] = useState<ToAccount | undefined>();
+
+  const {
+    account: connectedAccount,
+    isContractAddress: isConnectedAccountContract,
+  } = useConnection();
+
+  useEffect(() => {
+    if (!toChainId) {
+      return;
+    }
+
+    if (customToAddress) {
+      getCode(customToAddress, toChainId)
+        .then((code) =>
+          setToAccount({
+            address: customToAddress,
+            isContract: code !== "0x",
+          })
+        )
+        .catch((error) => {
+          console.error(error);
+        });
+      setToAccount({
+        address: customToAddress,
+        isContract: false,
+      });
+    } else if (connectedAccount) {
+      setToAccount({
+        address: connectedAccount,
+        isContract: isConnectedAccountContract,
+      });
+    } else {
+      setToAccount(undefined);
+    }
+  }, [
+    customToAddress,
+    connectedAccount,
+    isConnectedAccountContract,
+    toChainId,
+  ]);
+
+  return {
+    toAccount,
+    setCustomToAddress,
+  };
+}

--- a/src/views/Referrals/comp/StepperWithTooltips/useStepperWithTooltips.tsx
+++ b/src/views/Referrals/comp/StepperWithTooltips/useStepperWithTooltips.tsx
@@ -69,7 +69,7 @@ export default function useStepperWithTooltips(
         items.push(
           <StepItemComponent
             key={i}
-            title={tooltips[i].title}
+            title={tooltips[i].title || ""}
             titleSecondary={tooltips[i].titleSecondary}
             body={tooltips[i].body}
             type="completed"
@@ -84,7 +84,7 @@ export default function useStepperWithTooltips(
         items.push(
           <StepItemComponent
             key={i}
-            title={tooltips[i].title}
+            title={tooltips[i].title || ""}
             titleSecondary={tooltips[i].titleSecondary}
             body={tooltips[i].body}
             type="current"
@@ -99,7 +99,7 @@ export default function useStepperWithTooltips(
         items.push(
           <StepItemComponent
             key={i}
-            title={tooltips[i].title}
+            title={tooltips[i].title || ""}
             titleSecondary={tooltips[i].titleSecondary}
             body={tooltips[i].body}
             type="next"


### PR DESCRIPTION
Closes ACX-1119

Displays info tooltip and correct receiving token symbol (WETH) when the user attempts to bridge ETH from Mainnet to Polygon. The same tooltip is also displayed if the receiving address is a contract deployed on the destination chain.

This PR also includes a fix for a bug where a user could not reset/clear a custom changed `toAddress`.