### PR TITLE
fix: spread args in send with padded gas utils

### DIFF
--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -72,7 +72,7 @@ export function sendWithPaddedGas(
       chainId,
       contract,
       method,
-      args
+      ...args
     );
     return contract[method](...args, {
       gasLimit: gasToRecommend,


### PR DESCRIPTION
The PR https://github.com/across-protocol/frontend-v2/pull/849 caused an issue with on-chain actions that were wrapped by `sendWithPaddedGas` because we didn't spread the args properly.