### PR TITLE
feat: Import CHAIN_IDs and TOKEN_SYMBOLS_MAP from constants-v2 instead of sdk-v2

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -1,10 +1,15 @@
 import { ethers } from "ethers";
-import { constants, relayFeeCalculator, utils } from "@across-protocol/sdk-v2";
+import { relayFeeCalculator, utils } from "@across-protocol/sdk-v2";
+import * as constants from "@across-protocol/constants-v2";
+
+export const TOKEN_SYMBOLS_MAP = constants.TOKEN_SYMBOLS_MAP;
+
+export const CHAIN_IDs = constants.CHAIN_IDs;
 
 export const maxRelayFeePct = 0.25;
 
 export const disabledL1Tokens = [
-  constants.TOKEN_SYMBOLS_MAP.BADGER.addresses[constants.CHAIN_IDs.MAINNET],
+  TOKEN_SYMBOLS_MAP.BADGER.addresses[CHAIN_IDs.MAINNET],
 ].map((x) => x.toLowerCase());
 
 const defaultRelayerFeeCapitalCostConfig: {
@@ -105,22 +110,18 @@ export const SUPPORTED_CG_BASE_CURRENCIES = new Set(["eth", "usd"]);
 // 1:1 because we don't need to handle underlying tokens on FE
 export const EXTERNAL_POOL_TOKEN_EXCHANGE_RATE = utils.fixedPointAdjustment;
 
-export const TOKEN_SYMBOLS_MAP = constants.TOKEN_SYMBOLS_MAP;
-
-export const CHAIN_IDS = constants.CHAIN_IDs;
-
 export const ENABLED_POOLS_UNDERLYING_TOKENS = [
-  constants.TOKEN_SYMBOLS_MAP.ETH,
-  constants.TOKEN_SYMBOLS_MAP.WETH,
-  constants.TOKEN_SYMBOLS_MAP.USDC,
-  constants.TOKEN_SYMBOLS_MAP.USDT,
-  constants.TOKEN_SYMBOLS_MAP.DAI,
-  constants.TOKEN_SYMBOLS_MAP.WBTC,
-  constants.TOKEN_SYMBOLS_MAP.BAL,
-  constants.TOKEN_SYMBOLS_MAP.UMA,
-  constants.TOKEN_SYMBOLS_MAP.ACX,
-  constants.TOKEN_SYMBOLS_MAP.SNX,
-  constants.TOKEN_SYMBOLS_MAP.POOL,
+  TOKEN_SYMBOLS_MAP.ETH,
+  TOKEN_SYMBOLS_MAP.WETH,
+  TOKEN_SYMBOLS_MAP.USDC,
+  TOKEN_SYMBOLS_MAP.USDT,
+  TOKEN_SYMBOLS_MAP.DAI,
+  TOKEN_SYMBOLS_MAP.WBTC,
+  TOKEN_SYMBOLS_MAP.BAL,
+  TOKEN_SYMBOLS_MAP.UMA,
+  TOKEN_SYMBOLS_MAP.ACX,
+  TOKEN_SYMBOLS_MAP.SNX,
+  TOKEN_SYMBOLS_MAP.POOL,
 ];
 
 export const SECONDS_PER_YEAR = 365 * 24 * 60 * 60;

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -24,7 +24,7 @@ import {
 import { StaticJsonRpcProvider } from "@ethersproject/providers";
 import { VercelResponse } from "@vercel/node";
 import {
-  CHAIN_IDS,
+  CHAIN_IDs,
   MULTICALL3_ADDRESS,
   DEFI_LLAMA_POOL_LOOKUP,
   EXTERNAL_POOL_TOKEN_EXCHANGE_RATE,
@@ -279,8 +279,7 @@ export const makeHubPoolClientConfig = (chainId = 1) => {
     1: {
       chainId: 1,
       hubPoolAddress: "0xc186fA914353c44b2E33eBE05f21846F1048bEda",
-      wethAddress:
-        TOKEN_SYMBOLS_MAP.WETH.addresses[sdk.constants.CHAIN_IDs.MAINNET],
+      wethAddress: TOKEN_SYMBOLS_MAP.WETH.addresses[CHAIN_IDs.MAINNET],
       configStoreAddress: "0x3B03509645713718B78951126E0A6de6f10043f5",
       acceleratingDistributorAddress:
         "0x9040e41eF5E8b281535a96D9a48aCb8cfaBD9a48",
@@ -289,8 +288,7 @@ export const makeHubPoolClientConfig = (chainId = 1) => {
     5: {
       chainId: 5,
       hubPoolAddress: "0x0e2817C49698cc0874204AeDf7c72Be2Bb7fCD5d",
-      wethAddress:
-        TOKEN_SYMBOLS_MAP.WETH.addresses[sdk.constants.CHAIN_IDs.GOERLI],
+      wethAddress: TOKEN_SYMBOLS_MAP.WETH.addresses[CHAIN_IDs.GOERLI],
       configStoreAddress: "0x3215e3C91f87081757d0c41EF0CB77738123Be83",
       acceleratingDistributorAddress:
         "0xA59CE9FDFf8a0915926C2AF021d54E58f9B207CC",
@@ -329,116 +327,116 @@ export const queries: Record<
   number,
   () => sdk.relayFeeCalculator.QueryInterface
 > = {
-  [CHAIN_IDS.MAINNET]: () =>
+  [CHAIN_IDs.MAINNET]: () =>
     new sdk.relayFeeCalculator.EthereumQueries(
-      getProvider(CHAIN_IDS.MAINNET),
+      getProvider(CHAIN_IDs.MAINNET),
       undefined,
       undefined,
       undefined,
       undefined,
       REACT_APP_COINGECKO_PRO_API_KEY,
       getLogger(),
-      getGasMarkup(CHAIN_IDS.MAINNET)
+      getGasMarkup(CHAIN_IDs.MAINNET)
     ),
-  [CHAIN_IDS.OPTIMISM]: () =>
+  [CHAIN_IDs.OPTIMISM]: () =>
     new sdk.relayFeeCalculator.OptimismQueries(
-      getProvider(CHAIN_IDS.OPTIMISM),
+      getProvider(CHAIN_IDs.OPTIMISM),
       undefined,
       undefined,
       undefined,
       undefined,
       REACT_APP_COINGECKO_PRO_API_KEY,
       getLogger(),
-      getGasMarkup(CHAIN_IDS.OPTIMISM)
+      getGasMarkup(CHAIN_IDs.OPTIMISM)
     ),
-  [CHAIN_IDS.POLYGON]: () =>
+  [CHAIN_IDs.POLYGON]: () =>
     new sdk.relayFeeCalculator.PolygonQueries(
-      getProvider(CHAIN_IDS.POLYGON),
+      getProvider(CHAIN_IDs.POLYGON),
       undefined,
       undefined,
       undefined,
       undefined,
       REACT_APP_COINGECKO_PRO_API_KEY,
       getLogger(),
-      getGasMarkup(CHAIN_IDS.POLYGON)
+      getGasMarkup(CHAIN_IDs.POLYGON)
     ),
-  [CHAIN_IDS.ARBITRUM]: () =>
+  [CHAIN_IDs.ARBITRUM]: () =>
     new sdk.relayFeeCalculator.ArbitrumQueries(
-      getProvider(CHAIN_IDS.ARBITRUM),
+      getProvider(CHAIN_IDs.ARBITRUM),
       undefined,
       undefined,
       undefined,
       undefined,
       REACT_APP_COINGECKO_PRO_API_KEY,
       getLogger(),
-      getGasMarkup(CHAIN_IDS.ARBITRUM)
+      getGasMarkup(CHAIN_IDs.ARBITRUM)
     ),
-  [CHAIN_IDS.ZK_SYNC]: () =>
+  [CHAIN_IDs.ZK_SYNC]: () =>
     new sdk.relayFeeCalculator.ZkSyncQueries(
-      getProvider(CHAIN_IDS.ZK_SYNC),
+      getProvider(CHAIN_IDs.ZK_SYNC),
       undefined,
       undefined,
       undefined,
       undefined,
       REACT_APP_COINGECKO_PRO_API_KEY,
       getLogger(),
-      getGasMarkup(CHAIN_IDS.ZK_SYNC)
+      getGasMarkup(CHAIN_IDs.ZK_SYNC)
     ),
-  [CHAIN_IDS.BASE]: () =>
+  [CHAIN_IDs.BASE]: () =>
     new sdk.relayFeeCalculator.BaseQueries(
-      getProvider(CHAIN_IDS.BASE),
+      getProvider(CHAIN_IDs.BASE),
       undefined,
       undefined,
       undefined,
       undefined,
       REACT_APP_COINGECKO_PRO_API_KEY,
       getLogger(),
-      getGasMarkup(CHAIN_IDS.BASE)
+      getGasMarkup(CHAIN_IDs.BASE)
     ),
   /* --------------------------- Testnet queries --------------------------- */
-  [CHAIN_IDS.GOERLI]: () =>
+  [CHAIN_IDs.GOERLI]: () =>
     new sdk.relayFeeCalculator.EthereumGoerliQueries(
-      getProvider(CHAIN_IDS.GOERLI),
+      getProvider(CHAIN_IDs.GOERLI),
       undefined,
       undefined,
       undefined,
       undefined,
       REACT_APP_COINGECKO_PRO_API_KEY,
       getLogger(),
-      getGasMarkup(CHAIN_IDS.GOERLI)
+      getGasMarkup(CHAIN_IDs.GOERLI)
     ),
-  [CHAIN_IDS.ARBITRUM_GOERLI]: () =>
+  [CHAIN_IDs.ARBITRUM_GOERLI]: () =>
     new sdk.relayFeeCalculator.ArbitrumGoerliQueries(
-      getProvider(CHAIN_IDS.ARBITRUM_GOERLI),
+      getProvider(CHAIN_IDs.ARBITRUM_GOERLI),
       undefined,
       undefined,
       undefined,
       undefined,
       REACT_APP_COINGECKO_PRO_API_KEY,
       getLogger(),
-      getGasMarkup(CHAIN_IDS.ARBITRUM_GOERLI)
+      getGasMarkup(CHAIN_IDs.ARBITRUM_GOERLI)
     ),
-  [CHAIN_IDS.ZK_SYNC_GOERLI]: () =>
+  [CHAIN_IDs.ZK_SYNC_GOERLI]: () =>
     new sdk.relayFeeCalculator.zkSyncGoerliQueries(
-      getProvider(CHAIN_IDS.ZK_SYNC_GOERLI),
+      getProvider(CHAIN_IDs.ZK_SYNC_GOERLI),
       undefined,
       undefined,
       undefined,
       undefined,
       REACT_APP_COINGECKO_PRO_API_KEY,
       getLogger(),
-      getGasMarkup(CHAIN_IDS.ZK_SYNC_GOERLI)
+      getGasMarkup(CHAIN_IDs.ZK_SYNC_GOERLI)
     ),
-  [CHAIN_IDS.BASE_GOERLI]: () =>
+  [CHAIN_IDs.BASE_GOERLI]: () =>
     new sdk.relayFeeCalculator.BaseGoerliQueries(
-      getProvider(CHAIN_IDS.BASE_GOERLI),
+      getProvider(CHAIN_IDs.BASE_GOERLI),
       undefined,
       undefined,
       undefined,
       undefined,
       REACT_APP_COINGECKO_PRO_API_KEY,
       getLogger(),
-      getGasMarkup(CHAIN_IDS.BASE_GOERLI)
+      getGasMarkup(CHAIN_IDs.BASE_GOERLI)
     ),
 };
 
@@ -564,7 +562,7 @@ export const getSpokePool = (_chainId: number): SpokePool => {
 
 export const getSpokePoolAddress = (chainId: number): string => {
   switch (chainId) {
-    case CHAIN_IDS.ARBITRUM_GOERLI:
+    case CHAIN_IDs.ARBITRUM_GOERLI:
       return "0xD29C85F15DF544bA632C9E25829fd29d767d7978";
     default:
       return sdk.utils.getDeployedAddress("SpokePool", chainId);

--- a/api/coingecko.ts
+++ b/api/coingecko.ts
@@ -9,9 +9,13 @@ import {
   validAddress,
   getBalancerV2TokenPrice,
 } from "./_utils";
-import { SUPPORTED_CG_BASE_CURRENCIES } from "./_constants";
+import {
+  SUPPORTED_CG_BASE_CURRENCIES,
+  CHAIN_IDs,
+  TOKEN_SYMBOLS_MAP,
+} from "./_constants";
 
-import { coingecko, constants as sdkConstants } from "@across-protocol/sdk-v2";
+import { coingecko } from "@across-protocol/sdk-v2";
 
 const { Coingecko } = coingecko;
 const {
@@ -33,7 +37,7 @@ const getCoingeckoPrices = async (
   } = {},
   balancerV2PoolTokens: string[] = []
 ): Promise<number> => {
-  const baseCurrencyToken = Object.values(sdkConstants.TOKEN_SYMBOLS_MAP).find(
+  const baseCurrencyToken = Object.values(TOKEN_SYMBOLS_MAP).find(
     ({ symbol }) => symbol === baseCurrency.toUpperCase()
   );
 
@@ -42,7 +46,7 @@ const getCoingeckoPrices = async (
   // Special case: token and base are the same. Coingecko class returns a single result in this case, so it must
   // be handled separately.
   const baseCurrentTokenAddress =
-    baseCurrencyToken.addresses[sdkConstants.CHAIN_IDs.MAINNET];
+    baseCurrencyToken.addresses[CHAIN_IDs.MAINNET];
   if (tokenAddress.toLowerCase() === baseCurrentTokenAddress.toLowerCase())
     return 1;
 

--- a/api/token-list.ts
+++ b/api/token-list.ts
@@ -1,5 +1,4 @@
 import { VercelResponse } from "@vercel/node";
-import { constants } from "@across-protocol/sdk-v2";
 import {
   getLogger,
   handleErrorCondition,
@@ -8,6 +7,7 @@ import {
   DISABLED_CHAINS_FOR_AVAILABLE_ROUTES,
 } from "./_utils";
 import { TypedVercelRequest } from "./_types";
+import { TOKEN_SYMBOLS_MAP } from "./_constants";
 
 const handler = async (_: TypedVercelRequest<{}>, response: VercelResponse) => {
   const logger = getLogger();
@@ -48,10 +48,10 @@ const handler = async (_: TypedVercelRequest<{}>, response: VercelResponse) => {
     const enrichedTokensPerChain = Object.values(tokensPerChain).map(
       (token) => {
         const tokenInfo =
-          constants.TOKEN_SYMBOLS_MAP[
+          TOKEN_SYMBOLS_MAP[
             ["USDC.e", "USDbC"].includes(token.symbol)
               ? "USDC"
-              : (token.symbol as keyof typeof constants.TOKEN_SYMBOLS_MAP)
+              : (token.symbol as keyof typeof TOKEN_SYMBOLS_MAP)
           ];
         return {
           ...token,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "AGPL-3.0-only",
   "dependencies": {
+    "@across-protocol/constants-v2": "^1.0.4",
     "@across-protocol/sdk-v2": "^0.16.4",
     "@amplitude/analytics-browser": "^1.6.6",
     "@amplitude/marketing-analytics-browser": "^0.3.6",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import { ethers, providers } from "ethers";
-import { constants, utils } from "@across-protocol/sdk-v2";
+import { utils } from "@across-protocol/sdk-v2";
+import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants-v2";
 import * as superstruct from "superstruct";
 
 import { parseEtherLike } from "./format";
@@ -30,18 +31,18 @@ import GoerliRoutes from "data/routes_5_0x0e2817C49698cc0874204AeDf7c72Be2Bb7fCD
 
 /* Chains and Tokens section */
 export enum ChainId {
-  MAINNET = constants.CHAIN_IDs.MAINNET,
-  OPTIMISM = constants.CHAIN_IDs.OPTIMISM,
-  ARBITRUM = constants.CHAIN_IDs.ARBITRUM,
-  POLYGON = constants.CHAIN_IDs.POLYGON,
-  ZK_SYNC = constants.CHAIN_IDs.ZK_SYNC,
-  BASE = constants.CHAIN_IDs.BASE,
+  MAINNET = CHAIN_IDs.MAINNET,
+  OPTIMISM = CHAIN_IDs.OPTIMISM,
+  ARBITRUM = CHAIN_IDs.ARBITRUM,
+  POLYGON = CHAIN_IDs.POLYGON,
+  ZK_SYNC = CHAIN_IDs.ZK_SYNC,
+  BASE = CHAIN_IDs.BASE,
   // testnets
-  ARBITRUM_GOERLI = constants.CHAIN_IDs.ARBITRUM_GOERLI,
-  ZK_SYNC_GOERLI = constants.CHAIN_IDs.ZK_SYNC_GOERLI,
-  BASE_GOERLI = constants.CHAIN_IDs.BASE_GOERLI,
-  GOERLI = constants.CHAIN_IDs.GOERLI,
-  MUMBAI = constants.CHAIN_IDs.MUMBAI,
+  ARBITRUM_GOERLI = CHAIN_IDs.ARBITRUM_GOERLI,
+  ZK_SYNC_GOERLI = CHAIN_IDs.ZK_SYNC_GOERLI,
+  BASE_GOERLI = CHAIN_IDs.BASE_GOERLI,
+  GOERLI = CHAIN_IDs.GOERLI,
+  MUMBAI = CHAIN_IDs.MUMBAI,
 }
 
 // Maps `ChainId` to an object and inverts the Key/Value
@@ -348,7 +349,7 @@ export const tokenList = [
   ...Object.entries(orderedTokenSymbolLogoMap).flatMap(([symbol, logoURI]) => {
     // NOTE: Handle cases for bridged USDC such as USDC.e or USDbC.
     if (bridgedUSDCSymbols.includes(symbol)) {
-      const usdcTokenInfo = constants.TOKEN_SYMBOLS_MAP.USDC;
+      const usdcTokenInfo = TOKEN_SYMBOLS_MAP.USDC;
       return {
         ...usdcTokenInfo,
         logoURI,
@@ -359,9 +360,7 @@ export const tokenList = [
     }
 
     const tokenInfo =
-      constants.TOKEN_SYMBOLS_MAP[
-        symbol as keyof typeof constants.TOKEN_SYMBOLS_MAP
-      ];
+      TOKEN_SYMBOLS_MAP[symbol as keyof typeof TOKEN_SYMBOLS_MAP];
 
     if (!tokenInfo) {
       return [];
@@ -483,7 +482,7 @@ export const getToken = (symbol: string): TokenInfo => {
  * @returns The token info for the token with the given address
  */
 export const getTokenByAddress = (address: string): TokenInfo => {
-  const token = Object.values(constants.TOKEN_SYMBOLS_MAP).find((token) =>
+  const token = Object.values(TOKEN_SYMBOLS_MAP).find((token) =>
     Object.values(token.addresses).includes(address)
   );
   assert(token, "No token found for address: " + address);

--- a/src/views/Bridge/components/RouteNotSupportedTooltipText.tsx
+++ b/src/views/Bridge/components/RouteNotSupportedTooltipText.tsx
@@ -1,4 +1,4 @@
-import { constants } from "@across-protocol/sdk-v2";
+import { CHAIN_IDs } from "@across-protocol/constants-v2";
 
 import { Text } from "components/Text";
 import { getChainInfo } from "utils";
@@ -15,8 +15,7 @@ export const RouteNotSupportedTooltipText = ({
   toChain,
 }: Props) => {
   const isArbitrumNativeUSDC =
-    (fromChain === constants.CHAIN_IDs.ARBITRUM ||
-      toChain === constants.CHAIN_IDs.ARBITRUM) &&
+    (fromChain === CHAIN_IDs.ARBITRUM || toChain === CHAIN_IDs.ARBITRUM) &&
     symbol === "USDC";
   return (
     <Text color="white-70" size="sm">

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,11 @@
     "@uma/common" "^2.17.0"
     hardhat "^2.9.3"
 
+"@across-protocol/constants-v2@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.4.tgz#df31c81038982a25de2b1b8f7604875f3de1186c"
+  integrity sha512-Nzl8Z1rZFvcpuKQu7CmBVfvgB13/NoulcsRVYBSkG90imS/e6mugxzqD9UrUb+WOL0ODMCANCAoDw54ZBBzNiQ==
+
 "@across-protocol/contracts-v2@^2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@across-protocol/contracts-v2/-/contracts-v2-2.4.3.tgz#9cc0b1f52b4f819b32ca1524ef84af9dfed8687a"


### PR DESCRIPTION
This brings this repo in sync with sdk-v2, relayer-v2, contracts-v2 so that all constants are imported from a single place rather than having to ripple all changes from contracts-v2 --> sdk-v2 --> *
Signed-off-by: nicholaspai <npai.nyc@gmail.com>

