### PR TITLE
fix: :bug: remove ability to specify backup capital cost fee

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -58,11 +58,6 @@ export const DEFAULT_GAS_MARKUP = 0;
 // Don't permit HUB_POOL_CHAIN_ID=0
 export const HUB_POOL_CHAIN_ID = Number(REACT_APP_HUBPOOL_CHAINID || 1);
 
-// Permit REACT_APP_FLAT_RELAY_CAPITAL_FEE=0
-export const FLAT_RELAY_CAPITAL_FEE = Number(
-  process.env.REACT_APP_FLAT_RELAY_CAPITAL_FEE ?? 0.03
-); // 0.03%
-
 // Tokens that should be disabled in the routes
 export const DISABLED_ROUTE_TOKENS = (
   process.env.DISABLED_ROUTE_TOKENS || ""
@@ -453,7 +448,6 @@ export const getRelayerFeeCalculator = (destinationChainId: number) => {
 
   const relayerFeeCalculatorConfig = {
     feeLimitPercent: maxRelayFeePct * 100,
-    capitalCostsPercent: FLAT_RELAY_CAPITAL_FEE, // This is set same way in ./src/utils/bridge.ts
     queries: queryFn(),
     capitalCostsConfig: relayerFeeCapitalCostConfig,
   };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-only",
   "dependencies": {
     "@across-protocol/constants-v2": "^1.0.4",
-    "@across-protocol/sdk-v2": "^0.16.4",
+    "@across-protocol/sdk-v2": "^0.17.3",
     "@amplitude/analytics-browser": "^1.6.6",
     "@amplitude/marketing-analytics-browser": "^0.3.6",
     "@balancer-labs/sdk": "^1.1.3",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -408,10 +408,6 @@ export const FEE_ESTIMATION = ".004";
 export const MAX_RELAY_FEE_PERCENT = Number(
   process.env.REACT_APP_MAX_RELAY_FEE_PERCENT || 50
 );
-export const FLAT_RELAY_CAPITAL_FEE = process.env
-  .REACT_APP_FLAT_RELAY_CAPITAL_FEE
-  ? Number(process.env.REACT_APP_FLAT_RELAY_CAPITAL_FEE)
-  : 0;
 export const SHOW_ACX_NAV_TOKEN =
   process.env.REACT_APP_SHOW_ACX_NAV_TOKEN === "true";
 export const AddressZero = ethers.constants.AddressZero;

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,18 +21,18 @@
   resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.4.tgz#df31c81038982a25de2b1b8f7604875f3de1186c"
   integrity sha512-Nzl8Z1rZFvcpuKQu7CmBVfvgB13/NoulcsRVYBSkG90imS/e6mugxzqD9UrUb+WOL0ODMCANCAoDw54ZBBzNiQ==
 
-"@across-protocol/contracts-v2@^2.4.3":
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/@across-protocol/contracts-v2/-/contracts-v2-2.4.3.tgz#9cc0b1f52b4f819b32ca1524ef84af9dfed8687a"
-  integrity sha512-NT5zBhTMYk7jUgZ6Q+xXz0p3ukXth8F6lBTiNCIrrzFSBl5JLVrhk00+TIIIOfwtpGSiG+MGkKuwCOKWMhwOMg==
+"@across-protocol/contracts-v2@^2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts-v2/-/contracts-v2-2.4.4.tgz#face03ecb7c9f3c2e3171996eb4af432a718dcef"
+  integrity sha512-6HVAXhff9GhIny0XfXQYHbaply+sTG/hffaoN+/qygoX59wOduNdokjicV095tDOgVqoVEFpI8m3P/fMM08bcw==
   dependencies:
     "@defi-wonderland/smock" "^2.3.4"
     "@eth-optimism/contracts" "^0.5.40"
     "@ethersproject/abstract-provider" "5.7.0"
     "@ethersproject/abstract-signer" "5.7.0"
     "@ethersproject/bignumber" "5.7.0"
-    "@openzeppelin/contracts" "4.9.2"
-    "@openzeppelin/contracts-upgradeable" "4.9.2"
+    "@openzeppelin/contracts" "4.9.3"
+    "@openzeppelin/contracts-upgradeable" "4.9.3"
     "@uma/common" "^2.34.0"
     "@uma/contracts-node" "^0.4.17"
     "@uma/core" "^2.56.0"
@@ -47,15 +47,16 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@^0.16.4":
-  version "0.16.4"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.16.4.tgz#89ef2dc46fae9647ed46fda50a4de270f925f68e"
-  integrity sha512-mpPYiW4Kb2uQXmPOmsnCqer/iSuRuixSJM91svIxwA2z3kw1xk57G94LeVSufFPzVD/5urUS/sYm7Ea0z75WSw==
+"@across-protocol/sdk-v2@^0.17.3":
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.17.3.tgz#182b3a0ed20291de367bd5b757618a0d1b3ced52"
+  integrity sha512-xn74oeBTy/5cGzrZL//7KSYuKf0kviduspLlbQudFqGQDlMUOV0+23sHY/jBLh4DmKLJhFL7jPwk+xbkn1WPFw==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
-    "@across-protocol/contracts-v2" "^2.4.3"
+    "@across-protocol/contracts-v2" "^2.4.4"
     "@eth-optimism/sdk" "^2.1.0"
     "@pinata/sdk" "^2.1.0"
+    "@types/mocha" "^10.0.1"
     "@uma/sdk" "^0.34.1"
     axios "^0.27.2"
     big-number "^2.0.0"
@@ -5983,10 +5984,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.3.tgz#f1d606e2827d409053f3e908ba4eb8adb1dd6995"
   integrity sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A==
 
-"@openzeppelin/contracts-upgradeable@4.9.2":
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.2.tgz#a817c75688f8daede420052fbcb34e52482e769e"
-  integrity sha512-siviV3PZV/fHfPaoIC51rf1Jb6iElkYWnNYZ0leO23/ukXuvOyoC/ahy8jqiV7g+++9Nuo3n/rk5ajSN/+d/Sg==
+"@openzeppelin/contracts-upgradeable@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.3.tgz#ff17a80fb945f5102571f8efecb5ce5915cc4811"
+  integrity sha512-jjaHAVRMrE4UuZNfDwjlLGDxTHWIOwTJS2ldnc278a0gevfXfPr8hxKEVBGFBE96kl2G3VHDZhUimw/+G3TG2A==
 
 "@openzeppelin/contracts-upgradeable@^4.8.1":
   version "4.8.3"
@@ -6014,10 +6015,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.3.tgz#939534757a81f8d69cc854c7692805684ff3111e"
   integrity sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw==
 
-"@openzeppelin/contracts@4.9.2":
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.2.tgz#1cb2d5e4d3360141a17dbc45094a8cad6aac16c1"
-  integrity sha512-mO+y6JaqXjWeMh9glYVzVu8HYPGknAAnWyxTRhGeckOruyXQMNnlcW6w/Dx9ftLeIQk6N+ZJFuVmTwF7lEIFrg==
+"@openzeppelin/contracts@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.3.tgz#00d7a8cf35a475b160b3f0293a6403c511099364"
+  integrity sha512-He3LieZ1pP2TNt5JbkPA4PNT9WC3gOTOlDcFGJW4Le4QKqwmiNJCRt44APfxMxvq7OugU/cqYuPcSBzOw38DAg==
 
 "@openzeppelin/contracts@^4.2.0", "@openzeppelin/contracts@^4.7.3", "@openzeppelin/contracts@^4.8.1":
   version "4.8.3"
@@ -8353,6 +8354,11 @@
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
+
+"@types/mocha@^10.0.1":
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.2.tgz#96d63314255540a36bf24da094cce7a13668d73b"
+  integrity sha512-NaHL0+0lLNhX6d9rs+NSt97WH/gIlRHmszXbQ/8/MV/eVcFNdeJ/GYhrFuUc8K7WuPhRhTSdMkCp8VMzhUq85w==
 
 "@types/ms@*":
   version "0.7.31"


### PR DESCRIPTION
We shouldn't be allowed to set a backup default cost config fee. This is indicative of a misconfured capital cost setting. We should have an intentional default for a given token or else we should fail.

A failure condition has been added to https://github.com/across-protocol/sdk-v2/pull/430 and we will need to bump the SDK before we merge this change.