### PR TITLE
improve: more effectively estimate suggested fees quote

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -505,6 +505,7 @@ export const getRelayerFeeDetails = async (
 
   const relayFeeCalculator = getRelayerFeeCalculator(destinationChainId);
   try {
+    const oneBp = ethers.utils.parseEther("0.0001");
     return await relayFeeCalculator.relayerFeeDetails(
       {
         amount: sdk.utils.toBN(amount),
@@ -512,8 +513,8 @@ export const getRelayerFeeDetails = async (
         depositor: recipientAddress,
         destinationChainId,
         originChainId,
-        relayerFeePct: sdk.utils.bnZero,
-        realizedLpFeePct: sdk.utils.bnZero,
+        relayerFeePct: oneBp,
+        realizedLpFeePct: oneBp,
         recipient: recipientAddress,
         message: message ?? sdk.constants.EMPTY_MESSAGE,
         quoteTimestamp: sdk.utils.getCurrentTime(),

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -505,7 +505,6 @@ export const getRelayerFeeDetails = async (
 
   const relayFeeCalculator = getRelayerFeeCalculator(destinationChainId);
   try {
-    const oneBp = ethers.utils.parseEther("0.0001");
     return await relayFeeCalculator.relayerFeeDetails(
       {
         amount: sdk.utils.toBN(amount),
@@ -513,8 +512,8 @@ export const getRelayerFeeDetails = async (
         depositor: recipientAddress,
         destinationChainId,
         originChainId,
-        relayerFeePct: oneBp,
-        realizedLpFeePct: oneBp,
+        relayerFeePct: sdk.utils.bnZero,
+        realizedLpFeePct: sdk.utils.bnZero,
         recipient: recipientAddress,
         message: message ?? sdk.constants.EMPTY_MESSAGE,
         quoteTimestamp: sdk.utils.getCurrentTime(),

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -6,7 +6,11 @@ import { BlockFinder } from "@uma/sdk";
 import { VercelResponse } from "@vercel/node";
 import { ethers } from "ethers";
 import { type, assert, Infer, optional, string } from "superstruct";
-import { disabledL1Tokens, DEFAULT_QUOTE_TIMESTAMP_BUFFER } from "./_constants";
+import {
+  disabledL1Tokens,
+  DEFAULT_QUOTE_TIMESTAMP_BUFFER,
+  DEFAULT_SIMULATED_RECIPIENT_ADDRESS,
+} from "./_constants";
 import { TypedVercelRequest } from "./_types";
 import {
   getLogger,
@@ -79,7 +83,7 @@ const handler = async (
     const destinationChainId = Number(_destinationChainId);
 
     relayerAddress ??= sdk.constants.DEFAULT_SIMULATED_RELAYER_ADDRESS;
-    recipientAddress ??= sdk.constants.DEFAULT_SIMULATED_RELAYER_ADDRESS;
+    recipientAddress ??= DEFAULT_SIMULATED_RECIPIENT_ADDRESS;
     token = ethers.utils.getAddress(token);
 
     const [latestBlock, tokenDetails] = await Promise.all([

--- a/src/hooks/useBridgeFees.ts
+++ b/src/hooks/useBridgeFees.ts
@@ -15,11 +15,17 @@ export function useBridgeFees(
   amount: ethers.BigNumber,
   fromChainId?: ChainId,
   toChainId?: ChainId,
-  tokenSymbol?: string
+  tokenSymbol?: string,
+  recipientAddress?: string
 ) {
   const { block } = useBlock(toChainId);
   const enabledQuery =
-    !!toChainId && !!fromChainId && !!block && !!tokenSymbol && amount.gt(0);
+    !!toChainId &&
+    !!fromChainId &&
+    !!block &&
+    !!tokenSymbol &&
+    amount.gt(0) &&
+    !!recipientAddress;
   const queryKey = enabledQuery
     ? bridgeFeesQueryKey(
         tokenSymbol,
@@ -38,6 +44,7 @@ export function useBridgeFees(
         blockTimestamp: block!.timestamp,
         toChainId: toChainId!,
         fromChainId: fromChainId!,
+        recipientAddress: recipientAddress!,
       });
     },
     {

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -32,6 +32,7 @@ type GetBridgeFeesArgs = {
   blockTimestamp: number;
   fromChainId: ChainId;
   toChainId: ChainId;
+  recipientAddress: string;
 };
 
 export type GetBridgeFeesResult = BridgeFees & {
@@ -52,6 +53,7 @@ export async function getBridgeFees({
   tokenSymbol,
   fromChainId,
   toChainId,
+  recipientAddress,
 }: GetBridgeFeesArgs): Promise<GetBridgeFeesResult> {
   const timeBeforeRequests = Date.now();
   const {
@@ -66,7 +68,8 @@ export async function getBridgeFees({
     amount,
     getConfig().getTokenInfoBySymbol(fromChainId, tokenSymbol).address,
     toChainId,
-    fromChainId
+    fromChainId,
+    recipientAddress
   );
   const timeAfterRequests = Date.now();
 

--- a/src/utils/serverless-api/mocked/suggested-fees.mocked.ts
+++ b/src/utils/serverless-api/mocked/suggested-fees.mocked.ts
@@ -14,7 +14,8 @@ export async function suggestedFeesMockedApiCall(
   _amount: ethers.BigNumber,
   _originToken: string,
   _toChainid: ChainId,
-  _fromChainid: ChainId
+  _fromChainid: ChainId,
+  _recipientAddress: string
 ): Promise<SuggestedApiFeeReturnType> {
   return {
     relayerFee: {

--- a/src/utils/serverless-api/prod/suggested-fees.prod.ts
+++ b/src/utils/serverless-api/prod/suggested-fees.prod.ts
@@ -15,13 +15,15 @@ export async function suggestedFeesApiCall(
   amount: ethers.BigNumber,
   originToken: string,
   toChainid: ChainId,
-  fromChainid: ChainId
+  fromChainid: ChainId,
+  recipientAddress: string
 ): Promise<SuggestedApiFeeReturnType> {
   const response = await axios.get(`/api/suggested-fees`, {
     params: {
       token: originToken,
       destinationChainId: toChainid,
       originChainId: fromChainid,
+      recipientAddress,
       amount: amount.toString(),
       skipAmountLimit: true,
     },

--- a/src/utils/serverless-api/types.ts
+++ b/src/utils/serverless-api/types.ts
@@ -56,7 +56,8 @@ export type SuggestedApiFeeType = (
   amount: ethers.BigNumber,
   originToken: string,
   toChainid: ChainId,
-  fromChainid: ChainId
+  fromChainid: ChainId,
+  recipientAddress: string
 ) => Promise<SuggestedApiFeeReturnType>;
 
 export type RetrieveLinkedWalletType = (

--- a/src/views/Bridge/hooks/useTransferQuote.ts
+++ b/src/views/Bridge/hooks/useTransferQuote.ts
@@ -26,7 +26,8 @@ export function useTransferQuote(
     amountToBridge,
     selectedRoute.fromChain,
     selectedRoute.toChain,
-    selectedRoute.fromTokenSymbol
+    selectedRoute.fromTokenSymbol,
+    toAddress
   );
   const limitsQuery = useBridgeLimits(
     selectedRoute.fromTokenSymbol,

--- a/src/views/Transactions/hooks/useSpeedUp.tsx
+++ b/src/views/Transactions/hooks/useSpeedUp.tsx
@@ -20,7 +20,7 @@ export function useSpeedUp(transfer: Deposit, token: Token) {
     transfer.sourceChainId,
     transfer.destinationChainId,
     token.symbol,
-    transfer.depositorAddr
+    transfer.recipientAddr
   );
 
   const [speedUpTxLink, setSpeedUpTxLink] = useState<string>("");

--- a/src/views/Transactions/hooks/useSpeedUp.tsx
+++ b/src/views/Transactions/hooks/useSpeedUp.tsx
@@ -19,7 +19,8 @@ export function useSpeedUp(transfer: Deposit, token: Token) {
     BigNumber.from(transfer.amount),
     transfer.sourceChainId,
     transfer.destinationChainId,
-    token.symbol
+    token.symbol,
+    transfer.depositorAddr
   );
 
   const [speedUpTxLink, setSpeedUpTxLink] = useState<string>("");


### PR DESCRIPTION
We discovered a short circuit in the Vercel API's estimation of fee quotes. 

This was causing a quote of roughly 80K gas units to make a fill. 

The original recipient address being used on the FE is `0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B`, which will incur a storage cost during the initial ERC20 transfer of 145,000 gas units. Properly passing `recipientAddress` in the suggested-fees endpoint on prod will incur 120,000 gas units.

In either case, we now default our recipient address to incur the storage cost of the ERC20 initializing a user's balance in the token.

Thus, the cost calculation will be preserved regardless of `recipientAddress` being provided and using the Across UI will produce a more accurate gas estimation making it the cheaper alternative over aggregators. 


Closes: ACX-1643