### PR TITLE
fix(Linea): Permit undefined origin chain IDs in fill estimates

### DIFF
--- a/src/utils/fill-times.ts
+++ b/src/utils/fill-times.ts
@@ -44,10 +44,17 @@ const fastFillTimesSecondsFromTo = {
     [ChainId.ZK_SYNC]: 5,
     [ChainId.BASE]: 139,
   },
+  [ChainId.LINEA]: {
+    [ChainId.MAINNET]: 12,
+    [ChainId.OPTIMISM]: 247,
+    [ChainId.POLYGON]: 111,
+    [ChainId.ZK_SYNC]: 5,
+    [ChainId.BASE]: 139,
+  },
 };
 
 export function getFastFillTimeByRoute(fromChainId: number, toChainId: number) {
-  const fillTimeInSeconds = fastFillTimesSecondsFromTo[fromChainId][toChainId];
+  const fillTimeInSeconds = fastFillTimesSecondsFromTo[fromChainId]?.[toChainId];
 
   return fillTimeInSeconds || 60;
 }

--- a/src/utils/fill-times.ts
+++ b/src/utils/fill-times.ts
@@ -43,14 +43,7 @@ const fastFillTimesSecondsFromTo = {
     [ChainId.POLYGON]: 111,
     [ChainId.ZK_SYNC]: 5,
     [ChainId.BASE]: 139,
-  },
-  [ChainId.LINEA]: {
-    [ChainId.MAINNET]: 12,
-    [ChainId.OPTIMISM]: 247,
-    [ChainId.POLYGON]: 111,
-    [ChainId.ZK_SYNC]: 5,
-    [ChainId.BASE]: 139,
-  },
+  }
 };
 
 export function getFastFillTimeByRoute(fromChainId: number, toChainId: number) {

--- a/src/utils/fill-times.ts
+++ b/src/utils/fill-times.ts
@@ -43,7 +43,7 @@ const fastFillTimesSecondsFromTo = {
     [ChainId.POLYGON]: 111,
     [ChainId.ZK_SYNC]: 5,
     [ChainId.BASE]: 139,
-  }
+  },
 };
 
 export function getFastFillTimeByRoute(fromChainId: number, toChainId: number) {

--- a/src/utils/fill-times.ts
+++ b/src/utils/fill-times.ts
@@ -47,7 +47,8 @@ const fastFillTimesSecondsFromTo = {
 };
 
 export function getFastFillTimeByRoute(fromChainId: number, toChainId: number) {
-  const fillTimeInSeconds = fastFillTimesSecondsFromTo[fromChainId]?.[toChainId];
+  const fillTimeInSeconds =
+    fastFillTimesSecondsFromTo[fromChainId]?.[toChainId];
 
   return fillTimeInSeconds || 60;
 }


### PR DESCRIPTION
I opted not to add dummy values for Linea because they'd be wrong; better to flag that they need to be measured and added.