### PR TITLE
fix: only set parsed amount if true-ish

### DIFF
--- a/src/views/Bridge/hooks/useAmountInput.ts
+++ b/src/views/Bridge/hooks/useAmountInput.ts
@@ -66,11 +66,13 @@ export function useAmountInput(selectedRoute: Route) {
   }, [prevFromTokenSymbol, selectedRoute.fromTokenSymbol, clearInput]);
 
   useEffect(() => {
-    try {
-      const parsed = utils.parseUnits(userAmountInput, token.decimals);
-      setParsedAmount(parsed);
-    } catch (error) {
-      setParsedAmount(undefined);
+    if (userAmountInput) {
+      try {
+        const parsed = utils.parseUnits(userAmountInput, token.decimals);
+        setParsedAmount(parsed);
+      } catch (error) {
+        setParsedAmount(undefined);
+      }
     }
   }, [userAmountInput, token.decimals]);
 


### PR DESCRIPTION
I noticed the some sporadic negative amount input on the bridge page. Not 100% sure what the root cause is but I suspect some race condition combined with the effect in `useAmountInput` hook.