### PR TITLE
refactor(api): statically resolve token details

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -201,12 +201,23 @@ export const resolveVercelEndpoint = () => {
   }
 };
 
-export const getTokenDetails = (
-  originTokenAddress: string,
+/**
+ * Utility function to resolve route details based on given `inputTokenAddress` and `destinationChainId`.
+ * The optional parameter `originChainId` can be omitted if the `inputTokenAddress` is unique across all
+ * chains. If the `inputTokenAddress` is not unique across all chains, the `originChainId` must be
+ * provided to resolve the correct token details.
+ * @param inputTokenAddress The token address to resolve details for.
+ * @param destinationChainId The destination chain id of the route.
+ * @param originChainId Optional if the `inputTokenAddress` is unique across all chains. Required if not.
+ * @returns Token details of route and additional information, such as the inferred origin chain id, L1
+ * token address and the input/output token addresses.
+ */
+export const getRouteDetails = (
+  inputTokenAddress: string,
   destinationChainId: number,
   originChainId?: number
 ) => {
-  const token = _getTokenByAddress(originTokenAddress, originChainId);
+  const token = _getTokenByAddress(inputTokenAddress, originChainId);
 
   if (!token) {
     throw new InputError(
@@ -218,7 +229,7 @@ export const getTokenDetails = (
 
   const possibleOriginChainIds = originChainId
     ? [originChainId]
-    : _getChainIdsOfToken(originTokenAddress, token);
+    : _getChainIdsOfToken(inputTokenAddress, token);
 
   if (possibleOriginChainIds.length === 0) {
     throw new InputError("Unsupported token address");
@@ -231,15 +242,15 @@ export const getTokenDetails = (
   }
 
   const resolvedOriginChainId = possibleOriginChainIds[0];
-  const originToken = token.addresses[resolvedOriginChainId];
+  const inputToken = token.addresses[resolvedOriginChainId];
 
-  if (!originToken) {
+  if (!inputToken) {
     throw new InputError("Unsupported token address on given origin chain");
   }
 
-  const destinationToken = token.addresses[destinationChainId];
+  const outputToken = token.addresses[destinationChainId];
 
-  if (!destinationToken) {
+  if (!outputToken) {
     throw new InputError(
       "Unsupported token address on given destination chain"
     );
@@ -249,8 +260,8 @@ export const getTokenDetails = (
     ...token,
     resolvedOriginChainId,
     l1Token: token.addresses[HUB_POOL_CHAIN_ID],
-    originToken,
-    destinationToken,
+    inputToken,
+    outputToken,
   };
 };
 

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -14,7 +14,7 @@ import {
   InputError,
   getRelayerFeeDetails,
   getCachedTokenPrice,
-  getTokenDetails,
+  getRouteDetails,
   getCachedTokenBalance,
   maxBN,
   minBN,
@@ -95,10 +95,10 @@ const handler = async (
     const {
       l1Token,
       resolvedOriginChainId: computedOriginChainId,
-      destinationToken,
+      outputToken: destinationToken,
       decimals,
       symbol,
-    } = getTokenDetails(
+    } = getRouteDetails(
       token,
       destinationChainId,
       originChainId ? Number(originChainId) : undefined

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -138,11 +138,11 @@ const handler = async (
         l1Token,
         ethers.BigNumber.from("10").pow(decimals),
         computedOriginChainId,
-        Number(destinationChainId),
+        destinationChainId,
         DEFAULT_SIMULATED_RECIPIENT_ADDRESS,
         tokenPriceNative,
         undefined,
-        getDefaultRelayerAddress(symbol, Number(destinationChainId))
+        getDefaultRelayerAddress(symbol, destinationChainId)
       ),
       hubPool.callStatic.multicall(multicallInput, { blockTag: BLOCK_TAG_LAG }),
       Promise.all(
@@ -170,7 +170,7 @@ const handler = async (
     );
 
     const lpCushion = ethers.utils.parseUnits(
-      getLpCushion(symbol, computedOriginChainId, Number(destinationChainId)),
+      getLpCushion(symbol, computedOriginChainId, destinationChainId),
       decimals
     );
     liquidReserves = liquidReserves.sub(lpCushion);

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -11,7 +11,7 @@ import {
 import { TypedVercelRequest } from "./_types";
 import {
   getLogger,
-  getTokenDetails,
+  getRouteDetails,
   InputError,
   getProvider,
   getRelayerFeeDetails,
@@ -87,7 +87,7 @@ const handler = async (
       l1Token,
       resolvedOriginChainId: computedOriginChainId,
       symbol,
-    } = getTokenDetails(
+    } = getRouteDetails(
       token,
       destinationChainId,
       originChainId ? Number(originChainId) : undefined

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -6,7 +6,6 @@ import { type, assert, Infer, optional, string } from "superstruct";
 import {
   disabledL1Tokens,
   DEFAULT_QUOTE_TIMESTAMP_BUFFER,
-  TOKEN_SYMBOLS_MAP,
   DEFAULT_SIMULATED_RECIPIENT_ADDRESS,
 } from "./_constants";
 import { TypedVercelRequest } from "./_types";
@@ -28,7 +27,7 @@ import {
   getSpokePoolAddress,
   getCachedTokenBalance,
   getDefaultRelayerAddress,
-  hasPotentialRouteCollision,
+  getHubPool,
 } from "./_utils";
 
 const SuggestedFeesQueryParamsSchema = type({
@@ -62,6 +61,7 @@ const handler = async (
       : DEFAULT_QUOTE_TIMESTAMP_BUFFER;
 
     const provider = getProvider(HUB_POOL_CHAIN_ID);
+    const hubPool = getHubPool(provider);
 
     assert(query, SuggestedFeesQueryParamsSchema);
 
@@ -83,24 +83,26 @@ const handler = async (
     const destinationChainId = Number(_destinationChainId);
     token = ethers.utils.getAddress(token);
 
-    const [latestBlock, tokenDetails] = await Promise.all([
-      provider.getBlock("latest"),
-      getTokenDetails(provider, undefined, token, originChainId),
-    ]);
-    const { l1Token, hubPool, chainId: computedOriginChainId } = tokenDetails;
-
-    const tokenInformation = Object.values(TOKEN_SYMBOLS_MAP).find(
-      (details) => details.addresses[HUB_POOL_CHAIN_ID] === l1Token
+    const {
+      l1Token,
+      resolvedOriginChainId: computedOriginChainId,
+      symbol,
+    } = getTokenDetails(
+      token,
+      destinationChainId,
+      originChainId ? Number(originChainId) : undefined
     );
 
-    if (!sdk.utils.isDefined(tokenInformation)) {
-      throw new InputError("Unsupported token address");
+    if (
+      disabledL1Tokens.includes(l1Token.toLowerCase()) ||
+      !isRouteEnabled(computedOriginChainId, destinationChainId, token)
+    ) {
+      throw new InputError(`Route is not enabled.`);
     }
 
-    relayer ??= getDefaultRelayerAddress(
-      tokenInformation.symbol,
-      destinationChainId
-    );
+    const latestBlock = await provider.getBlock("latest");
+
+    relayer ??= getDefaultRelayerAddress(symbol, destinationChainId);
     recipient ??= DEFAULT_SIMULATED_RECIPIENT_ADDRESS;
 
     if (sdk.utils.isDefined(message) && !sdk.utils.isMessageEmpty(message)) {
@@ -178,27 +180,10 @@ const handler = async (
     const amount = ethers.BigNumber.from(amountInput);
 
     const blockFinder = new BlockFinder(provider.getBlock.bind(provider));
-    const [{ number: blockTag }, routeEnabled] = await Promise.all([
-      blockFinder.getBlockForTimestamp(parsedTimestamp),
-      isRouteEnabled(computedOriginChainId, destinationChainId, token),
-    ]);
+    const { number: blockTag } = await blockFinder.getBlockForTimestamp(
+      parsedTimestamp
+    );
 
-    if (disabledL1Tokens.includes(l1Token.toLowerCase())) {
-      throw new InputError(`Route is not enabled.`);
-    }
-    if (!routeEnabled) {
-      const routeCollision = await hasPotentialRouteCollision(
-        provider,
-        undefined,
-        token,
-        originChainId
-      );
-      throw new InputError(
-        routeCollision
-          ? `More than one ACX route maps to the provided inputs causing ambiguity. Please specify the originChainId.`
-          : `Route is not enabled.`
-      );
-    }
     const configStoreClient = new sdk.contracts.acrossConfigStore.Client(
       ENABLED_ROUTES.acrossConfigStoreAddress,
       provider

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -100,8 +100,6 @@ const handler = async (
       throw new InputError(`Route is not enabled.`);
     }
 
-    const latestBlock = await provider.getBlock("latest");
-
     relayer ??= getDefaultRelayerAddress(symbol, destinationChainId);
     recipient ??= DEFAULT_SIMULATED_RECIPIENT_ADDRESS;
 
@@ -148,6 +146,8 @@ const handler = async (
         }
       }
     }
+
+    const latestBlock = await provider.getBlock("latest");
 
     // Note: Add a buffer to "latest" timestamp so that it corresponds to a block older than HEAD.
     // This is to improve relayer UX who have heightened risk of sending inadvertent invalid fills

--- a/test/api/_utils.test.ts
+++ b/test/api/_utils.test.ts
@@ -1,0 +1,71 @@
+import { TOKEN_SYMBOLS_MAP } from "@across-protocol/constants-v2";
+import { getRouteDetails } from "../../api/_utils";
+
+describe("_utils", () => {
+  describe("#getRouteDetails()", () => {
+    test("should throw if token is unknown", () => {
+      const unknownToken = "0x0";
+      const destinationChainId = 1;
+      expect(() =>
+        getRouteDetails(unknownToken, destinationChainId)
+      ).toThrowError(/Unsupported token address/);
+    });
+
+    test("should throw if token is unknown on given origin chain", () => {
+      const knownToken = TOKEN_SYMBOLS_MAP.ACX.addresses[1];
+      const destinationChainId = 10;
+      const unknownOriginChainId = 99999;
+      expect(() =>
+        getRouteDetails(knownToken, destinationChainId, unknownOriginChainId)
+      ).toThrowError(/Unsupported token on given origin chain/);
+    });
+
+    test("should throw if token is not unique across chains and 'originChainId' is omitted", () => {
+      // DAI has the same address on Arbitrum and Optimism
+      const notUniqueToken = TOKEN_SYMBOLS_MAP.DAI.addresses[10];
+      const destinationChainId = 1;
+      expect(() =>
+        getRouteDetails(notUniqueToken, destinationChainId)
+      ).toThrowError(/More than one route is enabled/);
+    });
+
+    test("should throw if destination token unknown", () => {
+      const knownToken = TOKEN_SYMBOLS_MAP.ACX.addresses[1];
+      const unknownDestinationChainId = 99999;
+      expect(() =>
+        getRouteDetails(knownToken, unknownDestinationChainId)
+      ).toThrowError(/Unsupported token address on given destination chain/);
+    });
+
+    test("should return route details for unique address across chains", () => {
+      const originChainId = 10;
+      const uniqueToken = TOKEN_SYMBOLS_MAP.ACX.addresses[originChainId];
+      const destinationChainId = 137;
+      expect(getRouteDetails(uniqueToken, destinationChainId)).toMatchObject({
+        l1Token: TOKEN_SYMBOLS_MAP.ACX.addresses[1],
+        resolvedOriginChainId: originChainId,
+        inputToken: TOKEN_SYMBOLS_MAP.ACX.addresses[originChainId],
+        outputToken: TOKEN_SYMBOLS_MAP.ACX.addresses[destinationChainId],
+        decimals: TOKEN_SYMBOLS_MAP.ACX.decimals,
+        symbol: TOKEN_SYMBOLS_MAP.ACX.symbol,
+      });
+    });
+
+    test("should return route details for not unique address across chains", () => {
+      // DAI has the same address on Arbitrum and Optimism
+      const originChainId = 10;
+      const uniqueToken = TOKEN_SYMBOLS_MAP.DAI.addresses[originChainId];
+      const destinationChainId = 42161;
+      expect(
+        getRouteDetails(uniqueToken, destinationChainId, originChainId)
+      ).toMatchObject({
+        l1Token: TOKEN_SYMBOLS_MAP.DAI.addresses[1],
+        resolvedOriginChainId: originChainId,
+        inputToken: TOKEN_SYMBOLS_MAP.DAI.addresses[originChainId],
+        outputToken: TOKEN_SYMBOLS_MAP.DAI.addresses[destinationChainId],
+        decimals: TOKEN_SYMBOLS_MAP.DAI.decimals,
+        symbol: TOKEN_SYMBOLS_MAP.DAI.symbol,
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR removes querying the HubPools `SetPoolRebalanceRoute` events is order to resolve the token details. Instead, we use a static approach to improve performance.