### PR TITLE
fix: resolve crash when OP unclaimed reward is null

### DIFF
--- a/src/views/Rewards/hooks/useRewardProgramCard.ts
+++ b/src/views/Rewards/hooks/useRewardProgramCard.ts
@@ -9,7 +9,7 @@ export function useRewardProgramCard(programName: rewardProgramTypes) {
   const { summary } = useRewardSummary(programName, account);
   const rewardsAmount =
     summary.program === "op-rebates"
-      ? summary.unclaimedRewards
+      ? summary.unclaimedRewards ?? 0
       : summary.rewardsAmount;
   return {
     ...programDetail,


### PR DESCRIPTION
This bug is a consequence of the Scraper API returning null rather than returning 0 for `unclaimedRewards` via the `/rewards/op-rebates/summary?userAddress={}` endpoint.