### PR TITLE
fix: op rebates claimable amounts

### DIFF
--- a/src/views/Rewards/hooks/useRewardProgramCard.ts
+++ b/src/views/Rewards/hooks/useRewardProgramCard.ts
@@ -9,7 +9,7 @@ export function useRewardProgramCard(programName: rewardProgramTypes) {
   const { summary } = useRewardSummary(programName, account);
   const rewardsAmount =
     summary.program === "op-rebates"
-      ? summary.claimableRewards
+      ? summary.unclaimedRewards
       : summary.rewardsAmount;
   return {
     ...programDetail,

--- a/src/views/RewardsProgram/hooks/useGenericRewardClaimCard.ts
+++ b/src/views/RewardsProgram/hooks/useGenericRewardClaimCard.ts
@@ -28,12 +28,12 @@ export function useGenericRewardClaimCard(program: rewardProgramTypes) {
   const { summary } = useRewardSummary(program, account);
   const rewardsAmount =
     summary.program === "op-rebates"
-      ? summary.claimableRewards
+      ? summary.unclaimedRewards
       : summary.rewardsAmount;
   const unclaimedAmount =
     summary.program === "referrals"
       ? unclaimedReferralData?.claimableAmount
-      : summary.unclaimedRewards;
+      : summary.claimableRewards;
 
   const formatUnits = formatUnitsFnBuilder(token.decimals);
 
@@ -49,7 +49,7 @@ export function useGenericRewardClaimCard(program: rewardProgramTypes) {
   return {
     ...programDetails,
     token,
-    rewardsAmount: BigNumber.from(rewardsAmount),
+    rewardsAmount: BigNumber.from(rewardsAmount ?? 0),
     unclaimedAmount: BigNumber.from(unclaimedAmount ?? 0),
     formatUnits,
     disconnectedState,

--- a/src/views/RewardsProgram/hooks/useOPRebatesProgram.ts
+++ b/src/views/RewardsProgram/hooks/useOPRebatesProgram.ts
@@ -32,11 +32,11 @@ export function useOPRebatesProgram() {
       {
         title: "Rewards",
         tooltip: "Rewards earned from this Optimism program",
-        value: `${formatUnits(summary.claimableRewards, token.decimals)} ${
+        value: `${formatUnits(summary.unclaimedRewards || 0, token.decimals)} ${
           token.symbol
         }`,
         prefix: `${formatUnits(
-          summary.unclaimedRewards ?? "0",
+          summary.claimableRewards ?? "0",
           token.decimals
         )} ${token.symbol} claimable`,
         prefixIcon: "clock",

--- a/src/views/RewardsProgram/hooks/useOPRebatesProgram.ts
+++ b/src/views/RewardsProgram/hooks/useOPRebatesProgram.ts
@@ -51,7 +51,7 @@ export function useOPRebatesProgram() {
 
   return {
     labels,
-    rewardsAmount: BigNumber.from(0),
-    claimableAmount: BigNumber.from(summary.unclaimedRewards || 0),
+    rewardsAmount: BigNumber.from(summary.unclaimedRewards || 0),
+    claimableAmount: BigNumber.from(summary.claimableRewards || 0),
   };
 }


### PR DESCRIPTION
There is a mixup with the amounts
<img width="580" alt="image" src="https://github.com/across-protocol/frontend-v2/assets/17645687/85701105-498e-4fc2-9afe-c4c6840b1fb2">
