### PR TITLE
fix: display amount input error when clicking max button

### DIFF
--- a/src/views/Bridge/components/AmountInput.tsx
+++ b/src/views/Bridge/components/AmountInput.tsx
@@ -71,6 +71,9 @@ export function AmountInput({
           </AmountInnerWrapperTextStack>
           <MaxButtonWrapper
             onClick={() => {
+              if (!didEnter) {
+                setDidEnter(true);
+              }
               onClickMaxBalance();
             }}
             disabled={!balance}


### PR DESCRIPTION
When a user clicked the `MAX` button, the initial amount validation did not behave correctly.