### PR TITLE
improve: restore tooltip for claiming intervals

### DIFF
--- a/src/views/RewardsProgram/GenericRewardsProgram/GenericInformationCard.tsx
+++ b/src/views/RewardsProgram/GenericRewardsProgram/GenericInformationCard.tsx
@@ -14,6 +14,10 @@ export type GenericRewardInformationRowType = {
   extendedPrefixSpacing?: boolean;
   prefixArrow?: boolean;
   prefixIcon?: "clock";
+  prefixIconTooltip?: {
+    title: string;
+    content: string;
+  };
 };
 
 const GenericInformationCard = ({
@@ -26,15 +30,19 @@ const GenericInformationCard = ({
   <GenericCard program={program}>
     <RowContainer elements={rows.length}>
       {rows.map(
-        ({
-          title,
-          tooltip,
-          value,
-          prefix,
-          extendedPrefixSpacing,
-          prefixArrow,
-          prefixIcon,
-        }) => (
+        (
+          {
+            title,
+            tooltip,
+            value,
+            prefix,
+            extendedPrefixSpacing,
+            prefixArrow,
+            prefixIcon,
+            prefixIconTooltip,
+          },
+          idx
+        ) => (
           <Row key={title}>
             <TitleWithTooltipStack>
               <Text color="grey-400">{title}</Text>
@@ -54,7 +62,20 @@ const GenericInformationCard = ({
                 {prefix && (
                   <>
                     <PrefixIconPrefixStack>
-                      {prefixIcon === "clock" && <ClockIcon />}
+                      {prefixIcon === "clock" &&
+                        (prefixIconTooltip ? (
+                          <Tooltip
+                            tooltipId={`prefix-info-tooltip-${idx}-${program}`}
+                            body={prefixIconTooltip.content}
+                            title={prefixIconTooltip.title}
+                            icon={prefixIcon}
+                            placement="bottom-start"
+                          >
+                            <ClockIcon />
+                          </Tooltip>
+                        ) : (
+                          <ClockIcon />
+                        ))}
                       <Text color="grey-400">{prefix}</Text>
                     </PrefixIconPrefixStack>
                     {prefixArrow && <ArrowIcon color="grey-400">←</ArrowIcon>}

--- a/src/views/RewardsProgram/GenericRewardsProgram/GenericRewardClaimCard.tsx
+++ b/src/views/RewardsProgram/GenericRewardsProgram/GenericRewardClaimCard.tsx
@@ -2,10 +2,11 @@ import styled from "@emotion/styled";
 import { ReactComponent as ClockIcon } from "assets/icons/clock.svg";
 import { PrimaryButton, Text } from "components";
 import { useState } from "react";
-import { COLORS, rewardProgramTypes } from "utils";
+import { COLORS, capitalizeFirstLetter, rewardProgramTypes } from "utils";
 import { useGenericRewardClaimCard } from "../hooks/useGenericRewardClaimCard";
 import { ClaimRewardsModal } from "./ClaimRewardsModal";
 import GenericCard from "./GenericCard";
+import { Tooltip } from "components/Tooltip";
 
 type GenericRewardClaimCardProps = {
   program: rewardProgramTypes;
@@ -24,6 +25,7 @@ const GenericRewardClaimCard = ({
     rewardTokenSymbol,
     formatUnits,
     isConnected,
+    programName,
   } = useGenericRewardClaimCard(program);
   const [isModalOpen, setModalOpen] = useState(false);
   return (
@@ -44,7 +46,16 @@ const GenericRewardClaimCard = ({
             </Text>
             {unclaimedAmount && (
               <ClaimableIconTextStack>
-                <ClockIcon />
+                <Tooltip
+                  body={`New ${programName.toLowerCase()} rewards are claimable 2 weeks after the first day of every month`}
+                  title={`${capitalizeFirstLetter(
+                    programName.toLowerCase()
+                  )} claiming`}
+                  icon="clock"
+                  placement="bottom-start"
+                >
+                  <ClockIcon />
+                </Tooltip>
                 <Text color="grey-400" size="md">
                   {formatUnits(unclaimedAmount)} {rewardTokenSymbol} claimable
                 </Text>

--- a/src/views/RewardsProgram/hooks/useACXReferralsProgram.ts
+++ b/src/views/RewardsProgram/hooks/useACXReferralsProgram.ts
@@ -1,9 +1,11 @@
 import { useConnection, useRewardSummary } from "hooks";
 import { GenericRewardInformationRowType } from "../GenericRewardsProgram/GenericInformationCard";
 import {
+  capitalizeFirstLetter,
   formatNumberTwoFracDigits,
   formatUnits,
   getToken,
+  rewardPrograms,
   rewardTiers,
 } from "utils";
 import { useMemo } from "react";
@@ -13,6 +15,7 @@ import { BigNumber } from "ethers";
 export function useACXReferralsProgram() {
   const { account } = useConnection();
   const { summary } = useRewardSummary("referrals", account);
+  const { programName } = rewardPrograms["referrals"];
   const token = useMemo(() => getToken("ACX"), []);
   const { data: unclaimedReferralData } = useUnclaimedReferralProofs();
 
@@ -73,26 +76,24 @@ export function useACXReferralsProgram() {
       {
         title: "Total Rewards",
         value: `${formatUnits(summary.rewardsAmount, token.decimals)} ACX`,
-        prefix: unclaimedReferralData?.claimableAmount.gt(0)
-          ? `${formatUnits(
-              unclaimedReferralData.claimableAmount,
-              token.decimals
-            )} ACX claimable`
-          : undefined,
+        prefix: `${formatUnits(
+          unclaimedReferralData?.claimableAmount ?? 0,
+          token.decimals
+        )} ACX claimable`,
         prefixIcon: "clock",
+        prefixIconTooltip: {
+          content: `New ${programName.toLowerCase()} rewards are claimable 2 weeks after the first day of every month`,
+          title: `${capitalizeFirstLetter(programName.toLowerCase())} claiming`,
+        },
       },
     ],
     [
       currentTier.title,
       nextTier,
-      summary.activeRefereesCount,
-      summary.referralRate,
-      summary.referreeWallets,
-      summary.rewardsAmount,
-      summary.transfers,
-      summary.volume,
+      summary,
       token.decimals,
       unclaimedReferralData?.claimableAmount,
+      programName,
     ]
   );
 


### PR DESCRIPTION
This PR restores the claim tooltip when hovering over the clock icons below:
![image](https://github.com/across-protocol/frontend-v2/assets/96435344/8b47161c-35a0-4402-960d-61db4f7a9767)
