### PR TITLE
fix: failed balance fetch usdbc

### DIFF
--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,13 +1,6 @@
 import { ethers } from "ethers";
 
-import {
-  getProvider,
-  ChainId,
-  getConfig,
-  toWeiSafe,
-  formatUnits,
-  reportTokenBalance,
-} from "utils";
+import { getProvider, ChainId, getConfig, toWeiSafe, formatUnits } from "utils";
 import { ERC20__factory } from "utils/typechain";
 
 export async function getNativeBalance(
@@ -17,9 +10,6 @@ export async function getNativeBalance(
 ) {
   const provider = getProvider(chainId);
   const balance = await provider.getBalance(account, blockNumber);
-
-  reportTokenBalance(chainId, balance, chainId === 137 ? "MATIC" : "ETH");
-
   return balance;
 }
 /**
@@ -38,9 +28,7 @@ export async function getBalance(
 ): Promise<ethers.BigNumber> {
   const provider = getProvider(chainId);
   const contract = ERC20__factory.connect(tokenAddress, provider);
-  const symbol = await contract.symbol({ blockTag: blockNumber });
   const balance = await contract.balanceOf(account, { blockTag: blockNumber });
-  reportTokenBalance(chainId, balance, symbol);
   return balance;
 }
 


### PR DESCRIPTION
Fixes ACX-1498

It was a bit hard to track down the issue due to the side-effect of reporting token balances in the `getBalance` function. I decided to move it out therefore.

But the root cause was that the `getTokenBalance` function fetched the symbol from the erc20 contract and tried to resolve it. Because we handle USDbC on Base the same as USDC, this led to errors.