### PR TITLE
hotfix(UI): parse units underflow

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -302,6 +302,13 @@ export function formatUSD(value: BigNumberish): string {
   return numeral(Number(formattedString).toFixed(2)).format("0,0.00");
 }
 
+/**
+ * A fault-tolerant version of `parseUnits` that will attempt to parse
+ * a string while being mindful of truncation.
+ * @param value The string to parse
+ * @param decimals The number of decimal places to parse this string with
+ * @returns A BigNumber representation of the parsed value with `decimals` precision
+ */
 export function parseUnitsWithExtendedDecimals(
   value: string,
   decimals: number

--- a/src/views/Bridge/hooks/useEstimatedTable.ts
+++ b/src/views/Bridge/hooks/useEstimatedTable.ts
@@ -9,6 +9,7 @@ import {
   formatUnits,
   isDefined,
   parseUnits,
+  parseUnitsWithExtendedDecimals,
 } from "utils";
 
 export function useEstimatedTable(
@@ -69,7 +70,9 @@ export function useEstimatedTable(
 
   const baseCurrencyConversions = useMemo(() => {
     const parseUsd = (usd?: number) =>
-      isDefined(usd) ? parseUnits(String(usd), 18) : undefined;
+      isDefined(usd)
+        ? parseUnitsWithExtendedDecimals(String(usd), 18)
+        : undefined;
     const formatNumericUsd = (usd: BigNumber) =>
       Number(Number(ethersUtils.formatUnits(usd, 18)).toFixed(2));
     const gasFeeInUSD = convertL1ToBaseCurrency(gasFee);


### PR DESCRIPTION
This PR aims to fix a bug related to the `estimatedBridgeTable` displaying discounted bridge fees after the 0.95 optimism program rebate is applied.