### PR TITLE
fix: add chain id 5 to external staking LPs const

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -285,6 +285,7 @@ export const externalLPsForStaking: Record<number, ExternalLPTokenList> = {
       ],
     },
   ],
+  5: [],
 };
 
 export const bridgedUSDCSymbolsMap = {


### PR DESCRIPTION
Goerli HubPool build was broken. This PR fixes it