### PR TITLE
fix: use specific 1 token value

### DIFF
--- a/api/limits.ts
+++ b/api/limits.ts
@@ -3,7 +3,7 @@
 
 import { HubPool__factory } from "@across-protocol/contracts-v2/dist/typechain";
 import { VercelResponse } from "@vercel/node";
-import { BigNumber, ethers } from "ethers";
+import { ethers } from "ethers";
 import {
   BLOCK_TAG_LAG,
   DEFAULT_SIMULATED_RECIPIENT_ADDRESS,
@@ -147,7 +147,7 @@ const handler = async (
     ] = await Promise.all([
       getRelayerFeeDetails(
         l1Token,
-        BigNumber.from("10").pow(tokenDetails.decimals),
+        ethers.BigNumber.from("10").pow(tokenDetails.decimals),
         computedOriginChainId,
         Number(destinationChainId),
         DEFAULT_SIMULATED_RECIPIENT_ADDRESS,

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -3,7 +3,7 @@
 
 import { HubPool__factory } from "@across-protocol/contracts-v2/dist/typechain";
 import { VercelResponse } from "@vercel/node";
-import { ethers } from "ethers";
+import { BigNumber, ethers } from "ethers";
 import {
   BLOCK_TAG_LAG,
   DEFAULT_SIMULATED_RECIPIENT_ADDRESS,
@@ -147,7 +147,7 @@ const handler = async (
     ] = await Promise.all([
       getRelayerFeeDetails(
         l1Token,
-        ethers.BigNumber.from("10").pow(18),
+        BigNumber.from("10").pow(tokenDetails.decimals),
         computedOriginChainId,
         Number(destinationChainId),
         DEFAULT_SIMULATED_RECIPIENT_ADDRESS,


### PR DESCRIPTION
We should use the token details to get the decimals so that we're passing one token of value to simulate the relayer details.