### PR TITLE
improve(error): improve error readout

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -198,7 +198,7 @@ export const resolveVercelEndpoint = () => {
   }
 };
 
-export const getTokenDetails = async (
+const _getTokenDetails = async (
   provider: providers.Provider,
   l1Token?: string,
   l2Token?: string,
@@ -231,15 +231,27 @@ export const getTokenDetails = async (
     return b.logIndex - a.logIndex;
   });
 
-  const event = events[0];
-
-  return {
+  return events.map((event) => ({
     hubPool,
     chainId: event.args.destinationChainId.toNumber(),
     l1Token: event.args.l1Token,
     l2Token: event.args.destinationToken,
-  };
+  }));
 };
+
+export const getTokenDetails = async (
+  provider: providers.Provider,
+  l1Token?: string,
+  l2Token?: string,
+  chainId?: string
+) => (await _getTokenDetails(provider, l1Token, l2Token, chainId))[0];
+
+export const hasPotentialRouteCollision = async (
+  provider: providers.Provider,
+  l1Token?: string,
+  l2Token?: string,
+  chainId?: string
+) => (await _getTokenDetails(provider, l1Token, l2Token, chainId)).length > 1;
 
 export class InputError extends Error {}
 
@@ -604,7 +616,7 @@ export const isRouteEnabled = (
   fromToken: string
 ): boolean => {
   const enabled = ENABLED_ROUTES.routes.some(
-    ({ fromTokenAddress, fromChain, toChain, fromTokenSymbol }) =>
+    ({ fromTokenAddress, fromChain, toChain }) =>
       fromChainId === fromChain &&
       toChainId === toChain &&
       fromToken.toLowerCase() === fromTokenAddress.toLowerCase()


### PR DESCRIPTION
## Issue Summary
The absence of `originChainId` parameter passed in `/limits` or `/suggested-fees` API calls can lead to a route collision due to a wildcard search, causing an "Invalid route" error even when valid routes exist.

## Immediate Action
Implement a custom error response indicating a route collision due to missing `originChainId`. This will provide clearer feedback, helping users distinguish between a true invalid route and a route collision.

## Long-term Resolution
Gradually enforce the inclusion of `originChainId` in API requests through a phased approach, with ample notice to partners for a smooth transition. This will prevent route collisions and improve the accuracy of route determination.
