### PR TITLE
feat: use new `SpokePoolVerifier` deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-only",
   "dependencies": {
     "@across-protocol/constants-v2": "^1.0.14",
-    "@across-protocol/contracts-v2": "2.5.4",
+    "@across-protocol/contracts-v2": "2.5.5",
     "@across-protocol/sdk-v2": "^0.22.18",
     "@amplitude/analytics-browser": "^2.3.5",
     "@balancer-labs/sdk": "^1.1.5",

--- a/scripts/generate-routes.ts
+++ b/scripts/generate-routes.ts
@@ -27,13 +27,14 @@ const enabledRoutes = {
       },
     ],
     spokePoolVerifier: {
-      address: "0xbcfEb7d29BB1b40c6eA3A9e3d0822a79819d63F3",
+      address: "0xB4A8d45647445EA9FC3E1058096142390683dBC2",
       enabledChains: [
         CHAIN_IDs.MAINNET,
         CHAIN_IDs.OPTIMISM,
         CHAIN_IDs.POLYGON,
         CHAIN_IDs.BASE,
         CHAIN_IDs.ARBITRUM,
+        CHAIN_IDs.LINEA,
       ],
     },
     routes: [

--- a/src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json
+++ b/src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json
@@ -2455,7 +2455,7 @@
     }
   ],
   "spokePoolVerifier": {
-    "address": "0xbcfEb7d29BB1b40c6eA3A9e3d0822a79819d63F3",
-    "enabledChains": [1, 10, 137, 8453, 42161]
+    "address": "0xB4A8d45647445EA9FC3E1058096142390683dBC2",
+    "enabledChains": [1, 10, 137, 8453, 42161, 59144]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,6 +41,26 @@
     axios "^1.6.2"
     zksync-web3 "^0.14.3"
 
+"@across-protocol/contracts-v2@2.5.5":
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts-v2/-/contracts-v2-2.5.5.tgz#298247113da9cad4317b3bad032f28a6a419df5a"
+  integrity sha512-UTAyBUPGuLghCwdKrxqdsyyPznc9wMT+trTTpZSWVPP4Y5Hkz8l9HkqFdFaWdaSfhmdUqv/uNHGxnENTM9moDw==
+  dependencies:
+    "@across-protocol/constants-v2" "^1.0.14"
+    "@defi-wonderland/smock" "^2.3.4"
+    "@eth-optimism/contracts" "^0.5.40"
+    "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/abstract-signer" "5.7.0"
+    "@ethersproject/bignumber" "5.7.0"
+    "@openzeppelin/contracts" "4.9.6"
+    "@openzeppelin/contracts-upgradeable" "4.9.6"
+    "@scroll-tech/contracts" "^0.1.0"
+    "@uma/common" "^2.34.0"
+    "@uma/contracts-node" "^0.4.17"
+    "@uma/core" "^2.56.0"
+    axios "^1.6.2"
+    zksync-web3 "^0.14.3"
+
 "@across-protocol/contracts@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-0.1.4.tgz#64b3d91e639d2bb120ea94ddef3d160967047fa5"


### PR DESCRIPTION
Closes ACX-1977

New deployments of `SpokePoolVerifier` contracts use the old `deposit` function signature and is also compatible on Linea.