### PR TITLE
fix: weth/eth tooltip and warning

### DIFF
--- a/src/views/Bridge/Bridge.tsx
+++ b/src/views/Bridge/Bridge.tsx
@@ -76,6 +76,7 @@ const Bridge = () => {
               onTxHashChange={onTxHashChange}
               explorerLink={explorerUrl}
               elapsedTimeFromDeposit={transactionElapsedTimeAsFormattedString}
+              toAccount={toAccount}
             />
           ) : (
             <BridgeForm

--- a/src/views/Bridge/components/BridgeForm.tsx
+++ b/src/views/Bridge/components/BridgeForm.tsx
@@ -19,8 +19,9 @@ import EstimatedTable from "./EstimatedTable";
 import QuickSwap from "./QuickSwap";
 import SlippageAlert from "./SlippageAlert";
 import { BigNumber } from "ethers";
-import { ToAccount } from "../hooks/useToAccount";
 import { getReceiveTokenSymbol } from "../utils";
+
+import type { ToAccount } from "../hooks/useToAccount";
 
 type BridgeFormProps = {
   availableTokens: TokenInfo[];

--- a/src/views/Bridge/components/BridgeForm.tsx
+++ b/src/views/Bridge/components/BridgeForm.tsx
@@ -20,6 +20,7 @@ import QuickSwap from "./QuickSwap";
 import SlippageAlert from "./SlippageAlert";
 import { BigNumber } from "ethers";
 import { ToAccount } from "../hooks/useToAccount";
+import { getReceiveTokenSymbol } from "../utils";
 
 type BridgeFormProps = {
   availableTokens: TokenInfo[];
@@ -108,9 +109,6 @@ const BridgeForm = ({
         </ChainIconSuperTextWrapper>
       </ChainIconTextWrapper>
     ) : undefined;
-
-  const isRouteMainnetToPolygon =
-    currentFromRoute === 1 && currentToRoute === 137;
 
   return (
     <>
@@ -222,7 +220,13 @@ const BridgeForm = ({
             }
             token={getToken(currentToken)}
             dataLoaded={isConnected}
-            willReceiveWETH={isRouteMainnetToPolygon || toAccount?.isContract}
+            receiveToken={getToken(
+              getReceiveTokenSymbol(
+                currentToRoute,
+                currentToken,
+                Boolean(toAccount?.isContract)
+              )
+            )}
           />
         )}
         <Divider />

--- a/src/views/Bridge/components/DepositConfirmation.tsx
+++ b/src/views/Bridge/components/DepositConfirmation.tsx
@@ -12,11 +12,14 @@ import { ReactComponent as EthereumGrayscaleLogo } from "assets/grayscale-logos/
 import { ReactComponent as PolygonGrayscaleLogo } from "assets/grayscale-logos/polygon.svg";
 import { ReactComponent as ArbitrumGrayscaleLogo } from "assets/grayscale-logos/arbitrum.svg";
 import { ReactComponent as OptimismGrayscaleLogo } from "assets/grayscale-logos/optimism.svg";
+import { getReceiveTokenSymbol } from "../utils";
+import { ToAccount } from "../hooks/useToAccount";
 
 type DepositConfirmationProps = {
   currentFromRoute: number | undefined;
   currentToRoute: number | undefined;
   currentToken: string;
+  toAccount?: ToAccount;
 
   fees: GetBridgeFeesResult | undefined;
   amountToBridge: BigNumber | undefined;
@@ -34,6 +37,7 @@ const DepositConfirmation = ({
   currentFromRoute,
   currentToRoute,
   currentToken,
+  toAccount,
   fees,
   amountToBridge,
   estimatedTime,
@@ -143,6 +147,13 @@ const DepositConfirmation = ({
         }
         token={getToken(currentToken)}
         dataLoaded={isConnected}
+        receiveToken={getToken(
+          getReceiveTokenSymbol(
+            currentToRoute || 1,
+            currentToken,
+            Boolean(toAccount?.isContract)
+          )
+        )}
       />
       <Divider />
       <Button

--- a/src/views/Bridge/components/EstimatedTable.tsx
+++ b/src/views/Bridge/components/EstimatedTable.tsx
@@ -22,7 +22,7 @@ type EstimatedTableProps = {
   totalReceived?: BigNumber;
   token: TokenInfo;
   dataLoaded: boolean;
-  willReceiveWETH?: boolean;
+  receiveToken: TokenInfo;
 };
 
 const EstimatedTable = ({
@@ -32,7 +32,7 @@ const EstimatedTable = ({
   bridgeFee,
   token,
   totalReceived,
-  willReceiveWETH,
+  receiveToken,
 }: EstimatedTableProps) => (
   <Wrapper>
     <Row>
@@ -71,7 +71,7 @@ const EstimatedTable = ({
           <TotalReceive
             totalReceived={totalReceived}
             token={token}
-            willReceiveWETH={willReceiveWETH}
+            receiveToken={receiveToken}
           />
         ) : (
           "-"
@@ -84,26 +84,31 @@ const EstimatedTable = ({
 function TotalReceive({
   totalReceived,
   token,
-  willReceiveWETH,
+  receiveToken,
 }: {
   totalReceived: BigNumber;
-  willReceiveWETH?: boolean;
+  receiveToken: TokenInfo;
   token: TokenInfo;
 }) {
-  if (!willReceiveWETH) {
+  const areTokensSame = token.symbol === receiveToken.symbol;
+
+  if (areTokensSame) {
     return <TokenFee amount={totalReceived} token={token} />;
   }
+
+  const isBridgeTokenETH = token.symbol === "ETH";
+  const tooltipText = isBridgeTokenETH
+    ? "When bridging ETH and recipient address is a smart contract, or destination is Polygon, you will receive WETH."
+    : "When bridging WETH and recipient address is an EOA, you will receive ETH.";
+
   return (
     <TotalReceiveRow>
-      <PopperTooltip
-        body="When bridging ETH and recipient address is a smart contract, or destination is Polygon, you will receive WETH."
-        placement="bottom-start"
-      >
+      <PopperTooltip body={tooltipText} placement="bottom-start">
         <WarningInfoIcon />
       </PopperTooltip>
       <TokenFee
         amount={totalReceived}
-        token={getToken("WETH")}
+        token={receiveToken}
         textColor="warning"
       />
     </TotalReceiveRow>

--- a/src/views/Bridge/components/EstimatedTable.tsx
+++ b/src/views/Bridge/components/EstimatedTable.tsx
@@ -5,12 +5,7 @@ import { Text } from "components/Text";
 import { PopperTooltip } from "components/Tooltip";
 import { ReactComponent as InfoIcon } from "assets/icons/info-16.svg";
 
-import {
-  capitalizeFirstLetter,
-  getChainInfo,
-  TokenInfo,
-  getToken,
-} from "utils";
+import { capitalizeFirstLetter, getChainInfo, TokenInfo } from "utils";
 
 import TokenFee from "./TokenFee";
 

--- a/src/views/Bridge/utils.ts
+++ b/src/views/Bridge/utils.ts
@@ -1,3 +1,14 @@
+/**
+ * Returns the token symbol to be used for the receive token. The protocol bridges
+ * ETH/WETH depending on certain conditions:
+ * - If the user wants to bridge ETH and destination chain is Polygon, the bridge will send WETH
+ * - If the user wants to bridge ETH and the receiver is a contract, the bridge will send WETH
+ * - If the user wants to bridge WETH and the receiver is an EOA, the bridge will send ETH
+ * @param destinationChainId Destination chain id.
+ * @param bridgeTokenSymbol Token symbol to be bridged.
+ * @param isReceiverContract Whether the receiver is a contract or not.
+ * @returns The token symbol to be used for the receive token.
+ */
 export function getReceiveTokenSymbol(
   destinationChainId: number,
   bridgeTokenSymbol: string,

--- a/src/views/Bridge/utils.ts
+++ b/src/views/Bridge/utils.ts
@@ -1,0 +1,20 @@
+export function getReceiveTokenSymbol(
+  destinationChainId: number,
+  bridgeTokenSymbol: string,
+  isReceiverContract: boolean
+) {
+  const isDestinationChainPolygon = destinationChainId === 137;
+
+  if (
+    bridgeTokenSymbol === "ETH" &&
+    (isDestinationChainPolygon || isReceiverContract)
+  ) {
+    return "WETH";
+  }
+
+  if (bridgeTokenSymbol === "WETH" && !isReceiverContract) {
+    return "ETH";
+  }
+
+  return bridgeTokenSymbol;
+}


### PR DESCRIPTION
Fixes ACX-1119

This refines the tooltip and warning based on the behavior for ETH/WETH:
- If a bridge transfer is being sent to an EOA, the EOA will receive ETH (not WETH)
- If a bridge transfer is being sent to a contract or to Polygon, the contract will receive WETH (not ETH)