### PR TITLE
improve(docs link): correct updated docs

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -12,7 +12,7 @@ export const NAV_LINKS = [
   {
     key: "faq",
     name: "FAQ",
-    url: "https://docs.across.to/additional-info/faq",
+    url: "https://docs.across.to/v/user-docs/additional-info/faq",
     icon: "",
   },
   {

--- a/src/views/Bridge/components/FeeInformationModal.tsx
+++ b/src/views/Bridge/components/FeeInformationModal.tsx
@@ -13,11 +13,11 @@ type FeeInformationModalProps = {
 const links: { text: string; link: string }[] = [
   {
     text: "The role of relayers",
-    link: "https://docs.across.to/how-across-works/overview",
+    link: "https://docs.across.to/v/user-docs/how-across-works/overview",
   },
   {
     text: "Relayer fees",
-    link: "https://docs.across.to/how-across-works/fees",
+    link: "https://docs.across.to/v/user-docs/how-across-works/fees",
   },
   {
     text: "Gas fees",

--- a/src/views/Rewards/components/AdditionalQuestionCTA.tsx
+++ b/src/views/Rewards/components/AdditionalQuestionCTA.tsx
@@ -18,7 +18,7 @@ const AdditionalQuestionCTA = () => (
     <ExternalButtonWrapper>
       <LinkButton
         text="FAQ"
-        link="https://docs.across.to/additional-info/faq"
+        link="https://docs.across.to/v/user-docs/how-across-works/overview"
       />
       <LinkButton text="Discord" link="https://discord.across.to" />
     </ExternalButtonWrapper>

--- a/src/views/RewardsProgram/hooks/useGenericRewardClaimCard.ts
+++ b/src/views/RewardsProgram/hooks/useGenericRewardClaimCard.ts
@@ -36,7 +36,7 @@ export function useGenericRewardClaimCard(program: rewardProgramTypes) {
     description:
       "Join the referral program and earn a portion of fees in ACX for transfers made from your unique referral link.",
     learnMoreLink:
-      "https://docs.across.to/how-to-use-across/rewards/referral-rewards#how-to-earn-referral-rewards",
+      "https://docs.across.to/v/user-docs/how-to-use-across/rewards/referral-rewards#how-to-earn-referral-rewards",
   };
 
   return {


### PR DESCRIPTION
Current docs links are out of date in several areas of the website. These broken links will lead to a 404 page on the Across gitbook.