### PR TITLE
fix: remove fallback message in speed up

### DIFF
--- a/src/views/Transactions/hooks/useSpeedUp.tsx
+++ b/src/views/Transactions/hooks/useSpeedUp.tsx
@@ -62,8 +62,7 @@ export function useSpeedUp(transfer: Deposit, token: Token) {
 
       const newRecipient =
         args.optionalUpdates?.newRecipient || transfer.recipientAddr;
-      const newMessage =
-        args.optionalUpdates?.newMessage || transfer.message || "0x";
+      const newMessage = args.optionalUpdates?.newMessage || transfer.message;
       const updatedOutputAmount = BigNumber.from(transfer.amount).sub(
         args.newRelayerFeePct.mul(transfer.amount).div(fixedPointAdjustment)
       );


### PR DESCRIPTION
Related to ACX-1968. The actual fix was this PR though https://github.com/across-protocol/scraper-api/pull/362

The fallback `0x` masked the root cause. We therefore remove it in this PR