### PR TITLE
fix: update quote on error

### DIFF
--- a/src/views/Bridge/hooks/useBridge.ts
+++ b/src/views/Bridge/hooks/useBridge.ts
@@ -103,10 +103,20 @@ export function useBridge() {
   }, [selectedRoute.fromChain, isConnected, checkWrongNetworkHandler]);
 
   useEffect(() => {
-    if (bridgeAction.isButtonActionLoading || trackingTxHash) {
+    if (
+      shouldUpdateQuote &&
+      (bridgeAction.isButtonActionLoading || trackingTxHash)
+    ) {
       setShouldUpdateQuote(false);
+    } else if (bridgeAction.didActionError && !shouldUpdateQuote) {
+      setShouldUpdateQuote(true);
     }
-  }, [bridgeAction.isButtonActionLoading, trackingTxHash]);
+  }, [
+    shouldUpdateQuote,
+    bridgeAction.isButtonActionLoading,
+    trackingTxHash,
+    bridgeAction.didActionError,
+  ]);
 
   const handleClickNewTx = useCallback(() => {
     clearInput();

--- a/src/views/Bridge/hooks/useBridgeAction.ts
+++ b/src/views/Bridge/hooks/useBridgeAction.ts
@@ -90,21 +90,17 @@ export function useBridgeAction(
     let succeeded = false;
     let timeSigned: number | undefined = undefined;
     let tx: ContractTransaction | undefined = undefined;
+    addToAmpliQueue(() => {
+      // Instrument amplitude before sending the transaction for the submit button.
+      ampli.transferSubmitted(
+        generateTransferSubmitted(frozenQuote, referrer, frozenInitialQuoteTime)
+      );
+    });
+    const timeSubmitted = Date.now();
+
+    tx = await sendAcrossDeposit(signer, frozenPayload);
+
     try {
-      addToAmpliQueue(() => {
-        // Instrument amplitude before sending the transaction for the submit button.
-        ampli.transferSubmitted(
-          generateTransferSubmitted(
-            frozenQuote,
-            referrer,
-            frozenInitialQuoteTime
-          )
-        );
-      });
-      const timeSubmitted = Date.now();
-
-      tx = await sendAcrossDeposit(signer, frozenPayload);
-
       // Instrument amplitude after signing the transaction for the submit button.
       timeSigned = Date.now();
       addToAmpliQueue(() => {
@@ -184,6 +180,7 @@ export function useBridgeAction(
     isConnected,
     buttonActionHandler: buttonActionHandler.mutate,
     isButtonActionLoading: buttonActionHandler.isLoading,
+    didActionError: buttonActionHandler.isError,
     buttonLabel: getButtonLabel({
       isConnected,
       isDataLoading: dataLoading,


### PR DESCRIPTION
Hopefully fixes ACX-1565

I could reproduce the above issue when I rejected the transaction within MetaMask and afterward changed the route or amount.

The root causes were:
- Fees were not updating when the action mutation errored by user rejecting a tx
- We did not let these kinds of errors bubble up and suppressed them.