### PR TITLE
fix: base currency conversions for fee preview

### DIFF
--- a/src/views/Bridge/hooks/useEstimatedTable.ts
+++ b/src/views/Bridge/hooks/useEstimatedTable.ts
@@ -69,9 +69,9 @@ export function useEstimatedTable(
 
   const baseCurrencyConversions = useMemo(() => {
     const parseUsd = (usd?: number) =>
-      isDefined(usd) ? parseUnits(String(usd.toFixed(2)), 18) : undefined;
+      isDefined(usd) ? parseUnits(String(usd), 18) : undefined;
     const formatNumericUsd = (usd: BigNumber) =>
-      Number(ethersUtils.formatUnits(usd, 18));
+      Number(Number(ethersUtils.formatUnits(usd, 18)).toFixed(2));
     const gasFeeInUSD = convertL1ToBaseCurrency(gasFee);
     const bridgeFeeInUSD = convertL1ToBaseCurrency(bridgeFee);
 

--- a/src/views/Bridge/hooks/useEstimatedTable.ts
+++ b/src/views/Bridge/hooks/useEstimatedTable.ts
@@ -69,7 +69,7 @@ export function useEstimatedTable(
 
   const baseCurrencyConversions = useMemo(() => {
     const parseUsd = (usd?: number) =>
-      isDefined(usd) ? parseUnits(String(usd), 18) : undefined;
+      isDefined(usd) ? parseUnits(String(usd.toFixed(2)), 18) : undefined;
     const formatNumericUsd = (usd: BigNumber) =>
       Number(ethersUtils.formatUnits(usd, 18));
     const gasFeeInUSD = convertL1ToBaseCurrency(gasFee);


### PR DESCRIPTION
Fixes base currency conversions on the fee preview for values > 1k. 

The root cause was again unexpected behavior of the helper `formatUSD`. I have seen quite a few bugs recently due to this function. From what I can tell, the function's naming suggests something else than it does. We should refactor the name soon.