### PR TITLE
fix: add balancer token computation to API

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -124,3 +124,59 @@ export const ENABLED_POOLS_UNDERLYING_TOKENS = [
 ];
 
 export const SECONDS_PER_YEAR = 365 * 24 * 60 * 60;
+
+export const MINIMAL_BALANCER_V2_POOL_ABI = [
+  {
+    inputs: [],
+    name: "getPoolId",
+    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getVault",
+    outputs: [{ internalType: "contract IVault", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+];
+
+export const MINIMAL_BALANCER_V2_VAULT_ABI = [
+  {
+    inputs: [{ internalType: "bytes32", name: "poolId", type: "bytes32" }],
+    name: "getPoolTokens",
+    outputs: [
+      { internalType: "contract IERC20[]", name: "tokens", type: "address[]" },
+      { internalType: "uint256[]", name: "balances", type: "uint256[]" },
+      { internalType: "uint256", name: "lastChangeBlock", type: "uint256" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+];
+
+export const MINIMAL_MULTICALL3_ABI = [
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "target", type: "address" },
+          { internalType: "bytes", name: "callData", type: "bytes" },
+        ],
+        internalType: "struct Multicall3.Call[]",
+        name: "calls",
+        type: "tuple[]",
+      },
+    ],
+    name: "aggregate",
+    outputs: [
+      { internalType: "uint256", name: "blockNumber", type: "uint256" },
+      { internalType: "bytes[]", name: "returnData", type: "bytes[]" },
+    ],
+    stateMutability: "payable",
+    type: "function",
+  },
+];
+
+export const MULTICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11";

--- a/api/coingecko.ts
+++ b/api/coingecko.ts
@@ -7,6 +7,7 @@ import {
   InputError,
   handleErrorCondition,
   validAddress,
+  getBalancerV2TokenPrice,
 } from "./_utils";
 import { SUPPORTED_CG_BASE_CURRENCIES } from "./_constants";
 
@@ -17,6 +18,7 @@ const {
   REACT_APP_COINGECKO_PRO_API_KEY,
   FIXED_TOKEN_PRICES,
   REDIRECTED_TOKEN_PRICE_LOOKUP_ADDRESSES,
+  BALANCER_V2_TOKENS,
 } = process.env;
 
 // Helper function to fetch prices from coingecko. Can fetch either or both token and base currency.
@@ -28,7 +30,8 @@ const getCoingeckoPrices = async (
   baseCurrency: string,
   hardcodedTokenPrices: {
     [token: string]: number;
-  } = {}
+  } = {},
+  balancerV2PoolTokens: string[] = []
 ): Promise<number> => {
   const baseCurrencyToken = Object.values(sdkConstants.TOKEN_SYMBOLS_MAP).find(
     ({ symbol }) => symbol === baseCurrency.toUpperCase()
@@ -44,37 +47,53 @@ const getCoingeckoPrices = async (
     return 1;
 
   // If either token or base currency is in hardcoded list then use hardcoded USD price.
-  let basePriceUsd = hardcodedTokenPrices[baseCurrentTokenAddress];
-  let tokenPriceUsd = hardcodedTokenPrices[tokenAddress];
+  let basePriceUsdPromise: Promise<number> | number | undefined =
+    hardcodedTokenPrices[baseCurrentTokenAddress];
+  let tokenPriceUsdPromise: Promise<number> | number | undefined =
+    hardcodedTokenPrices[tokenAddress];
+
+  if (
+    basePriceUsdPromise === undefined &&
+    balancerV2PoolTokens.includes(
+      ethers.utils.getAddress(baseCurrentTokenAddress)
+    )
+  ) {
+    // Note this assumes mainnet token because all token addresses are assumed to be mainnet in this function.
+    basePriceUsdPromise = getBalancerV2TokenPrice(baseCurrentTokenAddress);
+  }
+
+  if (
+    tokenPriceUsdPromise === undefined &&
+    balancerV2PoolTokens.includes(ethers.utils.getAddress(tokenAddress))
+  ) {
+    // Note this assumes mainnet token because all token addresses are assumed to be mainnet in this function.
+    basePriceUsdPromise = getBalancerV2TokenPrice(tokenAddress);
+  }
 
   // Fetch undefined base and token USD prices from coingecko client.
   // Always use usd as the base currency for the purpose of conversion.
-  const tokenAddressesToFetchPricesFor = [];
-  if (basePriceUsd === undefined)
-    tokenAddressesToFetchPricesFor.push(baseCurrentTokenAddress);
-  if (tokenPriceUsd === undefined)
-    tokenAddressesToFetchPricesFor.push(tokenAddress);
-
-  // Fetch prices and sanitize returned value
-  const prices = await coingeckoClient.getContractPrices(
-    tokenAddressesToFetchPricesFor,
-    "usd"
-  );
-  if (prices.length === 0 || prices.length > 2)
-    throw new Error("unexpected prices list returned by coingeckoClient");
-
-  // The ordering of the returned values are not guaranteed, so determine the ordering of the two values by
-  // comparing to the l1Token value.
-  if (prices.length === 2)
-    [tokenPriceUsd, basePriceUsd] =
-      prices[0].address.toLowerCase() === tokenAddress.toLowerCase()
-        ? [prices[0].price, prices[1].price]
-        : [prices[1].price, prices[0].price];
-  else {
-    // Only one price was fetched, and it was the one (i.e. base or token) that wasn't hardcoded.
-    if (basePriceUsd === undefined) basePriceUsd = prices[0].price;
-    else tokenPriceUsd = prices[0].price;
+  if (basePriceUsdPromise === undefined && tokenPriceUsdPromise === undefined) {
+    const groupedPromise = coingeckoClient.getContractPrices(
+      [baseCurrentTokenAddress, tokenAddress],
+      "usd"
+    );
+    basePriceUsdPromise = groupedPromise.then((prices) => prices[0].price);
+    tokenPriceUsdPromise = groupedPromise.then((prices) => prices[1].price);
+  } else if (basePriceUsdPromise === undefined) {
+    basePriceUsdPromise = coingeckoClient
+      .getContractPrices([baseCurrentTokenAddress, tokenAddress], "usd")
+      .then((prices) => prices[0].price);
+  } else if (tokenPriceUsdPromise === undefined) {
+    basePriceUsdPromise = coingeckoClient
+      .getContractPrices([baseCurrentTokenAddress, tokenAddress], "usd")
+      .then((prices) => prices[0].price);
   }
+
+  // Extract from a promise.all.
+  const [basePriceUsd, tokenPriceUsd] = await Promise.all([
+    basePriceUsdPromise,
+    tokenPriceUsdPromise,
+  ]);
 
   // Drop any decimals beyond the number of decimals for this token.
   return Number(
@@ -145,6 +164,11 @@ const handler = async (
       ])
     );
 
+    const balancerV2PoolTokens =
+      BALANCER_V2_TOKENS !== undefined
+        ? JSON.parse(BALANCER_V2_TOKENS).map(ethers.utils.getAddress)
+        : [];
+
     // Caller wants to override price for token, possibly because the token is not supported yet on the Coingecko API,
     // so assume the caller set the USD price of the token. We now need to dynamically load the base currency.
     if (
@@ -158,7 +182,8 @@ const handler = async (
           coingeckoClient,
           l1Token,
           baseCurrency,
-          fixedTokenPrices
+          fixedTokenPrices,
+          balancerV2PoolTokens
         );
       }
     }
@@ -174,7 +199,8 @@ const handler = async (
         coingeckoClient,
         l1Token,
         baseCurrency,
-        fixedTokenPrices
+        fixedTokenPrices,
+        balancerV2PoolTokens
       );
     }
 


### PR DESCRIPTION
**Overview**

This computes the price for a balancer v2 token correctly in the API. Previously, this would return 0 in the case of the ACX/wstETH bal pool.

Currently, this PR is in draft, as it has not been tested.