### PR TITLE
fix: add stale-while-revalidate to limits

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1259,14 +1259,17 @@ export function sendResponse(
   response: VercelResponse,
   body: Record<string, unknown>,
   statusCode = 200,
-  cache?: number
+  cacheSeconds = 300,
+  staleWhileRevalidateSeconds?: number
 ) {
-  // We only want to cache if the status code is 200 and the
-  // caching time has been defined.
-  if (statusCode === 200 && sdk.utils.isDefined(cache)) {
+  if (cacheSeconds > 0) {
+    // Per Vercel's documentation, Vercel will only cache a response when
+    // the status code is 200. I.e. we can always set a cache policy
     response.setHeader(
       "Cache-Control",
-      `s-max-age=${cache}, stale-while-revalidate=${cache}`
+      (staleWhileRevalidateSeconds ?? 0) > 0
+        ? `s-maxage=${cacheSeconds}, stale-while-revalidate=${staleWhileRevalidateSeconds}`
+        : `s-maxage=${cacheSeconds}`
     );
   }
   return response.status(statusCode).json(body);

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1261,7 +1261,6 @@ export function sendResponse(
   statusCode = 200,
   cache?: number
 ) {
-  response.setHeader("Content-Type", "application/json");
   // We only want to cache if the status code is 200 and the
   // caching time has been defined.
   if (statusCode === 200 && sdk.utils.isDefined(cache)) {
@@ -1270,5 +1269,5 @@ export function sendResponse(
       `s-max-age=${cache}, stale-while-revalidate=${cache}`
     );
   }
-  return response.status(statusCode).send(body);
+  return response.status(statusCode).json(body);
 }

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1260,16 +1260,16 @@ export function getDefaultRelayerAddress(
 export function sendResponse(
   response: VercelResponse,
   body: Record<string, unknown>,
-  statusCode = 200,
-  cacheSeconds = 300,
-  staleWhileRevalidateSeconds?: number
+  statusCode: number,
+  cacheSeconds: number,
+  staleWhileRevalidateSeconds: number
 ) {
   if (cacheSeconds > 0) {
     // Per Vercel's documentation, Vercel will only cache a response when
     // the status code is 200. I.e. we can always set a cache policy
     response.setHeader(
       "Cache-Control",
-      (staleWhileRevalidateSeconds ?? 0) > 0
+      staleWhileRevalidateSeconds > 0
         ? `s-maxage=${cacheSeconds}, stale-while-revalidate=${staleWhileRevalidateSeconds}`
         : `s-maxage=${cacheSeconds}`
     );

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1252,8 +1252,10 @@ export function getDefaultRelayerAddress(
  * @param response The response client provided by Vercel
  * @param body A payload in JSON format to send to the client
  * @param statusCode The status code - defaults to 200
- * @param cache The cache time in seconds - defaults to 300
+ * @param cacheSeconds The cache time in seconds - defaults to 300
+ * @param staleWhileRevalidateSeconds The stale while revalidate time in seconds - defaults to 0
  * @returns The response object
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
  */
 export function sendResponse(
   response: VercelResponse,

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1246,3 +1246,29 @@ export function getDefaultRelayerAddress(
     return sdk.constants.DEFAULT_SIMULATED_RELAYER_ADDRESS;
   }
 }
+
+/**
+ * Performs the needed function calls to return a Vercel Response
+ * @param response The response client provided by Vercel
+ * @param body A payload in JSON format to send to the client
+ * @param statusCode The status code - defaults to 200
+ * @param cache The cache time in seconds - defaults to 300
+ * @returns The response object
+ */
+export function sendResponse(
+  response: VercelResponse,
+  body: Record<string, unknown>,
+  statusCode = 200,
+  cache?: number
+) {
+  response.setHeader("Content-Type", "application/json");
+  // We only want to cache if the status code is 200 and the
+  // caching time has been defined.
+  if (statusCode === 200 && sdk.utils.isDefined(cache)) {
+    response.setHeader(
+      "Cache-Control",
+      `s-max-age=${cache}, stale-while-revalidate=${cache}`
+    );
+  }
+  return response.status(statusCode).send(body);
+}

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -31,6 +31,7 @@ import {
   HUB_POOL_CHAIN_ID,
   ENABLED_ROUTES,
   getDefaultRelayerAddress,
+  sendResponse,
 } from "./_utils";
 
 const LimitsQueryParamsSchema = object({
@@ -235,8 +236,7 @@ const handler = async (
       message: "Response data",
       responseJson,
     });
-    response.setHeader("Cache-Control", "s-maxage=300");
-    response.status(200).json(responseJson);
+    sendResponse(response, responseJson, 200, 300);
   } catch (error: unknown) {
     return handleErrorCondition("limits", response, logger, error);
   }

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -226,17 +226,14 @@ const handler = async (
         liquidReserves
       ).toString(),
     };
-
-    // Instruct Vercel to cache limit data for this token for 5 minutes. Caching can be used to limit number of
-    // Vercel invocations and run time for this serverless function and trades off potential inaccuracy in times of
-    // high volume. "max-age=0" instructs browsers not to cache, while s-maxage instructs Vercel edge caching
-    // to cache the responses and invalidate when deployments update.
     logger.debug({
       at: "Limits",
       message: "Response data",
       responseJson,
     });
-    sendResponse(response, responseJson, 200, 300);
+    // Respond with a 200 status code and 4 minutes of cache cache with
+    // a minute of stale-while-revalidate.
+    sendResponse(response, responseJson, 200, 240, 60);
   } catch (error: unknown) {
     return handleErrorCondition("limits", response, logger, error);
   }


### PR DESCRIPTION
We should add `stale-while-revalidate` to our caching policy. The UX is improved by not requiring an unlucky user to request a fresh, uncached response. 

Additionally, we have boilerplate on all endpoints to return a response. We should centralize our returned headers. This PR adds a small response function that is tested in limits.

---

Requirements Fulfilled:
- [x]  Returned value on `/limits` is not more than 5 minutes
- [x] Recalculation is computed in the background.

---

Partially closes ACX-1692