### PR TITLE
feat(ampli): disable default tracking of sessions

### DIFF
--- a/src/hooks/useLoadAmpli.ts
+++ b/src/hooks/useLoadAmpli.ts
@@ -25,7 +25,7 @@ export function useLoadAmpli() {
           defaultTracking: {
             attribution: true,
             pageViews: false,
-            sessions: true,
+            sessions: false,
             fileDownloads: false,
             formInteractions: false,
           },


### PR DESCRIPTION
We think that default session events from Amplitude pollute the data on some of the dashboards. This PR disables them to see if this is the root cause.