### PR TITLE
chore(contracts-v2): bump contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-only",
   "dependencies": {
     "@across-protocol/constants-v2": "^1.0.12",
-    "@across-protocol/contracts-v2": "2.5.0-beta.7",
+    "@across-protocol/contracts-v2": "2.5.1",
     "@across-protocol/sdk-v2": "^0.22.6",
     "@amplitude/analytics-browser": "^2.3.5",
     "@balancer-labs/sdk": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "AGPL-3.0-only",
   "dependencies": {
-    "@across-protocol/constants-v2": "^1.0.11",
+    "@across-protocol/constants-v2": "^1.0.12",
     "@across-protocol/contracts-v2": "2.5.0-beta.7",
     "@across-protocol/sdk-v2": "^0.22.6",
     "@amplitude/analytics-browser": "^2.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,6 +46,26 @@
     axios "^1.6.2"
     zksync-web3 "^0.14.3"
 
+"@across-protocol/contracts-v2@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts-v2/-/contracts-v2-2.5.1.tgz#81a85f735fe5060ce33b7f7f502b559052cdad1d"
+  integrity sha512-/c/2De7JKaR5g95ZC94XFgUTQgfB/1Iu0IOfz6m5ixkR40i58yFJLQoN2NbeFRBmSFRJaTGvz/5lIZ0hOraOQA==
+  dependencies:
+    "@across-protocol/constants-v2" "^1.0.11"
+    "@defi-wonderland/smock" "^2.3.4"
+    "@eth-optimism/contracts" "^0.5.40"
+    "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/abstract-signer" "5.7.0"
+    "@ethersproject/bignumber" "5.7.0"
+    "@openzeppelin/contracts" "4.9.3"
+    "@openzeppelin/contracts-upgradeable" "4.9.6"
+    "@scroll-tech/contracts" "^0.1.0"
+    "@uma/common" "^2.34.0"
+    "@uma/contracts-node" "^0.4.17"
+    "@uma/core" "^2.56.0"
+    axios "^1.6.2"
+    zksync-web3 "^0.14.3"
+
 "@across-protocol/contracts@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-0.1.4.tgz#64b3d91e639d2bb120ea94ddef3d160967047fa5"
@@ -5910,6 +5930,11 @@
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.3.tgz#ff17a80fb945f5102571f8efecb5ce5915cc4811"
   integrity sha512-jjaHAVRMrE4UuZNfDwjlLGDxTHWIOwTJS2ldnc278a0gevfXfPr8hxKEVBGFBE96kl2G3VHDZhUimw/+G3TG2A==
+
+"@openzeppelin/contracts-upgradeable@4.9.6":
+  version "4.9.6"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.6.tgz#38b21708a719da647de4bb0e4802ee235a0d24df"
+  integrity sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==
 
 "@openzeppelin/contracts-upgradeable@^4.8.1":
   version "4.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,6 +21,11 @@
   resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.11.tgz#58d34b5cb50351d097f2ca43c5a30b5908faed7c"
   integrity sha512-RpseYB2QxGyfyrfXtUeFxUSCUW1zqu442QFzsdD1LBZtymuzdHuL2MwtTdmRRnJSvzRTFTtlRh4bYDoExSb5zQ==
 
+"@across-protocol/constants-v2@^1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.12.tgz#a85e8d39efa9c5294a368e229eab65357f00645e"
+  integrity sha512-UrrPOxV/+FjCHmlMnezviAMXDiGDzUNCwKC2ifQ0U8PGa+lNulb7KCGNIEIFAFLHNn+/CMFST5Vwf+aAqbumvQ==
+
 "@across-protocol/contracts-v2@2.5.0-beta.7":
   version "2.5.0-beta.7"
   resolved "https://registry.yarnpkg.com/@across-protocol/contracts-v2/-/contracts-v2-2.5.0-beta.7.tgz#9410efc9e39b8b1b6e814dcd416e6017f7d40abd"


### PR DESCRIPTION
Bumps the contracts-v2 package version to 2.5.1