### PR TITLE
feat(api): extend `/pools` to handle balancer pool tokens

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import { constants, relayFeeCalculator } from "@across-protocol/sdk-v2";
+import { constants, relayFeeCalculator, utils } from "@across-protocol/sdk-v2";
 
 export const maxRelayFeePct = 0.25;
 
@@ -101,3 +101,6 @@ export const BLOCK_TAG_LAG = -1;
 // Note: this is a small subset of all the supported base currencies, but since we don't expect to use the others,
 // we've decided to keep this list small for now.
 export const SUPPORTED_CG_BASE_CURRENCIES = new Set(["eth", "usd"]);
+
+// 1:1 because we don't need to handle underlying tokens on FE
+export const EXTERNAL_POOL_TOKEN_EXCHANGE_RATE = utils.fixedPointAdjustment;

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -9,6 +9,8 @@ import * as sdk from "@across-protocol/sdk-v2";
 import { BigNumber, ethers, providers, utils } from "ethers";
 import { Log, Logging } from "@google-cloud/logging";
 import { define, StructError } from "superstruct";
+import { BalancerSDK, BALANCER_NETWORK_CONFIG } from "@balancer-labs/sdk";
+
 import enabledMainnetRoutesAsJson from "../src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json";
 import enabledGoerliRoutesAsJson from "../src/data/routes_5_0x0e2817C49698cc0874204AeDf7c72Be2Bb7fCD5d.json";
 
@@ -786,4 +788,65 @@ export function getFallbackTokenLogoURI(l1TokenAddress: string) {
   }
 
   return `https://github.com/trustwallet/assets/blob/master/blockchains/ethereum/assets/${l1TokenAddress}/logo.png?raw=true`;
+}
+
+export async function getPoolState(
+  tokenAddress: string,
+  externalPoolProvider?: string
+) {
+  if (!externalPoolProvider) {
+    const hubPoolClient = getHubPoolClient();
+    await hubPoolClient.updatePool(tokenAddress);
+    return hubPoolClient.getPoolState(tokenAddress);
+  }
+
+  return getExternalPoolState(tokenAddress, externalPoolProvider);
+}
+
+export async function getExternalPoolState(
+  tokenAddress: string,
+  externalPoolProvider: string
+) {
+  switch (externalPoolProvider) {
+    case "balancer":
+      return getBalancerPoolState(tokenAddress);
+    default:
+      throw new InputError("Invalid external pool provider");
+  }
+}
+
+async function getBalancerPoolState(poolTokenAddress: string) {
+  const supportedBalancerPools = {
+    ACXwstETH: {
+      id: "0x36be1e97ea98ab43b4debf92742517266f5731a3000200000000000000000466",
+      address: "0x32296969ef14eb0c6d29669c550d4a0449130230",
+    },
+  };
+
+  const config = {
+    network: {
+      ...BALANCER_NETWORK_CONFIG[HUB_POOL_CHAIN_ID as 1 | 5],
+      pools: {
+        ...BALANCER_NETWORK_CONFIG[HUB_POOL_CHAIN_ID as 1 | 5].pools,
+        ...supportedBalancerPools,
+      },
+    },
+    rpcUrl: infuraProvider(HUB_POOL_CHAIN_ID).connection.url,
+  };
+  const balancer = new BalancerSDK(config);
+
+  const pool = await balancer.pools.findBy("address", poolTokenAddress);
+
+  if (!pool) {
+    throw new InputError(
+      `Balancer pool with address ${poolTokenAddress} not found`
+    );
+  }
+
+  const apr = await balancer.pools.apr(pool);
+
+  return {
+    estimatedApy: Number(apr.max / 1000).toFixed(2),
+    exchangeRateCurrent: utils.parseEther("1").toString(), // 1:1 because we don't need to handle underlying tokens on FE
+  };
 }

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -820,11 +820,14 @@ export async function getExternalPoolState(
 }
 
 async function getBalancerPoolState(poolTokenAddress: string) {
-  const supportedBalancerPools = {
-    ACXwstETH: {
-      id: "0x36be1e97ea98ab43b4debf92742517266f5731a3000200000000000000000466",
-      address: "0x32296969ef14eb0c6d29669c550d4a0449130230",
+  const supportedBalancerPoolsMap = {
+    1: {
+      "50wstETH-50ACX": {
+        id: "0x36be1e97ea98ab43b4debf92742517266f5731a3000200000000000000000466",
+        address: "0x36Be1E97eA98AB43b4dEBf92742517266F5731a3",
+      },
     },
+    5: {},
   };
 
   const config = {
@@ -832,14 +835,17 @@ async function getBalancerPoolState(poolTokenAddress: string) {
       ...BALANCER_NETWORK_CONFIG[HUB_POOL_CHAIN_ID as 1 | 5],
       pools: {
         ...BALANCER_NETWORK_CONFIG[HUB_POOL_CHAIN_ID as 1 | 5].pools,
-        ...supportedBalancerPools,
+        ...supportedBalancerPoolsMap[HUB_POOL_CHAIN_ID as 1 | 5],
       },
     },
     rpcUrl: infuraProvider(HUB_POOL_CHAIN_ID).connection.url,
   };
   const balancer = new BalancerSDK(config);
 
-  const pool = await balancer.pools.findBy("address", poolTokenAddress);
+  const pool = await balancer.pools.findBy(
+    "address",
+    poolTokenAddress.toLowerCase()
+  );
 
   if (!pool) {
     throw new InputError(

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -14,7 +14,11 @@ import { BalancerSDK, BALANCER_NETWORK_CONFIG } from "@balancer-labs/sdk";
 import enabledMainnetRoutesAsJson from "../src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json";
 import enabledGoerliRoutesAsJson from "../src/data/routes_5_0x0e2817C49698cc0874204AeDf7c72Be2Bb7fCD5d.json";
 
-import { maxRelayFeePct, relayerFeeCapitalCostConfig } from "./_constants";
+import {
+  maxRelayFeePct,
+  relayerFeeCapitalCostConfig,
+  EXTERNAL_POOL_TOKEN_EXCHANGE_RATE,
+} from "./_constants";
 import { StaticJsonRpcProvider } from "@ethersproject/providers";
 import QueryBase from "@across-protocol/sdk-v2/dist/relayFeeCalculator/chain-queries/baseQuery";
 import { VercelResponse } from "@vercel/node";
@@ -847,6 +851,6 @@ async function getBalancerPoolState(poolTokenAddress: string) {
 
   return {
     estimatedApy: Number(apr.max / 1000).toFixed(2),
-    exchangeRateCurrent: utils.parseEther("1").toString(), // 1:1 because we don't need to handle underlying tokens on FE
+    exchangeRateCurrent: EXTERNAL_POOL_TOKEN_EXCHANGE_RATE,
   };
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@across-protocol/sdk-v2": "^0.10.4",
     "@amplitude/analytics-browser": "^1.6.6",
     "@amplitude/marketing-analytics-browser": "^0.3.6",
+    "@balancer-labs/sdk": "^1.1.3",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/src/utils/serverless-api/mocked/index.ts
+++ b/src/utils/serverless-api/mocked/index.ts
@@ -7,6 +7,7 @@ import { retrieveDiscordUserDetailsMockedCall } from "./retrieve-user-details.mo
 import { getDepositStatsMocked } from "./get-deposit-stats.mocked";
 import { coingeckoMockedApiCall } from "./coingecko.mocked";
 import { retrieveLimitsMocked } from "./bridge-limits.mocked";
+import { poolsApiCall } from "./pools.mocked";
 
 export const mockedEndpoints: ServerlessAPIEndpoints = {
   coingecko: coingeckoMockedApiCall,
@@ -21,4 +22,5 @@ export const mockedEndpoints: ServerlessAPIEndpoints = {
   splash: {
     getStats: getDepositStatsMocked,
   },
+  pools: poolsApiCall,
 };

--- a/src/utils/serverless-api/mocked/pools.mocked.ts
+++ b/src/utils/serverless-api/mocked/pools.mocked.ts
@@ -1,0 +1,11 @@
+import { PoolQueryData } from "../prod/pools";
+
+export async function poolsApiCall(
+  l1TokenOrExternalPoolToken: string,
+  externalPoolProvider?: string
+): Promise<PoolQueryData> {
+  return {
+    estimatedApy: "0.234",
+    exchangeRateCurrent: "1000000000000000000",
+  };
+}

--- a/src/utils/serverless-api/prod/index.ts
+++ b/src/utils/serverless-api/prod/index.ts
@@ -7,6 +7,7 @@ import rewardsApiCall from "./rewards";
 import { getDepositStats } from "./get-deposit-stats.prod";
 import { coingeckoApiCall } from "./coingecko";
 import { retrieveLimits } from "./retrieveLimits";
+import { poolsApiCall } from "./pools";
 
 export const prodEndpoints: ServerlessAPIEndpoints = {
   coingecko: coingeckoApiCall,
@@ -21,4 +22,5 @@ export const prodEndpoints: ServerlessAPIEndpoints = {
   splash: {
     getStats: getDepositStats,
   },
+  pools: poolsApiCall,
 };

--- a/src/utils/serverless-api/prod/pools.ts
+++ b/src/utils/serverless-api/prod/pools.ts
@@ -1,0 +1,21 @@
+import axios from "axios";
+
+export type PoolsApiCall = typeof poolsApiCall;
+
+export type PoolQueryData = {
+  estimatedApy: string;
+  exchangeRateCurrent: string;
+};
+
+export async function poolsApiCall(
+  l1TokenOrExternalPoolToken: string,
+  externalPoolProvider?: string
+): Promise<PoolQueryData> {
+  const response = await axios.get(`/api/pools`, {
+    params: {
+      token: l1TokenOrExternalPoolToken,
+      externalPoolProvider,
+    },
+  });
+  return response.data;
+}

--- a/src/utils/serverless-api/types.ts
+++ b/src/utils/serverless-api/types.ts
@@ -2,6 +2,7 @@ import { BigNumber, ethers, providers } from "ethers";
 import { Fee } from "utils/bridge";
 import { ChainId } from "utils/constants";
 import { CoingeckoApiCall } from "./prod/coingecko";
+import { PoolsApiCall } from "./prod/pools";
 
 export type ServerlessAPIEndpoints = {
   coingecko: CoingeckoApiCall;
@@ -16,6 +17,7 @@ export type ServerlessAPIEndpoints = {
   splash: {
     getStats: GetDepositStatsType;
   };
+  pools: PoolsApiCall;
 };
 
 export type RewardsApiFunction =

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,6 +2565,34 @@
     "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
+"@balancer-labs/sdk@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@balancer-labs/sdk/-/sdk-1.1.3.tgz#95bf8039f71d88b11c87425348ca8902eb38bfae"
+  integrity sha512-xUQHv0JW+cMEKbhpngeMfodUO0IbyKPHovOXpIDRYbscsNZWpKPtL4qrqyRH6m1f+/F3aImRZ7s1jKygnxQKug==
+  dependencies:
+    "@balancer-labs/sor" "4.1.1-beta.13"
+    "@ethersproject/abi" "^5.4.0"
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/base64" "5.5.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/contracts" "^5.4.0"
+    "@ethersproject/providers" "^5.4.5"
+    axios "^0.24.0"
+    graphql "^15.6.1"
+    graphql-request "^3.5.0"
+    json-to-graphql-query "^2.2.4"
+    lodash "^4.17.21"
+
+"@balancer-labs/sor@4.1.1-beta.13":
+  version "4.1.1-beta.13"
+  resolved "https://registry.yarnpkg.com/@balancer-labs/sor/-/sor-4.1.1-beta.13.tgz#b86c7dd693906259e4dd9adf574fafef8e50d048"
+  integrity sha512-zRezUNHcZ5mzfW8rSZZ83/xmxY//isNMmtdoL5edmFg/GRk3zDoGAO2h7OehksIRm74pqZqwpekzvFCf5pDm8g==
+  dependencies:
+    isomorphic-fetch "^2.2.1"
+
 "@base2/pretty-print-object@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.1.tgz#371ba8be66d556812dc7fb169ebc3c08378f69d4"
@@ -3422,7 +3450,7 @@
     "@ethersproject/logger" "^5.5.0"
     bn.js "^4.11.9"
 
-"@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.0.13", "@ethersproject/bignumber@^5.0.5", "@ethersproject/bignumber@^5.4.1", "@ethersproject/bignumber@^5.5.0", "@ethersproject/bignumber@^5.7.0":
+"@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.0.13", "@ethersproject/bignumber@^5.0.5", "@ethersproject/bignumber@^5.4.0", "@ethersproject/bignumber@^5.4.1", "@ethersproject/bignumber@^5.5.0", "@ethersproject/bignumber@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
   integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
@@ -3466,7 +3494,7 @@
   dependencies:
     "@ethersproject/bignumber" "^5.5.0"
 
-"@ethersproject/constants@5.7.0", "@ethersproject/constants@^5.0.8", "@ethersproject/constants@^5.5.0", "@ethersproject/constants@^5.7.0":
+"@ethersproject/constants@5.7.0", "@ethersproject/constants@^5.0.8", "@ethersproject/constants@^5.4.0", "@ethersproject/constants@^5.5.0", "@ethersproject/constants@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
   integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
@@ -3504,7 +3532,7 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/transactions" "^5.5.0"
 
-"@ethersproject/contracts@5.7.0", "@ethersproject/contracts@^5.4.1", "@ethersproject/contracts@^5.7.0":
+"@ethersproject/contracts@5.7.0", "@ethersproject/contracts@^5.4.0", "@ethersproject/contracts@^5.4.1", "@ethersproject/contracts@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.7.0.tgz#c305e775abd07e48aa590e1a877ed5c316f8bd1e"
   integrity sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==
@@ -3888,7 +3916,7 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
-"@ethersproject/providers@5.7.2", "@ethersproject/providers@^5.4.2", "@ethersproject/providers@^5.4.4", "@ethersproject/providers@^5.5.3", "@ethersproject/providers@^5.7.0", "@ethersproject/providers@^5.7.1", "@ethersproject/providers@^5.7.2":
+"@ethersproject/providers@5.7.2", "@ethersproject/providers@^5.4.2", "@ethersproject/providers@^5.4.4", "@ethersproject/providers@^5.4.5", "@ethersproject/providers@^5.5.3", "@ethersproject/providers@^5.7.0", "@ethersproject/providers@^5.7.1", "@ethersproject/providers@^5.7.2":
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
   integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
@@ -17521,7 +17549,7 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
-graphql-request@^3.3.0:
+graphql-request@^3.3.0, graphql-request@^3.5.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-3.7.0.tgz#c7406e537084f8b9788541e3e6704340ca13055b"
   integrity sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==
@@ -17537,7 +17565,7 @@ graphql-tag@^2.11.0:
   dependencies:
     tslib "^2.1.0"
 
-graphql@^15.4.0:
+graphql@^15.4.0, graphql@^15.6.1:
   version "15.8.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
   integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
@@ -19247,6 +19275,14 @@ isobject@^4.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
 
+isomorphic-fetch@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  integrity sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
+
 isomorphic-unfetch@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
@@ -20217,6 +20253,11 @@ json-text-sequence@~0.1.0:
   integrity sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==
   dependencies:
     delimit-stream "0.1.0"
+
+json-to-graphql-query@^2.2.4:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/json-to-graphql-query/-/json-to-graphql-query-2.2.5.tgz#56b072a693b50fd4dc981367b60d52e3dc78f426"
+  integrity sha512-5Nom9inkIMrtY992LMBBG1Zaekrc10JaRhyZgprwHBVMDtRgllTvzl0oBbg13wJsVZoSoFNNMaeIVQs0P04vsA==
 
 json5@^0.5.1:
   version "0.5.1"
@@ -22177,20 +22218,20 @@ node-fetch@2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@^2.6.1, node-fetch@^2.6.7:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
-  integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
-  dependencies:
-    whatwg-url "^5.0.0"
-
-node-fetch@~1.7.1:
+node-fetch@^1.0.1, node-fetch@~1.7.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@^2.6.1, node-fetch@^2.6.7:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
+  integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -29166,6 +29207,11 @@ whatwg-encoding@^2.0.0:
   integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
   dependencies:
     iconv-lite "0.6.3"
+
+whatwg-fetch@>=0.10.0:
+  version "3.6.17"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.17.tgz#009bbbfc122b227b74ba1ff31536b3a1a0e0e212"
+  integrity sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ==
 
 whatwg-fetch@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
Extends `/pools` API to allow
```
GET /pools?token=0x&externalPoolProvider=balancer
```

Adds support for external Balancer pool. The staking page will eventually call this endpoint on the frontend to determine the pool APY.

Part of ACX-1351