### PR TITLE
fix: quote update after user connected wallet via bridge action button

### DIFF
--- a/src/views/Bridge/hooks/useBridge.ts
+++ b/src/views/Bridge/hooks/useBridge.ts
@@ -117,7 +117,10 @@ export function useBridge() {
   useEffect(() => {
     if (shouldUpdateQuote && bridgeAction.isButtonActionLoading) {
       setShouldUpdateQuote(false);
-    } else if (bridgeAction.didActionError && !shouldUpdateQuote) {
+    } else if (
+      (bridgeAction.didActionError || !bridgeAction.isButtonActionLoading) &&
+      !shouldUpdateQuote
+    ) {
       setShouldUpdateQuote(true);
     }
   }, [

--- a/src/views/Bridge/hooks/useTransferQuote.ts
+++ b/src/views/Bridge/hooks/useTransferQuote.ts
@@ -39,6 +39,7 @@ export function useTransferQuote(
   return useQuery({
     queryKey: [
       "quote",
+      feesQuery.fees?.quoteBlock.toNumber(),
       selectedRoute.fromChain,
       selectedRoute.toChain,
       selectedRoute.fromTokenSymbol,

--- a/src/views/Bridge/hooks/useTransferQuote.ts
+++ b/src/views/Bridge/hooks/useTransferQuote.ts
@@ -39,7 +39,6 @@ export function useTransferQuote(
   return useQuery({
     queryKey: [
       "quote",
-      feesQuery.fees?.quoteBlock.toNumber(),
       selectedRoute.fromChain,
       selectedRoute.toChain,
       selectedRoute.fromTokenSymbol,


### PR DESCRIPTION
If a user connects a wallet via the primary CTA button on the bridge page, it leads to the quote not being updated. Ideally, the call to `connect()` should be in a separate handler/mutation and not inside the hook `useBridgeAction`. But we can refactor that in a separate PR.

Fixes ACX-1668