### PR TITLE
fix: fee breakdown for v3 fees

### DIFF
--- a/src/components/DepositsTable/cells/NetFeeCell.tsx
+++ b/src/components/DepositsTable/cells/NetFeeCell.tsx
@@ -72,16 +72,21 @@ function FeeWithBreakdown({ deposit }: { deposit: Deposit }) {
     ? getToken(deposit.rewards.type === "op-rebates" ? "OP" : "ACX")
     : undefined;
 
-  const relayCapitalFeeAmount = BigNumber.from(
-    isBigNumberish(deposit.feeBreakdown?.relayCapitalFeeAmount)
-      ? deposit.feeBreakdown?.relayCapitalFeeAmount || 0
+  const capitalAndLpFeeUsd =
+    Number(deposit.feeBreakdown?.totalBridgeFeeUsd || 0) -
+    Number(deposit.feeBreakdown?.relayGasFeeUsd || 0);
+  const capitalAndLpFeeAmount = BigNumber.from(
+    isBigNumberish(deposit.feeBreakdown?.totalBridgeFeeUsd)
+      ? deposit.feeBreakdown?.totalBridgeFeeUsd || 0
       : 0
+  ).add(
+    BigNumber.from(
+      isBigNumberish(deposit.feeBreakdown?.relayGasFeeAmount)
+        ? deposit.feeBreakdown?.relayGasFeeAmount || 0
+        : 0
+    )
   );
-  const lpFeeAmount = BigNumber.from(
-    isBigNumberish(deposit.feeBreakdown?.lpFeeAmount)
-      ? deposit.feeBreakdown?.lpFeeAmount || 0
-      : 0
-  );
+
   return (
     <>
       <Text color="light-200">${netFee.toFixed(2)}</Text>
@@ -111,18 +116,10 @@ function FeeWithBreakdown({ deposit }: { deposit: Deposit }) {
                 </Text>
                 <FeeValueWrapper>
                   <Text size="sm" color="grey-400">
-                    $
-                    {formatMaxFracDigits(
-                      Number(deposit.feeBreakdown?.relayCapitalFeeUsd || 0) +
-                        Number(deposit.feeBreakdown?.lpFeeUsd || 0),
-                      2
-                    )}
+                    ${formatMaxFracDigits(capitalAndLpFeeUsd, 2)}
                   </Text>
                   <Text size="sm" color="light-200">
-                    {formatUnits(
-                      relayCapitalFeeAmount.add(lpFeeAmount),
-                      tokenInfo.decimals
-                    )}{" "}
+                    {formatUnits(capitalAndLpFeeAmount, tokenInfo.decimals)}{" "}
                     {tokenInfo.symbol}
                   </Text>
                   <img src={tokenInfo.logoURI} alt={tokenInfo.symbol} />

--- a/src/components/DepositsTable/cells/NetFeeCell.tsx
+++ b/src/components/DepositsTable/cells/NetFeeCell.tsx
@@ -76,8 +76,8 @@ function FeeWithBreakdown({ deposit }: { deposit: Deposit }) {
     Number(deposit.feeBreakdown?.totalBridgeFeeUsd || 0) -
     Number(deposit.feeBreakdown?.relayGasFeeUsd || 0);
   const capitalAndLpFeeAmount = BigNumber.from(
-    isBigNumberish(deposit.feeBreakdown?.totalBridgeFeeUsd)
-      ? deposit.feeBreakdown?.totalBridgeFeeUsd || 0
+    isBigNumberish(deposit.feeBreakdown?.totalBridgeFeeAmount)
+      ? deposit.feeBreakdown?.totalBridgeFeeAmount || 0
       : 0
   ).sub(
     BigNumber.from(

--- a/src/components/DepositsTable/cells/NetFeeCell.tsx
+++ b/src/components/DepositsTable/cells/NetFeeCell.tsx
@@ -79,7 +79,7 @@ function FeeWithBreakdown({ deposit }: { deposit: Deposit }) {
     isBigNumberish(deposit.feeBreakdown?.totalBridgeFeeUsd)
       ? deposit.feeBreakdown?.totalBridgeFeeUsd || 0
       : 0
-  ).add(
+  ).sub(
     BigNumber.from(
       isBigNumberish(deposit.feeBreakdown?.relayGasFeeAmount)
         ? deposit.feeBreakdown?.relayGasFeeAmount || 0


### PR DESCRIPTION
The Scraper won't be able to distinguish the separate fee components of the total fee in v3 anymore (i.e. `lpFee`, `capitalFee` and `gasFee`). The fee breakdown will therefore only contain the `gasFee` certainly. This PR therefore uses that value to determine the details in the fee breakdown.