### PR TITLE
fix: enforce domain name on production environment

### DIFF
--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -4,12 +4,12 @@
  * @todo These are always going to be the same since we don't export REACT_APP currently.
  */
 export const resolveWebsiteUrl = () => {
-  const url = process.env.REACT_APP_VERCEL_URL ?? "across.to";
   const env = process.env.REACT_APP_VERCEL_ENV ?? "production";
   switch (env) {
-    case "preview":
     case "production":
-      return `https://${url}`;
+      return "https://across.to";
+    case "preview":
+      return `https://${process.env.REACT_APP_VERCEL_URL ?? "across.to"}`;
     case "development":
     default:
       return `http://localhost:3000`;


### PR DESCRIPTION
Although the FE is reading from the `REACT_APP_VERCEL_ENV` - we're getting the instantaneous vercel API. We should check for a production API and force the `across.to` domain name.