### PR TITLE
fix: do not clear amount input for interchangeable tokens

### DIFF
--- a/src/views/Bridge/hooks/useAmountInput.ts
+++ b/src/views/Bridge/hooks/useAmountInput.ts
@@ -1,16 +1,22 @@
 import { useState, useEffect, useCallback } from "react";
 import { BigNumber, utils } from "ethers";
 
-import { useAmplitude, useBalanceBySymbol } from "hooks";
+import { useAmplitude, useBalanceBySymbol, usePrevious } from "hooks";
 import { getConfig, Route, trackMaxButtonClicked } from "utils";
 
-import { AmountInputError, validateBridgeAmount } from "../utils";
+import {
+  AmountInputError,
+  validateBridgeAmount,
+  areTokensInterchangeable,
+} from "../utils";
 
-export function useAmountInput(selectedRoute: Route, didTxSucceed?: boolean) {
+export function useAmountInput(selectedRoute: Route) {
   const [userAmountInput, setUserAmountInput] = useState("");
   const [parsedAmount, setParsedAmount] = useState<BigNumber | undefined>(
     undefined
   );
+
+  const prevFromTokenSymbol = usePrevious(selectedRoute.fromTokenSymbol);
 
   const { addToAmpliQueue } = useAmplitude();
 
@@ -43,8 +49,18 @@ export function useAmountInput(selectedRoute: Route, didTxSucceed?: boolean) {
   }, []);
 
   useEffect(() => {
+    if (
+      prevFromTokenSymbol === selectedRoute.fromTokenSymbol ||
+      areTokensInterchangeable(
+        prevFromTokenSymbol,
+        selectedRoute.fromTokenSymbol
+      )
+    ) {
+      return;
+    }
+
     clearInput();
-  }, [selectedRoute.fromTokenSymbol, clearInput]);
+  }, [prevFromTokenSymbol, selectedRoute.fromTokenSymbol, clearInput]);
 
   useEffect(() => {
     try {

--- a/src/views/Bridge/utils.ts
+++ b/src/views/Bridge/utils.ts
@@ -19,6 +19,24 @@ export enum AmountInputError {
 
 const enabledRoutes = getConfig().getEnabledRoutes();
 
+const interchangeableTokenPairs: Record<string, string[]> = {
+  USDC: ["USDbC", "USDC.e"],
+  "USDC.e": ["USDC", "USDbC"],
+  USDbC: ["USDC", "USDC.e"],
+  ETH: ["WETH"],
+  WETH: ["ETH"],
+};
+
+export function areTokensInterchangeable(
+  tokenSymbol1: string,
+  tokenSymbol2: string
+) {
+  return (
+    Boolean(interchangeableTokenPairs[tokenSymbol1]) &&
+    interchangeableTokenPairs[tokenSymbol1].includes(tokenSymbol2)
+  );
+}
+
 /**
  * Returns the token symbol to be used for the receive token. The protocol bridges
  * ETH/WETH depending on certain conditions:
@@ -164,13 +182,6 @@ export function findNextBestRoute(
 ) {
   let route: Route | undefined;
 
-  const interchangeableTokenPairs: Record<string, string[]> = {
-    USDC: ["USDbC", "USDC.e"],
-    "USDC.e": ["USDC", "USDbC"],
-    USDbC: ["USDC", "USDC.e"],
-    ETH: ["WETH"],
-    WETH: ["ETH"],
-  };
   const equivalentTokenSymbols = filter.symbol
     ? interchangeableTokenPairs[filter.symbol]
     : undefined;


### PR DESCRIPTION
This PR changes the behavior of clearing the bridge amount input only if the newly selected token is truly different. 