### PR TITLE
improve: relax suggested-fees params

### DIFF
--- a/src/hooks/useBridgeFees.ts
+++ b/src/hooks/useBridgeFees.ts
@@ -20,12 +20,7 @@ export function useBridgeFees(
 ) {
   const { block } = useBlock(toChainId);
   const enabledQuery =
-    !!toChainId &&
-    !!fromChainId &&
-    !!block &&
-    !!tokenSymbol &&
-    amount.gt(0) &&
-    !!recipientAddress;
+    !!toChainId && !!fromChainId && !!block && !!tokenSymbol && amount.gt(0);
   const queryKey = enabledQuery
     ? bridgeFeesQueryKey(
         tokenSymbol,
@@ -44,7 +39,7 @@ export function useBridgeFees(
         blockTimestamp: block!.timestamp,
         toChainId: toChainId!,
         fromChainId: fromChainId!,
-        recipientAddress: recipientAddress!,
+        recipientAddress,
       });
     },
     {

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -32,7 +32,7 @@ type GetBridgeFeesArgs = {
   blockTimestamp: number;
   fromChainId: ChainId;
   toChainId: ChainId;
-  recipientAddress: string;
+  recipientAddress?: string;
 };
 
 export type GetBridgeFeesResult = BridgeFees & {

--- a/src/utils/serverless-api/mocked/coingecko.mocked.ts
+++ b/src/utils/serverless-api/mocked/coingecko.mocked.ts
@@ -7,6 +7,6 @@ export async function coingeckoMockedApiCall(
   price: ethers.BigNumber;
 }> {
   return {
-    price: ethers.utils.parseEther(String("0.1")),
+    price: ethers.utils.parseEther(String("0.17")),
   };
 }

--- a/src/utils/serverless-api/mocked/suggested-fees.mocked.ts
+++ b/src/utils/serverless-api/mocked/suggested-fees.mocked.ts
@@ -1,6 +1,7 @@
 import { BigNumber, ethers } from "ethers";
-import { ChainId } from "utils/constants";
+import { ChainId, getTokenByAddress } from "utils/constants";
 import { SuggestedApiFeeReturnType } from "../types";
+import { parseUnits } from "utils/format";
 
 /**
  * Creates a mocked variant of the suggestedAPI Call
@@ -15,24 +16,27 @@ export async function suggestedFeesMockedApiCall(
   _originToken: string,
   _toChainid: ChainId,
   _fromChainid: ChainId,
-  _recipientAddress: string
+  _recipientAddress?: string
 ): Promise<SuggestedApiFeeReturnType> {
+  const token = getTokenByAddress(_originToken);
+  const decimals = token?.decimals ?? 18;
+
   return {
     relayerFee: {
       pct: BigNumber.from("1"),
-      total: BigNumber.from("1"),
+      total: parseUnits("0.5", decimals),
     },
     relayerCapitalFee: {
       pct: BigNumber.from("1"),
-      total: BigNumber.from("1"),
+      total: parseUnits("0.5", decimals),
     },
     relayerGasFee: {
       pct: BigNumber.from("1"),
-      total: BigNumber.from("1"),
+      total: parseUnits("0.5", decimals),
     },
     lpFee: {
       pct: BigNumber.from("1"),
-      total: BigNumber.from("1"),
+      total: parseUnits("0.5", decimals),
     },
     isAmountTooLow: false,
     quoteBlock: BigNumber.from("1"),

--- a/src/utils/serverless-api/prod/suggested-fees.prod.ts
+++ b/src/utils/serverless-api/prod/suggested-fees.prod.ts
@@ -16,7 +16,7 @@ export async function suggestedFeesApiCall(
   originToken: string,
   toChainid: ChainId,
   fromChainid: ChainId,
-  recipientAddress: string
+  recipientAddress?: string
 ): Promise<SuggestedApiFeeReturnType> {
   const response = await axios.get(`/api/suggested-fees`, {
     params: {

--- a/src/utils/serverless-api/prod/suggested-fees.prod.ts
+++ b/src/utils/serverless-api/prod/suggested-fees.prod.ts
@@ -23,7 +23,7 @@ export async function suggestedFeesApiCall(
       token: originToken,
       destinationChainId: toChainid,
       originChainId: fromChainid,
-      recipientAddress,
+      recipient: recipientAddress,
       amount: amount.toString(),
       skipAmountLimit: true,
     },

--- a/src/utils/serverless-api/types.ts
+++ b/src/utils/serverless-api/types.ts
@@ -57,7 +57,7 @@ export type SuggestedApiFeeType = (
   originToken: string,
   toChainid: ChainId,
   fromChainid: ChainId,
-  recipientAddress: string
+  recipientAddress?: string
 ) => Promise<SuggestedApiFeeReturnType>;
 
 export type RetrieveLinkedWalletType = (


### PR DESCRIPTION
We no longer require `/suggested-fees` have a `recipient` as input. Additionally, we're passing `recipientAddress` instead of `recipient` per https://github.com/across-protocol/frontend-v2/commit/85c862142067491527493f3045180f335fcf1253.

Let's update the UI to reflect these name changes and required statuses.