### PR TITLE
improve: align rate model with correct parameters

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -17,13 +17,13 @@ const defaultRelayerFeeCapitalCostConfig: {
 } = {
   ETH: {
     lowerBound: ethers.utils.parseUnits("0.0001").toString(),
-    upperBound: ethers.utils.parseUnits("0.0006").toString(),
+    upperBound: ethers.utils.parseUnits("0.0004").toString(),
     cutoff: ethers.utils.parseUnits("750").toString(),
     decimals: 18,
   },
   WETH: {
     lowerBound: ethers.utils.parseUnits("0.0001").toString(),
-    upperBound: ethers.utils.parseUnits("0.0006").toString(),
+    upperBound: ethers.utils.parseUnits("0.0004").toString(),
     cutoff: ethers.utils.parseUnits("750").toString(),
     decimals: 18,
   },

--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -35,19 +35,19 @@ const defaultRelayerFeeCapitalCostConfig: {
   },
   DAI: {
     lowerBound: ethers.utils.parseUnits("0.0001").toString(),
-    upperBound: ethers.utils.parseUnits("0.00075").toString(),
+    upperBound: ethers.utils.parseUnits("0.0004").toString(),
     cutoff: ethers.utils.parseUnits("1500000").toString(),
     decimals: 18,
   },
   USDC: {
     lowerBound: ethers.utils.parseUnits("0.0001").toString(),
-    upperBound: ethers.utils.parseUnits("0.00075").toString(),
+    upperBound: ethers.utils.parseUnits("0.0004").toString(),
     cutoff: ethers.utils.parseUnits("1500000").toString(),
     decimals: 6,
   },
   USDT: {
     lowerBound: ethers.utils.parseUnits("0.0001").toString(),
-    upperBound: ethers.utils.parseUnits("0.00075").toString(),
+    upperBound: ethers.utils.parseUnits("0.0004").toString(),
     cutoff: ethers.utils.parseUnits("1500000").toString(),
     decimals: 6,
   },

--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -17,13 +17,13 @@ const defaultRelayerFeeCapitalCostConfig: {
 } = {
   ETH: {
     lowerBound: ethers.utils.parseUnits("0.0001").toString(),
-    upperBound: ethers.utils.parseUnits("0.0001").toString(),
+    upperBound: ethers.utils.parseUnits("0.0006").toString(),
     cutoff: ethers.utils.parseUnits("750").toString(),
     decimals: 18,
   },
   WETH: {
     lowerBound: ethers.utils.parseUnits("0.0001").toString(),
-    upperBound: ethers.utils.parseUnits("0.0001").toString(),
+    upperBound: ethers.utils.parseUnits("0.0006").toString(),
     cutoff: ethers.utils.parseUnits("750").toString(),
     decimals: 18,
   },
@@ -35,20 +35,20 @@ const defaultRelayerFeeCapitalCostConfig: {
   },
   DAI: {
     lowerBound: ethers.utils.parseUnits("0.0001").toString(),
-    upperBound: ethers.utils.parseUnits("0.0001").toString(),
-    cutoff: ethers.utils.parseUnits("250000").toString(),
+    upperBound: ethers.utils.parseUnits("0.00075").toString(),
+    cutoff: ethers.utils.parseUnits("1500000").toString(),
     decimals: 18,
   },
   USDC: {
     lowerBound: ethers.utils.parseUnits("0.0001").toString(),
-    upperBound: ethers.utils.parseUnits("0.0001").toString(),
+    upperBound: ethers.utils.parseUnits("0.00075").toString(),
     cutoff: ethers.utils.parseUnits("1500000").toString(),
     decimals: 6,
   },
   USDT: {
     lowerBound: ethers.utils.parseUnits("0.0001").toString(),
-    upperBound: ethers.utils.parseUnits("0.0001").toString(),
-    cutoff: ethers.utils.parseUnits("250000").toString(),
+    upperBound: ethers.utils.parseUnits("0.00075").toString(),
+    cutoff: ethers.utils.parseUnits("1500000").toString(),
     decimals: 6,
   },
   UMA: {


### PR DESCRIPTION
This PR updates the capital fee computation to the Across Parameters doc. These changes affect the `UB`, `LB`, and `Cutoff` for `WETH`, `ETH`, `UDSC`, `USDT`, and `DAI`.