### PR TITLE
fix(suggested-fees): Defer default relayer assignment

### DIFF
--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -83,9 +83,6 @@ const handler = async (
       throw new InputError("Origin and destination chains cannot be the same");
     }
     const destinationChainId = Number(_destinationChainId);
-
-    relayer ??= sdk.constants.DEFAULT_SIMULATED_RELAYER_ADDRESS;
-    recipient ??= DEFAULT_SIMULATED_RECIPIENT_ADDRESS;
     token = ethers.utils.getAddress(token);
 
     const [latestBlock, tokenDetails] = await Promise.all([
@@ -106,6 +103,7 @@ const handler = async (
       tokenInformation.symbol,
       Number(destinationChainId)
     );
+    recipient ??= DEFAULT_SIMULATED_RECIPIENT_ADDRESS;
 
     if (sdk.utils.isDefined(message) && !sdk.utils.isMessageEmpty(message)) {
       if (!ethers.utils.isHexString(message)) {

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -101,7 +101,7 @@ const handler = async (
 
     relayer ??= getDefaultRelayerAddress(
       tokenInformation.symbol,
-      Number(destinationChainId)
+      destinationChainId
     );
     recipient ??= DEFAULT_SIMULATED_RECIPIENT_ADDRESS;
 


### PR DESCRIPTION
We should use getDefaultRelayerAddress() now because it contains conditional logic for which relayer to select based on the token being bridged.
