### PR TITLE
fix: use pre-computed gas usage for deposit max amounts

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { ethers, providers } from "ethers";
+import { BigNumber, ethers, providers } from "ethers";
 import { utils } from "@across-protocol/sdk-v2";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants-v2";
 import * as superstruct from "superstruct";
@@ -697,5 +697,5 @@ export const walletBlacklist = (process.env.REACT_APP_WALLET_BLACKLIST || "")
   .split(",")
   .map((address) => address.toLowerCase());
 
-// Fallback gas costs for when the gas estimation fails
-export const fallbackEstimatedGasCosts = ethers.utils.parseEther("0.01");
+// Pre-computed gas expenditure for deposits used for estimations
+export const gasExpenditureDeposit = BigNumber.from(90_000);

--- a/src/views/Bridge/hooks/useMaxBalance.ts
+++ b/src/views/Bridge/hooks/useMaxBalance.ts
@@ -1,17 +1,8 @@
 import { useQuery } from "react-query";
-import { BigNumber, providers, constants, utils } from "ethers";
+import { BigNumber, constants } from "ethers";
 
 import { useBalanceBySymbol, useConnection } from "hooks";
-import {
-  getConfig,
-  Route,
-  max,
-  getProvider,
-  fallbackEstimatedGasCosts,
-} from "utils";
-import { getPaddedGasEstimation } from "utils/transactions";
-
-const config = getConfig();
+import { Route, max, getProvider, gasExpenditureDeposit } from "utils";
 
 export function useMaxBalance(selectedRoute: Route) {
   const { balance } = useBalanceBySymbol(
@@ -35,14 +26,9 @@ export function useMaxBalance(selectedRoute: Route) {
           selectedRoute.fromTokenSymbol !== "ETH"
             ? balance
             : // For ETH, we need to take the gas costs into account before setting the max. bridgable amount
-              await estimateGasCostsForDeposit(selectedRoute, signer)
-                .then((estimatedGasCosts) =>
-                  max(balance.sub(estimatedGasCosts), 0)
-                )
-                .catch((err) => {
-                  console.error(err);
-                  return max(balance.sub(fallbackEstimatedGasCosts), 0);
-                });
+              await estimateGasCostsForDeposit(selectedRoute).then(
+                (estimatedGasCosts) => max(balance.sub(estimatedGasCosts), 0)
+              );
       } else {
         maxBridgeAmount = constants.Zero;
       }
@@ -51,38 +37,13 @@ export function useMaxBalance(selectedRoute: Route) {
     },
     {
       enabled: Boolean(account && balance && signer),
+      retry: true,
     }
   );
 }
 
-async function estimateGasCostsForDeposit(
-  selectedRoute: Route,
-  signer: providers.JsonRpcSigner
-) {
+async function estimateGasCostsForDeposit(selectedRoute: Route) {
   const provider = getProvider(selectedRoute.fromChain);
-  const spokePool = config.getSpokePool(selectedRoute.fromChain, signer);
-  const tokenInfo = config.getTokenInfoByAddress(
-    selectedRoute.fromChain,
-    selectedRoute.fromTokenAddress
-  );
-  const amount = utils.parseUnits("0.000001", tokenInfo.decimals);
-  const argsForEstimation = {
-    recipient: await signer.getAddress(),
-    originToken: tokenInfo.address,
-    amount,
-    destinationChain: selectedRoute.toChain,
-    relayerFeePct: 0,
-    quoteTimestamp: BigNumber.from(Math.floor(Date.now() / 1000)).sub(60 * 60),
-    message: "0x",
-    maxCount: constants.MaxUint256,
-  };
-  const paddedGasEstimation = await getPaddedGasEstimation(
-    selectedRoute.fromChain,
-    spokePool,
-    "deposit",
-    ...Object.values(argsForEstimation),
-    { value: selectedRoute.isNative ? amount : 0 }
-  );
   const gasPrice = await provider.getGasPrice();
-  return gasPrice.mul(paddedGasEstimation);
+  return gasPrice.mul(gasExpenditureDeposit);
 }

--- a/src/views/Bridge/hooks/useMaxBalance.ts
+++ b/src/views/Bridge/hooks/useMaxBalance.ts
@@ -2,7 +2,13 @@ import { useQuery } from "react-query";
 import { BigNumber, constants } from "ethers";
 
 import { useBalanceBySymbol, useConnection } from "hooks";
-import { Route, max, getProvider, gasExpenditureDeposit } from "utils";
+import {
+  Route,
+  max,
+  getProvider,
+  gasExpenditureDeposit,
+  gasMultiplierPerChain,
+} from "utils";
 
 export function useMaxBalance(selectedRoute: Route) {
   const { balance } = useBalanceBySymbol(
@@ -42,8 +48,13 @@ export function useMaxBalance(selectedRoute: Route) {
   );
 }
 
+/**
+ * Estimated gas costs for a deposit with an empty message.
+ * This is used to calculate the maximum amount of ETH that can be bridged.
+ */
 async function estimateGasCostsForDeposit(selectedRoute: Route) {
   const provider = getProvider(selectedRoute.fromChain);
   const gasPrice = await provider.getGasPrice();
-  return gasPrice.mul(gasExpenditureDeposit);
+  const gasMultiplier = gasMultiplierPerChain[selectedRoute.fromChain] || 3;
+  return gasPrice.mul(gasMultiplier).mul(gasExpenditureDeposit);
 }


### PR DESCRIPTION
This PR makes setting the max. bridgable amount for native token deposits more ~accurate and~ reliable by:
- Removing the usage of a fallback value gas costs and using infinite retry
- Using a pre-computed value for gas expenditure instead of querying via an additional RPC call