### PR TITLE
feat: allow usage of override infura provider urls everywhere

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -313,21 +313,10 @@ export const getGasMarkup = (chainId: string | number) => {
   return gasMarkup[chainId] ?? DEFAULT_GAS_MARKUP;
 };
 
-export const providerForChain: {
-  [chainId: number]: ethers.providers.StaticJsonRpcProvider;
-} = {
-  1: infuraProvider(1),
-  10: infuraProvider(10),
-  137: infuraProvider(137),
-  42161: infuraProvider(42161),
-  // testnets
-  5: infuraProvider(5),
-  421613: infuraProvider(421613),
-};
 export const queries: Record<number, () => QueryBase> = {
   1: () =>
     new sdk.relayFeeCalculator.EthereumQueries(
-      providerForChain[1],
+      getProvider(1),
       undefined,
       undefined,
       undefined,
@@ -338,7 +327,7 @@ export const queries: Record<number, () => QueryBase> = {
     ),
   10: () =>
     new sdk.relayFeeCalculator.OptimismQueries(
-      providerForChain[10],
+      getProvider(10),
       undefined,
       undefined,
       undefined,
@@ -349,7 +338,7 @@ export const queries: Record<number, () => QueryBase> = {
     ),
   137: () =>
     new sdk.relayFeeCalculator.PolygonQueries(
-      providerForChain[137],
+      getProvider(137),
       undefined,
       undefined,
       undefined,
@@ -360,7 +349,7 @@ export const queries: Record<number, () => QueryBase> = {
     ),
   42161: () =>
     new sdk.relayFeeCalculator.ArbitrumQueries(
-      providerForChain[42161],
+      getProvider(42161),
       undefined,
       undefined,
       undefined,
@@ -372,7 +361,7 @@ export const queries: Record<number, () => QueryBase> = {
   // testnets
   5: () =>
     new sdk.relayFeeCalculator.EthereumQueries(
-      providerForChain[5],
+      getProvider(5),
       undefined,
       "0x063fFa6C9748e3f0b9bA8ee3bbbCEe98d92651f7",
       undefined,
@@ -383,7 +372,7 @@ export const queries: Record<number, () => QueryBase> = {
     ),
   421613: () =>
     new sdk.relayFeeCalculator.EthereumQueries(
-      providerForChain[421613],
+      getProvider(421613),
       undefined,
       undefined,
       undefined,
@@ -489,14 +478,16 @@ export const providerCache: Record<string, StaticJsonRpcProvider> = {};
  * @param _chainId A valid chain identifier where an AcrossV2 contract is deployed
  * @returns A provider object to query the requested blockchain
  */
-export const getProvider = (_chainId: number): providers.Provider => {
+export const getProvider = (
+  _chainId: number
+): providers.StaticJsonRpcProvider => {
   const chainId = _chainId.toString();
   if (!providerCache[chainId]) {
     const override = overrideProvider(chainId);
     if (override) {
       providerCache[chainId] = override;
     } else {
-      providerCache[chainId] = providerForChain[_chainId];
+      providerCache[chainId] = infuraProvider(_chainId);
     }
   }
   return providerCache[chainId];

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -236,7 +236,7 @@ export const infuraProvider = (nameOrChainId: providers.Networkish) => {
 export const overrideProvider = (
   chainId: string
 ): providers.StaticJsonRpcProvider | undefined => {
-  const url = process.env[`OVERRIDE_PROVIDER_${chainId}`];
+  const url = process.env[`REACT_APP_CHAIN_${chainId}_PROVIDER_URL`];
   if (url) {
     return new ethers.providers.StaticJsonRpcProvider(url);
   } else {

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -23,7 +23,7 @@ import {
   validAddress,
   positiveIntStr,
   getLpCushion,
-  infuraProvider,
+  getProvider,
   HUB_POOL_CHAIN_ID,
   ENABLED_ROUTES,
 } from "./_utils";
@@ -52,7 +52,7 @@ const handler = async (
       REACT_APP_TRANSFER_RESTRICTED_RELAYERS, // These are relayers whose funds stay put.
       REACT_APP_MIN_DEPOSIT_USD,
     } = process.env;
-    const provider = infuraProvider(HUB_POOL_CHAIN_ID);
+    const provider = getProvider(HUB_POOL_CHAIN_ID);
     logger.debug({
       at: "limits",
       message: `Using INFURA provider for chain ${HUB_POOL_CHAIN_ID}`,

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -12,7 +12,7 @@ import {
   getLogger,
   getTokenDetails,
   InputError,
-  infuraProvider,
+  getProvider,
   getRelayerFeeDetails,
   isRouteEnabled,
   getCachedTokenPrice,
@@ -53,7 +53,7 @@ const handler = async (
       ? Number(QUOTE_TIMESTAMP_BUFFER)
       : DEFAULT_QUOTE_TIMESTAMP_BUFFER;
 
-    const provider = infuraProvider(HUB_POOL_CHAIN_ID);
+    const provider = getProvider(HUB_POOL_CHAIN_ID);
 
     assert(query, SuggestedFeesQueryParamsSchema);
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -362,13 +362,6 @@ export const FLAT_RELAY_CAPITAL_FEE = process.env
 export const SHOW_ACX_NAV_TOKEN =
   process.env.REACT_APP_SHOW_ACX_NAV_TOKEN === "true";
 export const AddressZero = ethers.constants.AddressZero;
-export const ArbitrumProviderUrl =
-  process.env.REACT_APP_CHAIN_42161_PROVIDER_URL ||
-  `https://arbitrum-mainnet.infura.io/v3/${infuraId}`;
-
-export const PolygonProviderUrl =
-  process.env.REACT_APP_CHAIN_137_PROVIDER_URL ||
-  `https://polygon-mainnet.infura.io/v3/${infuraId}`;
 
 assert(
   isSupportedChainId(hubPoolChainId),

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,25 +1,48 @@
 import { ethers, providers } from "ethers";
 import { hubPoolChainId, ChainId, infuraId } from "./constants";
 
-function getProviderUrl(chainId: number) {
-  const overrideUrl = process.env[`REACT_APP_CHAIN_${chainId}_PROVIDER_URL`];
-  if (overrideUrl) {
-    return overrideUrl;
-  }
-
+function getInfuraProviderUrl(chainId: number) {
   const infuraUrl = new providers.InfuraProvider(chainId, infuraId).connection
     .url;
   return infuraUrl;
 }
 
 export const providerUrls: [ChainId, string][] = [
-  [ChainId.MAINNET, getProviderUrl(ChainId.MAINNET)],
-  [ChainId.ARBITRUM, getProviderUrl(ChainId.ARBITRUM)],
-  [ChainId.POLYGON, getProviderUrl(ChainId.POLYGON)],
-  [ChainId.OPTIMISM, getProviderUrl(ChainId.OPTIMISM)],
-  [ChainId.ARBITRUM_GOERLI, getProviderUrl(ChainId.ARBITRUM_GOERLI)],
-  [ChainId.GOERLI, getProviderUrl(ChainId.GOERLI)],
-  [ChainId.MUMBAI, getProviderUrl(ChainId.MUMBAI)],
+  [
+    ChainId.MAINNET,
+    process.env.REACT_APP_CHAIN_1_PROVIDER_URL ||
+      getInfuraProviderUrl(ChainId.MAINNET),
+  ],
+  [
+    ChainId.ARBITRUM,
+    process.env.REACT_APP_CHAIN_42161_PROVIDER_URL ||
+      getInfuraProviderUrl(ChainId.ARBITRUM),
+  ],
+  [
+    ChainId.POLYGON,
+    process.env.REACT_APP_CHAIN_137_PROVIDER_URL ||
+      getInfuraProviderUrl(ChainId.POLYGON),
+  ],
+  [
+    ChainId.OPTIMISM,
+    process.env.REACT_APP_CHAIN_10_PROVIDER_URL ||
+      getInfuraProviderUrl(ChainId.OPTIMISM),
+  ],
+  [
+    ChainId.ARBITRUM_GOERLI,
+    process.env.REACT_APP_CHAIN_421613_PROVIDER_URL ||
+      getInfuraProviderUrl(ChainId.ARBITRUM_GOERLI),
+  ],
+  [
+    ChainId.GOERLI,
+    process.env.REACT_APP_CHAIN_5_PROVIDER_URL ||
+      getInfuraProviderUrl(ChainId.GOERLI),
+  ],
+  [
+    ChainId.MUMBAI,
+    process.env.REACT_APP_CHAIN_80001_PROVIDER_URL ||
+      getInfuraProviderUrl(ChainId.MUMBAI),
+  ],
 ];
 
 export const providerUrlsTable: Record<number, string> =

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,35 +1,38 @@
-import { ethers } from "ethers";
-import { hubPoolChainId, ChainId } from "./constants";
-const infuraId = process.env.REACT_APP_PUBLIC_INFURA_ID || "";
-const ArbitrumProviderUrl =
-  process.env.REACT_APP_CHAIN_42161_PROVIDER_URL ||
-  `https://arbitrum-mainnet.infura.io/v3/${infuraId}`;
+import { ethers, providers } from "ethers";
+import { hubPoolChainId, ChainId, infuraId } from "./constants";
 
-const PolygonProviderUrl =
-  process.env.REACT_APP_CHAIN_137_PROVIDER_URL ||
-  `https://polygon-mainnet.infura.io/v3/${infuraId}`;
+function getProviderUrl(chainId: number) {
+  const overrideUrl = process.env[`REACT_APP_CHAIN_${chainId}_PROVIDER_URL`];
+  if (overrideUrl) {
+    return overrideUrl;
+  }
+
+  const infuraUrl = new providers.InfuraProvider(chainId, infuraId).connection
+    .url;
+  return infuraUrl;
+}
 
 export const providerUrls: [ChainId, string][] = [
-  [ChainId.MAINNET, `https://mainnet.infura.io/v3/${infuraId}`],
-  [ChainId.ARBITRUM, ArbitrumProviderUrl],
-  [ChainId.POLYGON, PolygonProviderUrl],
-  [ChainId.OPTIMISM, `https://optimism-mainnet.infura.io/v3/${infuraId}`],
-  [ChainId.ARBITRUM_GOERLI, `https://arbitrum-goerli.infura.io/v3/${infuraId}`],
-  [ChainId.GOERLI, `https://goerli.infura.io/v3/${infuraId}`],
-  [ChainId.MUMBAI, `https://polygon-mumbai.infura.io/v3/${infuraId}`],
+  [ChainId.MAINNET, getProviderUrl(ChainId.MAINNET)],
+  [ChainId.ARBITRUM, getProviderUrl(ChainId.ARBITRUM)],
+  [ChainId.POLYGON, getProviderUrl(ChainId.POLYGON)],
+  [ChainId.OPTIMISM, getProviderUrl(ChainId.OPTIMISM)],
+  [ChainId.ARBITRUM_GOERLI, getProviderUrl(ChainId.ARBITRUM_GOERLI)],
+  [ChainId.GOERLI, getProviderUrl(ChainId.GOERLI)],
+  [ChainId.MUMBAI, getProviderUrl(ChainId.MUMBAI)],
 ];
 
 export const providerUrlsTable: Record<number, string> =
   Object.fromEntries(providerUrls);
 
-export const providers: [number, ethers.providers.StaticJsonRpcProvider][] =
-  providerUrls.map(([chainId, url]) => {
-    return [chainId, new ethers.providers.StaticJsonRpcProvider(url, chainId)];
-  });
 export const providersTable: Record<
   number,
   ethers.providers.StaticJsonRpcProvider
-> = Object.fromEntries(providers);
+> = Object.fromEntries(
+  providerUrls.map(([chainId, url]) => {
+    return [chainId, new ethers.providers.StaticJsonRpcProvider(url, chainId)];
+  })
+);
 
 export function getProvider(
   chainId: ChainId = hubPoolChainId


### PR DESCRIPTION
This allows the usage of the env var `REACT_APP_CHAIN_<CHAIN_ID>_PROVIDER_URL` to override the default Infura provider URL. 

Setting the above env var will affect all RPC calls for the respective chain in all API handlers and on the frontend. Previously, we had the env var `OVERRIDE_PROVIDER_<CHAIN_ID>` which will be replaced by the shared one on the frontend.