### PR TITLE
refactor: remove name collision of internal `formatUnits` helper

### DIFF
--- a/src/components/DepositsTable/cells/AmountCell.tsx
+++ b/src/components/DepositsTable/cells/AmountCell.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 
 import { Text } from "components/Text";
 import { Deposit } from "hooks/useDeposits";
-import { formatUnits, Token } from "utils";
+import { formatUnitsWithMaxFractions, Token } from "utils";
 
 import { BaseCell } from "./BaseCell";
 
@@ -16,7 +16,7 @@ export function AmountCell({ deposit, token, width }: Props) {
   return (
     <StyledAmountCell width={width}>
       <Text color="light-200">
-        {formatUnits(deposit.amount, token.decimals)}
+        {formatUnitsWithMaxFractions(deposit.amount, token.decimals)}
       </Text>
     </StyledAmountCell>
   );

--- a/src/components/DepositsTable/cells/NetFeeCell.tsx
+++ b/src/components/DepositsTable/cells/NetFeeCell.tsx
@@ -11,7 +11,7 @@ import { BaseCell } from "./BaseCell";
 import {
   COLORS,
   fixedPointAdjustment,
-  formatUnits,
+  formatUnitsWithMaxFractions,
   formatWeiPct,
   getConfig,
   getToken,
@@ -44,7 +44,7 @@ function FeeWithoutBreakdown({ deposit }: { deposit: Deposit }) {
   return (
     <>
       <Text color="light-200">
-        {formatUnits(
+        {formatUnitsWithMaxFractions(
           BigNumber.from(deposit.amount)
             .mul(deposit.depositRelayerFeePct || 0)
             .div(fixedPointAdjustment),
@@ -119,7 +119,10 @@ function FeeWithBreakdown({ deposit }: { deposit: Deposit }) {
                     ${formatMaxFracDigits(capitalAndLpFeeUsd, 2)}
                   </Text>
                   <Text size="sm" color="light-200">
-                    {formatUnits(capitalAndLpFeeAmount, tokenInfo.decimals)}{" "}
+                    {formatUnitsWithMaxFractions(
+                      capitalAndLpFeeAmount,
+                      tokenInfo.decimals
+                    )}{" "}
                     {tokenInfo.symbol}
                   </Text>
                   <img src={tokenInfo.logoURI} alt={tokenInfo.symbol} />
@@ -138,7 +141,7 @@ function FeeWithBreakdown({ deposit }: { deposit: Deposit }) {
                     )}
                   </Text>
                   <Text size="sm" color="light-200">
-                    {formatUnits(
+                    {formatUnitsWithMaxFractions(
                       BigNumber.from(
                         isBigNumberish(deposit.feeBreakdown?.relayGasFeeAmount)
                           ? deposit.feeBreakdown?.relayGasFeeAmount || 0

--- a/src/components/DepositsTable/cells/RewardsCell.tsx
+++ b/src/components/DepositsTable/cells/RewardsCell.tsx
@@ -4,7 +4,11 @@ import { Text } from "components/Text";
 import { Deposit } from "hooks/useDeposits";
 
 import { BaseCell } from "./BaseCell";
-import { formatUnits, getToken, formatMaxFracDigits } from "utils";
+import {
+  formatUnitsWithMaxFractions,
+  getToken,
+  formatMaxFracDigits,
+} from "utils";
 
 type Props = {
   deposit: Deposit;
@@ -23,7 +27,10 @@ export function RewardsCell({ deposit, width }: Props) {
           <TitleWrapper>
             <img src={rewardToken.logoURI} alt={rewardToken.symbol} />
             <Text color="light-200">
-              {formatUnits(deposit.rewards.amount, rewardToken.decimals)}{" "}
+              {formatUnitsWithMaxFractions(
+                deposit.rewards.amount,
+                rewardToken.decimals
+              )}{" "}
               {rewardToken.symbol}
             </Text>
           </TitleWrapper>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -100,7 +100,7 @@ export const veryLargeNumberFormatter = (num: number, precision?: number) =>
     maximumFractionDigits: precision || 0,
   }).format(num);
 
-export function formatUnits(
+export function formatUnitsWithMaxFractions(
   wei: ethers.BigNumberish,
   decimals: number,
   maxFractions?: Partial<{
@@ -119,19 +119,11 @@ export function formatUnits(
   return smallNumberFormatter(value, maxFractions?.s);
 }
 
-export function formatUnitsFnBuilder(decimals: number) {
+export function formatUnitsWithMaxFractionsFnBuilder(decimals: number) {
   function closure(wei: ethers.BigNumberish) {
-    return formatUnits(wei, decimals);
+    return formatUnitsWithMaxFractions(wei, decimals);
   }
   return closure;
-}
-
-export function makeFormatUnits(decimals: number) {
-  return (wei: ethers.BigNumberish) => formatUnits(wei, decimals);
-}
-
-export function formatEther(wei: ethers.BigNumberish): string {
-  return formatUnits(wei, 18);
 }
 
 export function formatEtherRaw(wei: ethers.BigNumberish): string {
@@ -178,7 +170,7 @@ export function formattedBigNumberToNumber(
   decimals: number = 18
 ): number {
   try {
-    return Number(formatUnits(value, decimals));
+    return Number(ethers.utils.formatUnits(value, decimals));
   } catch (_e) {
     return Number.NaN;
   }

--- a/src/utils/staking-pool.ts
+++ b/src/utils/staking-pool.ts
@@ -1,7 +1,7 @@
 import {
   fixedPointAdjustment,
   formattedBigNumberToNumber,
-  formatUnitsFnBuilder,
+  formatUnitsWithMaxFractionsFnBuilder,
   getConfig,
   hubPoolChainId,
   parseEtherLike,
@@ -237,7 +237,8 @@ export async function fetchStakingPool(
 
   // We can resolve custom formatter & parsers for the current LP
   // token that we are working with.
-  const lpTokenFormatter = formatUnitsFnBuilder(lpTokenDecimalCount);
+  const lpTokenFormatter =
+    formatUnitsWithMaxFractionsFnBuilder(lpTokenDecimalCount);
   const lpTokenParser = (wei: BigNumberish) =>
     toWeiSafe(wei.toString(), lpTokenDecimalCount);
 

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 
-import { getProvider, ChainId, getConfig, toWeiSafe, formatUnits } from "utils";
+import { getProvider, ChainId, getConfig } from "utils";
 import { ERC20__factory } from "utils/typechain";
 
 export async function getNativeBalance(
@@ -61,17 +61,3 @@ export async function getAllowance(
   const contract = ERC20__factory.connect(address, provider);
   return contract.allowance(owner, spender, { blockTag: blockNumber });
 }
-
-export const calculateRemoveAmount = (
-  percent: number,
-  position: ethers.BigNumber,
-  decimals: number
-) => {
-  if (position.toString() === "0") return "0";
-  const scaler = ethers.BigNumber.from("10").pow(decimals);
-
-  const removeAmountToWei = toWeiSafe(percent.toString(), decimals);
-
-  const weiAmount = position.mul(removeAmountToWei).div(scaler.mul(100));
-  return formatUnits(weiAmount, decimals);
-};

--- a/src/views/Bridge/components/EstimatedTable.tsx
+++ b/src/views/Bridge/components/EstimatedTable.tsx
@@ -10,7 +10,7 @@ import {
   bridgedUSDCSymbolsMap,
   capitalizeFirstLetter,
   COLORS,
-  formatUnits,
+  formatUnitsWithMaxFractions,
   formatUSD,
   formatWeiPct,
   getChainInfo,
@@ -70,7 +70,9 @@ const PriceFee = ({
       )}
       {tokenFee ? (
         <Text size="md" color={highlightTokenFee ? "primary" : "white"}>
-          {`${formatUnits(tokenFee, token.decimals)} ${token.symbol}`}
+          {`${formatUnitsWithMaxFractions(tokenFee, token.decimals)} ${
+            token.symbol
+          }`}
         </Text>
       ) : (
         <Text size="md" color="grey-400">

--- a/src/views/Bridge/components/TokenFee.tsx
+++ b/src/views/Bridge/components/TokenFee.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { Text, TextColor } from "components/Text";
 import { BigNumber } from "ethers";
-import { formatUnits, TokenInfo } from "utils";
+import { formatUnitsWithMaxFractions, TokenInfo } from "utils";
 
 type TokenFeeProps = {
   token: TokenInfo;
@@ -12,7 +12,7 @@ type TokenFeeProps = {
 const TokenFee = ({ token, amount, textColor = "grey-400" }: TokenFeeProps) => (
   <Wrapper>
     <NumericText size="md" color={textColor}>
-      {formatUnits(amount, token.decimals)}{" "}
+      {formatUnitsWithMaxFractions(amount, token.decimals)}{" "}
       {token.displaySymbol || token.symbol.toUpperCase()}{" "}
     </NumericText>
     <TokenSymbol src={token.logoURI} />

--- a/src/views/Bridge/components/TokenSelector.tsx
+++ b/src/views/Bridge/components/TokenSelector.tsx
@@ -7,7 +7,13 @@ import { Selector } from "components";
 import { Text } from "components/Text";
 import { SelectorPropType } from "components/Selector/Selector";
 
-import { formatUnits, QUERIESV2, TokenInfo, getToken, Route } from "utils";
+import {
+  formatUnitsWithMaxFractions,
+  QUERIESV2,
+  TokenInfo,
+  getToken,
+  Route,
+} from "utils";
 import { useBalancesBySymbols, useConnection } from "hooks";
 
 import { RouteNotSupportedTooltipText } from "./RouteNotSupportedTooltipText";
@@ -77,7 +83,10 @@ export function TokenSelector({ selectedRoute, onSelectToken }: Props) {
         suffix:
           balances && balances[i]?.gt(0) ? (
             <Text size="md" color="grey-400">
-              {formatUnits(balances[i] ?? BigNumber.from(0), t.decimals)}
+              {formatUnitsWithMaxFractions(
+                balances[i] ?? BigNumber.from(0),
+                t.decimals
+              )}
             </Text>
           ) : undefined,
       }))}

--- a/src/views/Bridge/hooks/useEstimatedTable.ts
+++ b/src/views/Bridge/hooks/useEstimatedTable.ts
@@ -6,7 +6,7 @@ import { useMemo, useState } from "react";
 import {
   TokenInfo,
   fixedPointAdjustment,
-  formatUnits,
+  formatUnitsWithMaxFractions,
   isDefined,
   parseUnits,
   parseUnitsWithExtendedDecimals,
@@ -91,7 +91,7 @@ export function useEstimatedTable(
     const numericBridgeFee = formatNumericUsd(bridgeFeeInUSD);
     const numericReward = availableRewardPercentage
       ? (numericBridgeFee + numericGasFee) *
-        Number(formatUnits(availableRewardPercentage, 18))
+        Number(formatUnitsWithMaxFractions(availableRewardPercentage, 18))
       : undefined;
 
     const netFeeAsBaseCurrency =

--- a/src/views/Bridge/hooks/useMaxBalance.ts
+++ b/src/views/Bridge/hooks/useMaxBalance.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "react-query";
-import { BigNumber, constants } from "ethers";
+import { BigNumber, constants, utils } from "ethers";
 
 import { useBalanceBySymbol, useConnection } from "hooks";
 import {
@@ -56,5 +56,8 @@ async function estimateGasCostsForDeposit(selectedRoute: Route) {
   const provider = getProvider(selectedRoute.fromChain);
   const gasPrice = await provider.getGasPrice();
   const gasMultiplier = gasMultiplierPerChain[selectedRoute.fromChain] || 3;
-  return gasPrice.mul(gasMultiplier).mul(gasExpenditureDeposit);
+  return gasPrice
+    .mul(utils.parseEther(String(gasMultiplier)))
+    .mul(gasExpenditureDeposit)
+    .div(constants.WeiPerEther);
 }

--- a/src/views/LiquidityPool/LiquidityPool.tsx
+++ b/src/views/LiquidityPool/LiquidityPool.tsx
@@ -6,7 +6,7 @@ import CardWrapper from "components/CardWrapper";
 import { Tabs, Tab } from "components/Tabs";
 import {
   formatNumberMaxFracDigits,
-  formatUnits,
+  formatUnitsWithMaxFractions,
   formatWeiPct,
   getConfig,
   max,
@@ -77,7 +77,7 @@ export default function LiquidityPool() {
     if (!selectedLiquidityPool || !amount) {
       return "-";
     }
-    return `${formatUnits(amount, selectedToken.decimals, {
+    return `${formatUnitsWithMaxFractions(amount, selectedToken.decimals, {
       xl: 3,
     })} ${selectedToken.symbol}`;
   };

--- a/src/views/Rewards/components/RewardProgramCard.tsx
+++ b/src/views/Rewards/components/RewardProgramCard.tsx
@@ -1,5 +1,10 @@
 import styled from "@emotion/styled";
-import { COLORS, QUERIESV2, formatUnits, rewardProgramTypes } from "utils";
+import {
+  COLORS,
+  QUERIESV2,
+  formatUnitsWithMaxFractions,
+  rewardProgramTypes,
+} from "utils";
 import { Text } from "components";
 import { ReactComponent as ChevronRight } from "assets/icons/arrow-right-16.svg";
 import { useRewardProgramCard } from "../hooks/useRewardProgramCard";
@@ -32,7 +37,8 @@ const RewardProgramCard = ({ program }: RewardProgramCardProps) => {
         </Text>
         {isConnected && (
           <Text color="grey-400" size="md">
-            {formatUnits(rewardsAmount, token.decimals)} {token.symbol} earned
+            {formatUnitsWithMaxFractions(rewardsAmount, token.decimals)}{" "}
+            {token.symbol} earned
           </Text>
         )}
       </TextStack>

--- a/src/views/RewardsProgram/GenericRewardsProgram/GenericRewardClaimCard.tsx
+++ b/src/views/RewardsProgram/GenericRewardsProgram/GenericRewardClaimCard.tsx
@@ -23,7 +23,7 @@ const GenericRewardClaimCard = ({
     rewardsAmount,
     unclaimedAmount,
     rewardTokenSymbol,
-    formatUnits,
+    formatUnitsWithMaxFractions,
     isConnected,
     programName,
     claimableTooltipBody,
@@ -43,7 +43,7 @@ const GenericRewardClaimCard = ({
           </LogoContainer>
           <TextStack>
             <Text color="white" size="2xl">
-              {formatUnits(rewardsAmount)} {rewardTokenSymbol}
+              {formatUnitsWithMaxFractions(rewardsAmount)} {rewardTokenSymbol}
             </Text>
             {unclaimedAmount && (
               <ClaimableIconTextStack>
@@ -58,7 +58,8 @@ const GenericRewardClaimCard = ({
                   <InfoIcon />
                 </Tooltip>
                 <Text color="grey-400" size="md">
-                  {formatUnits(unclaimedAmount)} {rewardTokenSymbol} claimable
+                  {formatUnitsWithMaxFractions(unclaimedAmount)}{" "}
+                  {rewardTokenSymbol} claimable
                 </Text>
               </ClaimableIconTextStack>
             )}

--- a/src/views/RewardsProgram/hooks/useACXReferralsProgram.ts
+++ b/src/views/RewardsProgram/hooks/useACXReferralsProgram.ts
@@ -3,7 +3,7 @@ import { GenericRewardInformationRowType } from "../GenericRewardsProgram/Generi
 import {
   capitalizeFirstLetter,
   formatNumberTwoFracDigits,
-  formatUnits,
+  formatUnitsWithMaxFractions,
   getToken,
   rewardPrograms,
   rewardTiers,
@@ -79,8 +79,11 @@ export function useACXReferralsProgram() {
       },
       {
         title: "Total rewards",
-        value: `${formatUnits(summary.rewardsAmount, token.decimals)} ACX`,
-        prefix: `${formatUnits(
+        value: `${formatUnitsWithMaxFractions(
+          summary.rewardsAmount,
+          token.decimals
+        )} ACX`,
+        prefix: `${formatUnitsWithMaxFractions(
           unclaimedReferralData?.claimableAmount ?? 0,
           token.decimals
         )} ACX claimable`,

--- a/src/views/RewardsProgram/hooks/useGenericRewardClaimCard.ts
+++ b/src/views/RewardsProgram/hooks/useGenericRewardClaimCard.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "ethers";
 import { useConnection, useRewardSummary } from "hooks";
 import { useUnclaimedProofs } from "hooks/useUnclaimedProofs";
 import {
-  formatUnitsFnBuilder,
+  formatUnitsWithMaxFractionsFnBuilder,
   getToken,
   rewardProgramTypes,
   rewardPrograms,
@@ -28,7 +28,9 @@ export function useGenericRewardClaimCard(program: rewardProgramTypes) {
       : summary.rewardsAmount;
   const unclaimedAmount = unclaimedReferralData?.claimableAmount;
 
-  const formatUnits = formatUnitsFnBuilder(token.decimals);
+  const formatUnitsWithMaxFractions = formatUnitsWithMaxFractionsFnBuilder(
+    token.decimals
+  );
 
   // TODO: add a state for OP rewards and a state for referral rewards
   const disconnectedState: GenericRewardClaimCardDisconnectedStateProps = {
@@ -44,7 +46,7 @@ export function useGenericRewardClaimCard(program: rewardProgramTypes) {
     token,
     rewardsAmount: BigNumber.from(rewardsAmount ?? 0),
     unclaimedAmount: BigNumber.from(unclaimedAmount ?? 0),
-    formatUnits,
+    formatUnitsWithMaxFractions,
     disconnectedState,
     isConnected,
   };

--- a/src/views/RewardsProgram/hooks/useOPRebatesProgram.ts
+++ b/src/views/RewardsProgram/hooks/useOPRebatesProgram.ts
@@ -2,7 +2,7 @@ import { useConnection, useRewardSummary } from "hooks";
 import { GenericRewardInformationRowType } from "../GenericRewardsProgram/GenericInformationCard";
 import {
   capitalizeFirstLetter,
-  formatUnits,
+  formatUnitsWithMaxFractions,
   getToken,
   rewardPrograms,
 } from "utils";
@@ -34,10 +34,11 @@ export function useOPRebatesProgram() {
       {
         title: "Rewards",
         tooltip: "Rewards earned from this Optimism program",
-        value: `${formatUnits(summary.unclaimedRewards || 0, token.decimals)} ${
-          token.symbol
-        }`,
-        prefix: `${formatUnits(
+        value: `${formatUnitsWithMaxFractions(
+          summary.unclaimedRewards || 0,
+          token.decimals
+        )} ${token.symbol}`,
+        prefix: `${formatUnitsWithMaxFractions(
           unclaimedOpRewardsData?.claimableAmount ?? 0,
           token.decimals
         )} ${token.symbol} claimable`,

--- a/src/views/Staking/components/StakingForm/StakingForm.tsx
+++ b/src/views/Staking/components/StakingForm/StakingForm.tsx
@@ -20,7 +20,7 @@ import { Tab, Tabs } from "components/Tabs";
 import StakingInputBlock from "../StakingInputBlock";
 import { StakingFormPropType } from "../../types";
 import { repeatableTernaryBuilder } from "utils/ternary";
-import { formatEther, formatWeiPct, formatNumberMaxFracDigits } from "utils";
+import { formatWeiPct, formatNumberMaxFracDigits } from "utils";
 import SectionTitleWrapperV2 from "components/SectionTitleWrapperV2";
 import { Text } from "components/Text";
 import { useStakeFormLogic } from "views/Staking/hooks/useStakeFormLogic";
@@ -217,7 +217,7 @@ export const StakingForm = ({
                   />
                   <Text color={activeColor}>
                     {Number(
-                      formatEther(poolData.currentUserRewardMultiplier)
+                      utils.formatEther(poolData.currentUserRewardMultiplier)
                     ).toFixed(2)}
                     x
                   </Text>


### PR DESCRIPTION
This PR renames our custom utility which formats a number AND truncates the fractional digits to `formatUnitsWithMaxFractions`. Previously it was named `formatUnits` which conflicts with a utility from `ethers`. This name collision has historically led to bugs where our internal utility did things we did not expect based on the name.