### PR TITLE
fix: isV2 flag in log parser

### DIFF
--- a/src/utils/deposits.ts
+++ b/src/utils/deposits.ts
@@ -62,7 +62,7 @@ export async function getDepositByTxHash(
     depositTxReceipt,
     parsedDepositLog,
     depositTimestamp: block.timestamp,
-    isV2: parseFundsDepositedLog.name === "FundsDeposited",
+    isV2: parsedDepositLog.name === "FundsDeposited",
   };
 }
 


### PR DESCRIPTION
I noticed this bug 