### PR TITLE
fix(snx relayer): temporarily move relayer support

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -103,10 +103,12 @@ export const defaultRelayerAddressOverride: Record<
   string,
   { relayer: string; destinationChains: number[] }
 > = {
-  SNX: {
-    relayer: "0x19cDc2b23AF0cC791ca64dda5BFc094Cddda31Cd",
-    destinationChains: [1, 10],
-  },
+  // This should be added back in when SNX's relayer bot goes back online
+  // by referencing estimates for V3 events.
+  // SNX: {
+  //   relayer: "0x19cDc2b23AF0cC791ca64dda5BFc094Cddda31Cd",
+  //   destinationChains: [1, 10],
+  // },
 };
 
 const relayerFeeCapitalCostOverrides: Record<


### PR DESCRIPTION
The activation of Linea has caused an issue for the Synthetix relayer, so temporarily ignore its SNX balance.