### PR TITLE
fix: only show speed up button if not delayed and unprofitable

### DIFF
--- a/src/components/DepositsTable/DataRow.tsx
+++ b/src/components/DepositsTable/DataRow.tsx
@@ -105,10 +105,4 @@ const StyledRow = styled.tr`
   border-width: 0px 1px 1px 1px;
   border-style: solid;
   border-color: ${COLORS["grey-600"]};
-
-  :hover {
-    #speed-up-icon {
-      display: block;
-    }
-  }
 `;

--- a/src/components/DepositsTable/cells/ActionsCell.tsx
+++ b/src/components/DepositsTable/cells/ActionsCell.tsx
@@ -43,12 +43,8 @@ export function ActionsCell({ deposit, onClickSpeedUp }: Props) {
   }, [deposit, onClickSpeedUp]);
 
   const speedUp =
-    deposit.status === "pending" ? (
-      isProfitable ? (
-        <ZapIconOnHover id="speed-up-icon" onClick={handleClickSpeedUp} />
-      ) : (
-        <ZapIconPersistent onClick={handleClickSpeedUp} />
-      )
+    !isDelayed && !isProfitable ? (
+      <ZapIconPersistent onClick={handleClickSpeedUp} />
     ) : null;
 
   return (

--- a/src/components/DepositsTable/cells/ActionsCell.tsx
+++ b/src/components/DepositsTable/cells/ActionsCell.tsx
@@ -107,14 +107,6 @@ const SlowRelayInfoIconTooltip = styled(InfoIcon)`
   }
 `;
 
-const ZapIconOnHover = styled(ZapIcon)`
-  display: none;
-
-  path {
-    stroke: ${COLORS["grey-400"]};
-  }
-`;
-
 const ZapIconPersistent = styled(ZapIcon)`
   path {
     stroke: ${COLORS.yellow};


### PR DESCRIPTION
Users got confused when their deposits got delayed and tried to speed up. To prevent this in the future, we only allow speed up if the deposit is unprofitable and not delayed