### PR TITLE
fix: use default message for speed up

### DIFF
--- a/src/views/Transactions/hooks/useSpeedUp.tsx
+++ b/src/views/Transactions/hooks/useSpeedUp.tsx
@@ -51,7 +51,8 @@ export function useSpeedUp(transfer: Deposit, token: Token) {
 
       const newRecipient =
         args.optionalUpdates?.newRecipient || transfer.recipientAddr;
-      const newMessage = args.optionalUpdates?.newMessage || transfer.message;
+      const newMessage =
+        args.optionalUpdates?.newMessage || transfer.message || "0x";
 
       const typedData = sdkUtils.getUpdateDepositTypedData(
         transfer.depositId,


### PR DESCRIPTION
Fixes ACX-1219

This is only a partial fix. I have another PR https://github.com/across-protocol/scraper-api/pull/241 open for the Scraper that should fully fix the speed up.