### PR TITLE
improve: clean up providers.ts

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -73,6 +73,7 @@ export type ChainInfo = {
   chainId: ChainId;
   logoURI: string;
   rpcUrl?: string;
+  customRpcUrl?: string;
   explorerUrl: string;
   constructExplorerLink: (txHash: string) => string;
   pollingInterval: number;
@@ -102,6 +103,7 @@ export const chainInfoList: ChainInfoList = [
     constructExplorerLink: defaultConstructExplorerLink("https://etherscan.io"),
     nativeCurrencySymbol: "ETH",
     pollingInterval: defaultBlockPollingInterval,
+    customRpcUrl: process.env.REACT_APP_CHAIN_1_PROVIDER_URL,
   },
   {
     name: "Arbitrum",
@@ -114,6 +116,7 @@ export const chainInfoList: ChainInfoList = [
       `https://arbiscan.io/tx/${txHash}`,
     nativeCurrencySymbol: "AETH",
     pollingInterval: defaultBlockPollingInterval,
+    customRpcUrl: process.env.REACT_APP_CHAIN_42161_PROVIDER_URL,
   },
   {
     name: "Optimism",
@@ -125,6 +128,7 @@ export const chainInfoList: ChainInfoList = [
       `https://optimistic.etherscan.io/tx/${txHash}`,
     nativeCurrencySymbol: "OETH",
     pollingInterval: defaultBlockPollingInterval,
+    customRpcUrl: process.env.REACT_APP_CHAIN_10_PROVIDER_URL,
   },
   {
     name: "Polygon",
@@ -138,6 +142,7 @@ export const chainInfoList: ChainInfoList = [
     ),
     nativeCurrencySymbol: "MATIC",
     pollingInterval: defaultBlockPollingInterval,
+    customRpcUrl: process.env.REACT_APP_CHAIN_137_PROVIDER_URL,
   },
   {
     name: "zkSync",
@@ -151,6 +156,7 @@ export const chainInfoList: ChainInfoList = [
     ),
     nativeCurrencySymbol: "ETH",
     pollingInterval: 10_000,
+    customRpcUrl: process.env.REACT_APP_CHAIN_324_PROVIDER_URL,
   },
   {
     name: "Base",
@@ -162,6 +168,7 @@ export const chainInfoList: ChainInfoList = [
     constructExplorerLink: defaultConstructExplorerLink("https://basescan.org"),
     nativeCurrencySymbol: "ETH",
     pollingInterval: 10_000,
+    customRpcUrl: process.env.REACT_APP_CHAIN_8453_PROVIDER_URL,
   },
   // testnets
   {
@@ -175,6 +182,7 @@ export const chainInfoList: ChainInfoList = [
     ),
     nativeCurrencySymbol: "ETH",
     pollingInterval: defaultBlockPollingInterval,
+    customRpcUrl: process.env.REACT_APP_CHAIN_5_PROVIDER_URL,
   },
   {
     name: "Mumbai",
@@ -187,6 +195,7 @@ export const chainInfoList: ChainInfoList = [
     ),
     nativeCurrencySymbol: "WMATIC",
     pollingInterval: defaultBlockPollingInterval,
+    customRpcUrl: process.env.REACT_APP_CHAIN_80001_PROVIDER_URL,
   },
   {
     name: "Arbitrum Goerli",
@@ -198,6 +207,7 @@ export const chainInfoList: ChainInfoList = [
       `https://testnet.arbiscan.io/tx/${txHash}`,
     nativeCurrencySymbol: "ETH",
     pollingInterval: defaultBlockPollingInterval,
+    customRpcUrl: process.env.REACT_APP_CHAIN_421613_PROVIDER_URL,
   },
   {
     name: "zkSync Goerli",
@@ -211,6 +221,7 @@ export const chainInfoList: ChainInfoList = [
     ),
     nativeCurrencySymbol: "ETH",
     pollingInterval: defaultBlockPollingInterval,
+    customRpcUrl: process.env.REACT_APP_CHAIN_280_PROVIDER_URL,
   },
   {
     name: "Base Goerli",
@@ -224,6 +235,7 @@ export const chainInfoList: ChainInfoList = [
     ),
     nativeCurrencySymbol: "ETH",
     pollingInterval: defaultBlockPollingInterval,
+    customRpcUrl: process.env.REACT_APP_CHAIN_84531_PROVIDER_URL,
   },
 ];
 

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -11,7 +11,7 @@ function getInfuraProviderUrl(chainId: number): string | undefined {
 
 function getProviderUrl(chainId: number): string {
   const resolvedRpcUrl =
-    process.env[`REACT_APP_CHAIN_${chainId}_PROVIDER_URL`] ||
+    chainInfoTable[chainId]?.customRpcUrl ||
     getInfuraProviderUrl(chainId) ||
     chainInfoTable[chainId]?.rpcUrl;
   if (resolvedRpcUrl) {

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,79 +1,44 @@
 import { ethers, providers } from "ethers";
-import { hubPoolChainId, ChainId, infuraId } from "./constants";
+import { hubPoolChainId, ChainId, infuraId, chainInfoTable } from "./constants";
 
-function getInfuraProviderUrl(chainId: number) {
-  const infuraUrl = new providers.InfuraProvider(chainId, infuraId).connection
-    .url;
-  return infuraUrl;
+function getInfuraProviderUrl(chainId: number): string | undefined {
+  try {
+    return new providers.InfuraProvider(chainId, infuraId).connection.url;
+  } catch (e) {
+    return undefined;
+  }
 }
 
-export const providerUrls: [ChainId, string][] = [
-  [
-    ChainId.MAINNET,
-    process.env.REACT_APP_CHAIN_1_PROVIDER_URL ||
-      getInfuraProviderUrl(ChainId.MAINNET),
-  ],
-  [
-    ChainId.ARBITRUM,
-    process.env.REACT_APP_CHAIN_42161_PROVIDER_URL ||
-      getInfuraProviderUrl(ChainId.ARBITRUM),
-  ],
-  [
-    ChainId.POLYGON,
-    process.env.REACT_APP_CHAIN_137_PROVIDER_URL ||
-      getInfuraProviderUrl(ChainId.POLYGON),
-  ],
-  [
-    ChainId.OPTIMISM,
-    process.env.REACT_APP_CHAIN_10_PROVIDER_URL ||
-      getInfuraProviderUrl(ChainId.OPTIMISM),
-  ],
-  [
-    ChainId.ZK_SYNC,
-    process.env.REACT_APP_CHAIN_324_PROVIDER_URL ||
-      "https://mainnet.era.zksync.io",
-  ],
-  [
-    ChainId.BASE,
-    process.env.REACT_APP_CHAIN_8453_PROVIDER_URL || "https://mainnet.base.org",
-  ],
-  // testnets
-  [
-    ChainId.ARBITRUM_GOERLI,
-    process.env.REACT_APP_CHAIN_421613_PROVIDER_URL ||
-      getInfuraProviderUrl(ChainId.ARBITRUM_GOERLI),
-  ],
-  [
-    ChainId.GOERLI,
-    process.env.REACT_APP_CHAIN_5_PROVIDER_URL ||
-      getInfuraProviderUrl(ChainId.GOERLI),
-  ],
-  [
-    ChainId.MUMBAI,
-    process.env.REACT_APP_CHAIN_80001_PROVIDER_URL ||
-      getInfuraProviderUrl(ChainId.MUMBAI),
-  ],
-  [
-    ChainId.ZK_SYNC_GOERLI,
-    process.env.REACT_APP_CHAIN_280_PROVIDER_URL ||
-      "https://zksync2-testnet.zksync.dev/",
-  ],
-  [
-    ChainId.BASE_GOERLI,
-    process.env.REACT_APP_CHAIN_84531_PROVIDER_URL || "https://goerli.base.org",
-  ],
-];
-
-export const providerUrlsTable: Record<number, string> =
-  Object.fromEntries(providerUrls);
+function getProviderUrl(chainId: number): string {
+  const resolvedRpcUrl =
+    process.env[`REACT_APP_CHAIN_${chainId}_PROVIDER_URL`] ||
+    getInfuraProviderUrl(chainId) ||
+    chainInfoTable[chainId]?.rpcUrl;
+  if (resolvedRpcUrl) {
+    return resolvedRpcUrl;
+  } else {
+    throw new Error(`No provider URL found for chainId ${chainId}`);
+  }
+}
 
 export const providersTable: Record<
   number,
   ethers.providers.StaticJsonRpcProvider
-> = Object.fromEntries(
-  providerUrls.map(([chainId, url]) => {
-    return [chainId, new ethers.providers.StaticJsonRpcProvider(url, chainId)];
-  })
+> = Object.values(ChainId)
+  .filter((c) => !Number.isNaN(Number(c)))
+  .reduce(
+    (acc, v) => ({
+      ...acc,
+      [Number(v)]: new ethers.providers.StaticJsonRpcProvider(
+        getProviderUrl(Number(v)),
+        Number(v)
+      ),
+    }),
+    {}
+  );
+
+export const providerUrlsTable: Record<number, string> = Object.fromEntries(
+  Object.entries(providersTable).map(([k, v]) => [k, v.connection.url])
 );
 
 export function getProvider(


### PR DESCRIPTION
We are redefining a list of chain ids when we have access to them already. This PR cleans up how we handle the initial instantiation of providers.