### PR TITLE
feat: :art: only reset bridge input on chain switch

### DIFF
--- a/src/views/Bridge/components/CoinSelector.tsx
+++ b/src/views/Bridge/components/CoinSelector.tsx
@@ -148,7 +148,7 @@ function useCoinSelector(
     setUserAmountInput("");
     setAmountToBridge(undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentToken, toChain, fromChain]);
+  }, [currentToken]);
 
   const errorMessage:
     | "insufficientBalance"


### PR DESCRIPTION
This change disallows the input to be automatically reset when switching a chain. When a user attempts to change chains, their input token size will not be changed. However, this may cause invalid inputs if the user switches to a chain where the input token balance is insufficient to bridge.

Breaking Changes: none
