### PR TITLE
fix: only show invalid amt when there's an amount

### DIFF
--- a/src/views/Bridge/components/AmountInput.tsx
+++ b/src/views/Bridge/components/AmountInput.tsx
@@ -4,7 +4,7 @@ import { BigNumber, utils } from "ethers";
 
 import { Text } from "components/Text";
 import { UnstyledButton } from "components/Button";
-import { QUERIESV2, Route, getToken } from "utils";
+import { QUERIESV2, Route, getToken, isDefined } from "utils";
 
 import BridgeInputErrorAlert from "./BridgeAlert";
 import { AmountInputError } from "../utils";
@@ -36,7 +36,9 @@ export function AmountInput({
 
   const token = getToken(selectedRoute.fromTokenSymbol);
 
-  const isAmountValid = !Boolean(validationError);
+  // Valid if no input, otherwise check if there's not an error
+  const isAmountValid =
+    (amountInput ?? "") === "" || !isDefined(validationError);
 
   return (
     <AmountExternalWrapper>
@@ -229,4 +231,5 @@ const AmountInnerInput = styled.input<IValidInput>`
   }
   /* Firefox */
   -moz-appearance: textfield;
+  appearance: textfield;
 `;


### PR DESCRIPTION
The UI has a bug where it marks an empty input field with a red "please input positive number" error. The UI should go back to the unchanged state when a user removed their amount.

Steps to reproduce.

1. Visit `https://across.to/bridge`
2. Enter a number into the amount field.
3. Remove the amount entirely

You will be left with this:
<img width="635" alt="image" src="https://github.com/across-protocol/frontend-v2/assets/96435344/31ac872f-d3dc-479a-a4f0-b81743f42934">
